### PR TITLE
fix(reopen): kill stale Claude + accept gitignore-only phase-5 fixes

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,8 +9,8 @@ export interface ModelPreset {
 }
 
 export const MODEL_PRESETS: ModelPreset[] = [
-  { id: 'opus-max',     label: 'Claude Opus 4.6 / max',    runner: 'claude', model: 'claude-opus-4-6',   effort: 'max' },
-  { id: 'opus-high',    label: 'Claude Opus 4.6 / high',   runner: 'claude', model: 'claude-opus-4-6',   effort: 'high' },
+  { id: 'opus-max',     label: 'Claude Opus 4.7 / xHigh',  runner: 'claude', model: 'claude-opus-4-7',   effort: 'xHigh' },
+  { id: 'opus-high',    label: 'Claude Opus 4.7 / high',   runner: 'claude', model: 'claude-opus-4-7',   effort: 'high' },
   { id: 'sonnet-high',  label: 'Claude Sonnet 4.6 / high', runner: 'claude', model: 'claude-sonnet-4-6', effort: 'high' },
   { id: 'codex-high',   label: 'Codex / high',             runner: 'codex',  model: 'gpt-5.4',           effort: 'high' },
   { id: 'codex-medium', label: 'Codex / medium',           runner: 'codex',  model: 'gpt-5.4',           effort: 'medium' },

--- a/src/phases/interactive.ts
+++ b/src/phases/interactive.ts
@@ -132,12 +132,16 @@ export function validatePhaseArtifacts(
     try {
       const head = execSync('git rev-parse HEAD', { cwd, encoding: 'utf-8' }).trim();
       const base = state.implRetryBase;
-      // HEAD must have advanced beyond the retry base
-      if (head === base) return false;
-
-      // Working tree must be clean
       const status = execSync('git status --porcelain', { cwd, encoding: 'utf-8' }).trim();
-      return status === '';
+      // Working tree must always be clean
+      if (status !== '') return false;
+      // HEAD advanced — always valid
+      if (head !== base) return true;
+      // HEAD did not advance. Accept only on reopen (implCommit already set):
+      // a verify-failure reopen may legitimately require only gitignored artifact
+      // fixes (e.g., checklist.json) and no further impl commits. First-attempt
+      // zero-commit is still rejected to prevent empty sessions passing through.
+      return state.implCommit !== null;
     } catch {
       return false;
     }

--- a/src/runners/claude.ts
+++ b/src/runners/claude.ts
@@ -25,7 +25,10 @@ export async function runClaudeInteractive(
   const sessionName = state.tmuxSession;
   const workspacePane = state.tmuxWorkspacePane;
 
-  // Kill previous workspace process if alive (and matches saved start-time)
+  // Kill previous workspace process if alive (and matches saved start-time).
+  // Claude Code does not exit after writing the sentinel — it stays idle awaiting input.
+  // If we don't kill it, the next sendKeysToPane below types the wrapper command INTO
+  // Claude's input box (not a shell prompt), the PID file never appears, and phase reopen fails.
   if (state.lastWorkspacePid !== null && isPidAlive(state.lastWorkspacePid)) {
     const savedStart = state.lastWorkspacePidStartTime;
     const actualStart = getProcessStartTime(state.lastWorkspacePid);
@@ -35,7 +38,13 @@ export async function runClaudeInteractive(
       while (isPidAlive(state.lastWorkspacePid) && Date.now() < deadline) {
         await new Promise<void>((r) => setTimeout(r, 200));
       }
+      if (isPidAlive(state.lastWorkspacePid)) {
+        await killProcessGroup(state.lastWorkspacePid, SIGTERM_WAIT_MS);
+      }
     }
+    state.lastWorkspacePid = null;
+    state.lastWorkspacePidStartTime = null;
+    writeState(runDir, state);
   }
 
   // Safety: Ctrl+C + wait

--- a/tests/phases/interactive.test.ts
+++ b/tests/phases/interactive.test.ts
@@ -558,6 +558,17 @@ describe('validatePhaseArtifacts — Phase 5', () => {
     const result = validatePhaseArtifacts(5, state, repoDir);
     expect(result).toBe(false);
   });
+
+  it('accepts zero-commit reopen when implCommit is already set', () => {
+    // A Phase 6 verify-failure reopen may require only gitignored artifact
+    // fixes (e.g., checklist.json). Claude writes the sentinel without new
+    // commits; validation must not fail.
+    const repoDir = createTestRepo();
+    const head = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+    const state = makeState({ implRetryBase: head, implCommit: 'prior-impl-sha' });
+    const result = validatePhaseArtifacts(5, state, repoDir);
+    expect(result).toBe(true);
+  });
 });
 
 // ─── runInteractivePhase: advisor reminder ordering ──────────────────────────

--- a/tests/phases/interactive.test.ts
+++ b/tests/phases/interactive.test.ts
@@ -612,6 +612,6 @@ describe('runInteractivePhase — advisor reminder fires before sendKeysToPane',
 
     expect(command).toContain('--dangerously-skip-permissions');
     expect(command).toContain('--effort');
-    expect(command).toContain('max');
+    expect(command).toContain('xHigh');
   });
 });


### PR DESCRIPTION
## Summary

- Found and fixed two reopen-path bugs during a todo-manager QA run:
  - **Stale Claude Code not killed between phase attempts** — Ctrl+C alone leaves Claude idle, so the next wrapper command lands in Claude's input box instead of a shell. Null PID → 10-min sentinel timeout → phase fails → tmux session dies.
  - **`validatePhaseArtifacts(phase=5)` rejects legitimate zero-commit reopens** — a verify-failure reopen may only require a gitignored checklist fix; requiring HEAD to advance makes that path unreachable.
- Also bumped the Opus preset to 4.7 / xHigh (matches current model availability).

## Changes

| File | Change |
|------|--------|
| `src/runners/claude.ts` | Escalate to `killProcessGroup(SIGTERM)` if Ctrl+C grace expires; null out `lastWorkspacePid`. |
| `src/phases/interactive.ts` | Accept zero-commit phase-5 reopen when `implCommit !== null`; still reject first-attempt empty sessions. |
| `src/config.ts` | `claude-opus-4-6` → `claude-opus-4-7`, effort `max` → `xHigh`. |
| `tests/phases/interactive.test.ts` | New regression test + `xHigh` string in existing assertion. |

All 427 tests pass.

## Test plan

- [x] `npm run build`
- [x] `npx vitest run` (31 files, 427 pass, 1 skipped)
- [x] Manual QA: harness session with vague todo-manager spec reaches phase-5 reopen path successfully (previously died at 10-min timeout).