### PR TITLE
chore: land UX quick-wins + codex session resume design docs

### DIFF
--- a/docs/plans/2026-04-18-codex-session-resume.md
+++ b/docs/plans/2026-04-18-codex-session-resume.md
@@ -1,0 +1,1932 @@
+# Per-Phase Codex Session Resume — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**관련 문서:**
+- Spec: `docs/specs/2026-04-18-codex-session-resume-design.md`
+- Eval checklist: 본 문서 §Eval Checklist
+- Eval report (작성 예정): `docs/process/evals/2026-04-18-codex-session-resume-eval.md`
+
+**Goal:** Harness gate reject 루프에서 Codex 세션을 phase 단위로 재사용해 redundant cold-start을 제거한다. 동일 phase의 retry는 `codex exec resume <id>`로 이어가고, phase 간에는 격리한다.
+
+**Architecture:** `HarnessState.phaseCodexSessions`에 각 gate phase(2/4/7)별 `GateSessionInfo` lineage 저장. `runCodexGate`가 `resumeSessionId` + `buildFreshPromptOnFallback` closure를 받아 resume 경로와 `session_missing` 카테고리 시 자동 fresh fallback을 처리. 세션 수명은 `phaseCodexSessions` null 세팅 + 관련 replay sidecar 삭제로 관리되며, preset 변경·backward jump에서 호출되는 invalidation helper가 이를 수행한다. `feedback` 파일은 reopen flow가 참조하므로 invalidation 대상이 아님.
+
+**Tech Stack:** TypeScript (Node.js), vitest, Codex CLI 1.0.3+ (`codex exec resume` 지원), fs/child_process 동기·비동기 API.
+
+---
+
+## File Structure
+
+### 신규 파일
+- `tests/runners/codex-resume.test.ts` — resume/fallback/error taxonomy runner unit tests
+- `tests/context/assembler-resume.test.ts` — Variant A/B 프롬프트 조립 tests
+- `tests/phases/gate-resume.test.ts` — runGatePhase 경로 분기, sidecar compatibility gate tests
+- `tests/state-invalidation.test.ts` — preset/jump invalidation helpers tests
+- `tests/integration/codex-session-resume.test.ts` — cross-module scenarios
+- `scripts/codex-resume-probe.mjs` — Task 0 pilot probe (체크인 후 로컬 실험용 — 선택적)
+
+### 수정 파일
+- `src/types.ts` — `GateSessionInfo` 추가, `HarnessState.phaseCodexSessions`, `GateResult.sourcePreset`, `GateOutcome`/`GateError`.sourcePreset/resumedFrom/resumeFallback, LogEvent 확장
+- `src/state.ts` — `createInitialState` 기본값 + migration + `invalidatePhaseSessionsOnPresetChange` + `invalidatePhaseSessionsOnJump`
+- `src/context/assembler.ts` — `assembleGateResumePrompt` 추가
+- `src/runners/codex.ts` — `runCodexGate` 시그니처 확장, 내부 `runCodexExecRaw` + error classifier, `session_missing` fallback, 모든 종료 경로에서 metadata 추출
+- `src/phases/gate.ts` — `runGatePhase` 경로 분기, sidecar replay compatibility gate, hydration 확장
+- `src/phases/verdict.ts` — (변경 없음 예상, 단 `buildGateResult`에 sourcePreset 전파는 gate.ts에서 처리하므로 여기선 영향 없음)
+- `src/phases/runner.ts` — verdict 경로까지 아우르는 redirect guard, gate_verdict/gate_error 이벤트에 resumedFrom/resumeFallback 전달
+- `src/commands/inner.ts` — preset 교체 후 `invalidatePhaseSessionsOnPresetChange`, `consumePendingAction`의 jump 분기에 `invalidatePhaseSessionsOnJump` 호출
+- `src/signal.ts` — SIGUSR1 jump 핸들러에 `invalidatePhaseSessionsOnJump` 호출
+- 기존 테스트(`tests/state.test.ts`, `tests/phases/gate.test.ts`, `tests/runners/codex.test.ts`, `tests/commands/inner.test.ts`, `tests/signal.test.ts`, `tests/resume.test.ts`) — 시그니처 변경 반영
+
+---
+
+## Task 0: Codex CLI 동작 Pilot (pre-implementation probe)
+
+스펙 §9 open questions 해소: 실존하지 않는 UUID로 resume 호출 시 stderr/exit 패턴, resume 후에도 stdout에 session id가 찍히는지, 모델 오버라이드가 원 세션과 달라도 동작하는지.
+
+**Files:**
+- Create: `scripts/codex-resume-probe.mjs` (optional probe script)
+- Create: 본 태스크 실행 결과를 spec §9 바로 밑에 인라인 코멘트로 기록하거나, `docs/specs/2026-04-18-codex-session-resume-design.md`의 §9에 결과 서브섹션 추가
+
+- [ ] **Step 1: fresh 호출 stdout에서 session id 추출 패턴 확인**
+
+Run (fresh session으로 최소 프롬프트):
+```bash
+echo "Say 'hello' and stop." | codex exec --model gpt-5-codex -c model_reasoning_effort="minimal" - 2>&1 | tee /tmp/codex-probe-fresh.txt
+```
+`session id:` 라인을 grep해서 UUID 형식 확인:
+```bash
+grep -iE "session id:\s*[0-9a-f-]+" /tmp/codex-probe-fresh.txt
+```
+Expected: 한 줄에 `session id: <uuid>` 형태로 출력.
+
+- [ ] **Step 2: 실존 session id로 resume 호출 시 응답과 session id 패턴 확인**
+
+위 Step 1에서 얻은 UUID를 `$SID`에 담고:
+```bash
+echo "Say 'world' and stop." | codex exec resume "$SID" - 2>&1 | tee /tmp/codex-probe-resume.txt
+grep -iE "session id:\s*[0-9a-f-]+" /tmp/codex-probe-resume.txt
+```
+Expected: exit 0, stdout 또는 stderr에 같은 UUID 또는 새 UUID 찍힘. 결과를 §9 Q#2 (동일 id vs fork)에 반영.
+
+- [ ] **Step 3: 존재하지 않는 UUID로 resume 호출 시 에러 패턴 확인**
+
+```bash
+echo "noop" | codex exec resume "00000000-0000-0000-0000-000000000000" - 2>&1 | tee /tmp/codex-probe-missing.txt
+echo "exit code: $?"
+```
+Expected: non-zero exit. stderr에 "session not found" 또는 유사 패턴. 정확한 문자열을 §9 Q#1에 반영하여 Task 4 `session_missing` 정규식 확정.
+
+- [ ] **Step 4: 모델/effort 오버라이드 호환성 확인**
+
+Step 1을 `gpt-5-codex` + effort=low로 한 뒤, 같은 세션을 `gpt-5-codex` + effort=high로 resume:
+```bash
+echo "Summarize in one sentence." | codex exec resume "$SID" --model gpt-5-codex -c model_reasoning_effort="high" - 2>&1 | tee /tmp/codex-probe-modelchange.txt
+echo "exit code: $?"
+```
+Expected: exit 0 또는 document된 error. §9 Q#3에 결과 기록. 현재 spec 정책상 preset 변경 시 세션을 invalidate하므로 이 case가 런타임에 도달하지 않지만 edge case 자료로 남긴다.
+
+- [ ] **Step 5: 결과를 spec §9에 추가 (세 Q 각각 "pilot 결과" 서브-bullet)**
+
+`docs/specs/2026-04-18-codex-session-resume-design.md`의 §9를 Edit. 각 open question 밑에 `> pilot 결과 (2026-04-18): ...` 한두 줄 요약 추가.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/specs/2026-04-18-codex-session-resume-design.md
+git commit -m "docs(spec): record Codex CLI resume pilot findings in §9"
+```
+
+---
+
+## Task 1: 타입 확장
+
+**Files:**
+- Modify: `src/types.ts`
+
+- [ ] **Step 1: `GateSessionInfo` 타입 추가**
+
+`src/types.ts`의 `interface HarnessState` 선언 **직전**에:
+
+```ts
+export interface GateSessionInfo {
+  sessionId: string;                         // non-empty, validated on save/load
+  runner: 'claude' | 'codex';                // reserved — v1에서 실질 'codex'만 저장됨
+  model: string;
+  effort: string;
+  lastOutcome: 'approve' | 'reject' | 'error';
+}
+```
+
+- [ ] **Step 2: `HarnessState`에 `phaseCodexSessions` 필드 추가**
+
+`HarnessState` interface 안, 다른 `Record<string, ...>` 필드들 주변에:
+
+```ts
+  // Per-phase Codex session resume (§4.1 of spec)
+  phaseCodexSessions: Record<'2' | '4' | '7', GateSessionInfo | null>;
+```
+
+- [ ] **Step 3: `GateResult`에 `sourcePreset` 확장**
+
+기존 `GateResult` 인터페이스에 필드 추가 (optional):
+
+```ts
+export interface GateResult {
+  exitCode: number;
+  timestamp: number;
+  runner?: 'claude' | 'codex';
+  promptBytes?: number;
+  durationMs?: number;
+  tokensTotal?: number;
+  codexSessionId?: string;
+  sourcePreset?: { model: string; effort: string };  // NEW
+}
+```
+
+- [ ] **Step 4: `GateOutcome`/`GateError`에 resume 메타데이터 확장**
+
+```ts
+export interface GateOutcome {
+  type: 'verdict';
+  verdict: GateVerdict;
+  comments: string;
+  rawOutput: string;
+  runner?: 'claude' | 'codex';
+  promptBytes?: number;
+  durationMs?: number;
+  tokensTotal?: number;
+  codexSessionId?: string;
+  recoveredFromSidecar?: boolean;
+  sourcePreset?: { model: string; effort: string };    // NEW (replay hydration)
+  resumedFrom?: string | null;                          // NEW
+  resumeFallback?: boolean;                             // NEW
+}
+
+export interface GateError {
+  type: 'error';
+  error: string;
+  rawOutput?: string;
+  runner?: 'claude' | 'codex';
+  promptBytes?: number;
+  durationMs?: number;
+  exitCode?: number;
+  tokensTotal?: number;
+  codexSessionId?: string;
+  recoveredFromSidecar?: boolean;
+  sourcePreset?: { model: string; effort: string };    // NEW
+  resumedFrom?: string | null;                          // NEW
+  resumeFallback?: boolean;                             // NEW
+}
+```
+
+- [ ] **Step 5: `LogEvent` 타입의 `gate_verdict`/`gate_error` variant에 신규 필드 추가**
+
+기존 `gate_verdict` variant에:
+
+```ts
+  | (LogEventBase & {
+      event: 'gate_verdict';
+      phase: number;
+      retryIndex: number;
+      runner: 'claude' | 'codex';
+      verdict: GateVerdict;
+      durationMs?: number;
+      tokensTotal?: number;
+      promptBytes?: number;
+      codexSessionId?: string;
+      recoveredFromSidecar?: boolean;
+      resumedFrom?: string | null;   // NEW
+      resumeFallback?: boolean;       // NEW
+    })
+```
+
+동일하게 `gate_error` variant에도:
+
+```ts
+  | (LogEventBase & {
+      event: 'gate_error';
+      phase: number;
+      retryIndex: number;
+      runner?: 'claude' | 'codex';
+      error: string;
+      exitCode?: number;
+      durationMs?: number;
+      tokensTotal?: number;
+      codexSessionId?: string;
+      recoveredFromSidecar?: boolean;
+      resumedFrom?: string | null;   // NEW
+      resumeFallback?: boolean;       // NEW
+    })
+```
+
+- [ ] **Step 6: TypeScript 빌드 통과 확인**
+
+```bash
+pnpm -s tsc --noEmit
+```
+Expected: 에러 없음. 에러가 있으면 필드 누락이나 오타 확인.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/types.ts
+git commit -m "feat(types): add GateSessionInfo and resume-related metadata fields"
+```
+
+---
+
+## Task 2: state.ts — 초기값, migration, invalidation helpers
+
+**Files:**
+- Modify: `src/state.ts`
+- Create: `tests/state-invalidation.test.ts`
+
+- [ ] **Step 1: `createInitialState`에 `phaseCodexSessions` 기본값 추가**
+
+`createInitialState` 함수의 return 객체에, 다른 Record 필드들 주변에:
+
+```ts
+    phaseCodexSessions: { '2': null, '4': null, '7': null },
+```
+
+- [ ] **Step 2: `migrateState`에 `phaseCodexSessions` 호환 처리 추가**
+
+`migrateState` 함수 body 끝부분(기존 `phaseReopenSource` 처리 아래)에:
+
+```ts
+  if (!raw.phaseCodexSessions || typeof raw.phaseCodexSessions !== 'object') {
+    raw.phaseCodexSessions = { '2': null, '4': null, '7': null };
+  }
+  for (const k of ['2', '4', '7'] as const) {
+    const v = raw.phaseCodexSessions[k];
+    if (v === undefined || v === null) {
+      raw.phaseCodexSessions[k] = null;
+      continue;
+    }
+    if (
+      typeof v !== 'object' ||
+      typeof v.sessionId !== 'string' ||
+      v.sessionId.trim().length === 0 ||
+      typeof v.runner !== 'string' ||
+      typeof v.model !== 'string' ||
+      typeof v.effort !== 'string' ||
+      (v.lastOutcome !== 'approve' && v.lastOutcome !== 'reject' && v.lastOutcome !== 'error')
+    ) {
+      raw.phaseCodexSessions[k] = null;
+    }
+  }
+```
+
+- [ ] **Step 3: 실패하는 invalidation 테스트 작성**
+
+`tests/state-invalidation.test.ts` 생성:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import {
+  invalidatePhaseSessionsOnPresetChange,
+  invalidatePhaseSessionsOnJump,
+} from '../src/state.js';
+import type { HarnessState, GateSessionInfo } from '../src/types.js';
+
+function makeSession(model: string, effort: string): GateSessionInfo {
+  return { sessionId: 'abc-123', runner: 'codex', model, effort, lastOutcome: 'reject' };
+}
+
+function makeState(): HarnessState {
+  // 테스트용 최소 state — 실제 스키마의 미사용 필드는 any 캐스트
+  return {
+    phasePresets: {
+      '2': 'codex-high',
+      '4': 'codex-high',
+      '7': 'codex-high',
+    },
+    phaseCodexSessions: {
+      '2': makeSession('gpt-5-codex', 'high'),
+      '4': makeSession('gpt-5-codex', 'high'),
+      '7': makeSession('gpt-5-codex', 'high'),
+    },
+  } as unknown as HarnessState;
+}
+
+function makeRunDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'harness-inv-'));
+}
+
+function touch(runDir: string, filename: string) {
+  fs.writeFileSync(path.join(runDir, filename), 'x');
+}
+
+function exists(runDir: string, filename: string): boolean {
+  return fs.existsSync(path.join(runDir, filename));
+}
+
+describe('invalidatePhaseSessionsOnPresetChange', () => {
+  it('nulls session when preset model changes for same runner', () => {
+    const state = makeState();
+    const prev = { '2': 'codex-high', '4': 'codex-high', '7': 'codex-high' };
+    state.phasePresets['2'] = 'codex-medium';
+    const runDir = makeRunDir();
+    invalidatePhaseSessionsOnPresetChange(state, prev, runDir);
+    expect(state.phaseCodexSessions['2']).toBeNull();
+    expect(state.phaseCodexSessions['4']).not.toBeNull();
+  });
+
+  it('nulls session when runner changes from codex to claude', () => {
+    const state = makeState();
+    const prev = { '2': 'codex-high', '4': 'codex-high', '7': 'codex-high' };
+    state.phasePresets['4'] = 'sonnet-high';
+    const runDir = makeRunDir();
+    invalidatePhaseSessionsOnPresetChange(state, prev, runDir);
+    expect(state.phaseCodexSessions['4']).toBeNull();
+    expect(state.phaseCodexSessions['2']).not.toBeNull();
+  });
+
+  it('keeps session when preset unchanged (no-op)', () => {
+    const state = makeState();
+    const prev = { '2': 'codex-high', '4': 'codex-high', '7': 'codex-high' };
+    const runDir = makeRunDir();
+    invalidatePhaseSessionsOnPresetChange(state, prev, runDir);
+    expect(state.phaseCodexSessions['2']).not.toBeNull();
+    expect(state.phaseCodexSessions['4']).not.toBeNull();
+    expect(state.phaseCodexSessions['7']).not.toBeNull();
+  });
+
+  it('deletes replay sidecars but preserves feedback file on invalidation', () => {
+    const state = makeState();
+    const runDir = makeRunDir();
+    touch(runDir, 'gate-2-raw.txt');
+    touch(runDir, 'gate-2-result.json');
+    touch(runDir, 'gate-2-error.md');
+    touch(runDir, 'gate-2-feedback.md');
+    const prev = { '2': 'codex-high', '4': 'codex-high', '7': 'codex-high' };
+    state.phasePresets['2'] = 'codex-medium';
+    invalidatePhaseSessionsOnPresetChange(state, prev, runDir);
+    expect(exists(runDir, 'gate-2-raw.txt')).toBe(false);
+    expect(exists(runDir, 'gate-2-result.json')).toBe(false);
+    expect(exists(runDir, 'gate-2-error.md')).toBe(false);
+    expect(exists(runDir, 'gate-2-feedback.md')).toBe(true);
+  });
+});
+
+describe('invalidatePhaseSessionsOnJump', () => {
+  it('nulls sessions for gate phases >= targetPhase only', () => {
+    const state = makeState();
+    const runDir = makeRunDir();
+    invalidatePhaseSessionsOnJump(state, 3, runDir);
+    expect(state.phaseCodexSessions['2']).not.toBeNull();
+    expect(state.phaseCodexSessions['4']).toBeNull();
+    expect(state.phaseCodexSessions['7']).toBeNull();
+  });
+
+  it('deletes replay sidecars but preserves feedback file on jump', () => {
+    const state = makeState();
+    const runDir = makeRunDir();
+    touch(runDir, 'gate-7-raw.txt');
+    touch(runDir, 'gate-7-result.json');
+    touch(runDir, 'gate-7-feedback.md');
+    invalidatePhaseSessionsOnJump(state, 5, runDir);
+    expect(exists(runDir, 'gate-7-raw.txt')).toBe(false);
+    expect(exists(runDir, 'gate-7-result.json')).toBe(false);
+    expect(exists(runDir, 'gate-7-feedback.md')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 4: 테스트 실행 → 실패 확인 (함수 미구현)**
+
+```bash
+pnpm -s vitest run tests/state-invalidation.test.ts
+```
+Expected: "invalidatePhaseSessionsOnPresetChange is not a function" 류 에러.
+
+- [ ] **Step 5: `invalidatePhaseSessionsOnPresetChange` 구현**
+
+`src/state.ts` 상단 import에 `getPresetById` 추가(없다면):
+
+```ts
+import { PHASE_DEFAULTS, REQUIRED_PHASE_KEYS, MODEL_PRESETS, getPresetById } from './config.js';
+```
+
+파일 끝에 다음 함수 추가:
+
+```ts
+/**
+ * Invalidate stored Codex gate sessions when user changes phase preset mid-run.
+ * Deletes replay sidecars to prevent sidecar replay from bypassing invalidation.
+ * Feedback file (gate-N-feedback.md) is preserved — reopen flow depends on it.
+ */
+export function invalidatePhaseSessionsOnPresetChange(
+  state: HarnessState,
+  prevPresets: Record<string, string>,
+  runDir: string,
+): void {
+  for (const phase of ['2', '4', '7'] as const) {
+    const prevId = prevPresets[phase];
+    const currId = state.phasePresets[phase];
+    if (prevId === currId) continue;
+    const prev = getPresetById(prevId);
+    const curr = getPresetById(currId);
+    if (
+      !prev || !curr ||
+      prev.runner !== curr.runner ||
+      (curr.runner === 'codex' && (prev.model !== curr.model || prev.effort !== curr.effort))
+    ) {
+      state.phaseCodexSessions[phase] = null;
+      for (const filename of [`gate-${phase}-raw.txt`, `gate-${phase}-result.json`, `gate-${phase}-error.md`]) {
+        try { fs.unlinkSync(path.join(runDir, filename)); } catch { /* ignore missing */ }
+      }
+    }
+  }
+}
+```
+
+필요한 import (`path`)가 이미 상단에 있으면 재사용, 없으면 추가.
+
+- [ ] **Step 6: `invalidatePhaseSessionsOnJump` 구현**
+
+`src/state.ts` 파일 끝에:
+
+```ts
+/**
+ * Invalidate Codex gate sessions for phases >= targetPhase on backward jump.
+ * Deletes replay sidecars to prevent sidecar replay after jump.
+ * Feedback file preserved — reopen flow dependency.
+ */
+export function invalidatePhaseSessionsOnJump(
+  state: HarnessState,
+  targetPhase: number,
+  runDir: string,
+): void {
+  for (const phase of [2, 4, 7] as const) {
+    if (phase >= targetPhase) {
+      state.phaseCodexSessions[String(phase) as '2' | '4' | '7'] = null;
+      for (const filename of [`gate-${phase}-raw.txt`, `gate-${phase}-result.json`, `gate-${phase}-error.md`]) {
+        try { fs.unlinkSync(path.join(runDir, filename)); } catch { /* ignore missing */ }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 7: 테스트 재실행 → 통과 확인**
+
+```bash
+pnpm -s vitest run tests/state-invalidation.test.ts
+```
+Expected: 6 passed.
+
+- [ ] **Step 8: 기존 state 테스트 migration 케이스 업데이트**
+
+`tests/state.test.ts`에서 `createInitialState` 또는 `migrateState` 테스트 블록이 있으면 `phaseCodexSessions` 기본값 / legacy state 호환 케이스 추가:
+
+```ts
+it('migrateState sets default phaseCodexSessions for legacy state', () => {
+  const legacy = {
+    /* ...existing legacy fixture without phaseCodexSessions... */
+  };
+  const migrated = migrateState(legacy as any);
+  expect(migrated.phaseCodexSessions).toEqual({ '2': null, '4': null, '7': null });
+});
+
+it('migrateState discards malformed GateSessionInfo entries', () => {
+  const legacy = {
+    /* ... */
+    phaseCodexSessions: {
+      '2': { sessionId: '', runner: 'codex', model: 'x', effort: 'high', lastOutcome: 'reject' },
+      '4': null,
+      '7': { sessionId: 'abc', runner: 'codex', model: 'x', effort: 'high', lastOutcome: 'invalid' },
+    },
+  };
+  const migrated = migrateState(legacy as any);
+  expect(migrated.phaseCodexSessions['2']).toBeNull(); // empty sessionId → null
+  expect(migrated.phaseCodexSessions['7']).toBeNull(); // invalid lastOutcome → null
+});
+```
+
+- [ ] **Step 9: 전체 state 테스트 통과 확인**
+
+```bash
+pnpm -s vitest run tests/state.test.ts tests/state-invalidation.test.ts
+```
+Expected: all passed.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/state.ts tests/state.test.ts tests/state-invalidation.test.ts
+git commit -m "feat(state): add phaseCodexSessions and invalidation helpers"
+```
+
+---
+
+## Task 3: assembler.ts — assembleGateResumePrompt (Variant A/B)
+
+**Files:**
+- Modify: `src/context/assembler.ts`
+- Create: `tests/context/assembler-resume.test.ts`
+
+- [ ] **Step 1: 실패하는 resume prompt 테스트 작성**
+
+`tests/context/assembler-resume.test.ts` 생성:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { assembleGateResumePrompt } from '../../src/context/assembler.js';
+import type { HarnessState } from '../../src/types.js';
+
+function makeState(overrides: Partial<HarnessState> = {}): HarnessState {
+  // 최소 state — test에 필요한 필드만 채움
+  return {
+    runId: 'r1',
+    artifacts: {
+      spec: 'fixtures/spec.md',
+      plan: 'fixtures/plan.md',
+      evalReport: 'fixtures/eval.md',
+      decisionLog: '.harness/r1/decisions.md',
+      checklist: '.harness/r1/checklist.json',
+    },
+    baseCommit: 'abc',
+    implCommit: null,
+    evalCommit: null,
+    verifiedAtHead: null,
+    externalCommitsDetected: false,
+    ...overrides,
+  } as unknown as HarnessState;
+}
+
+describe('assembleGateResumePrompt — Variant A (reject)', () => {
+  it('includes updated artifacts and previous feedback', () => {
+    const cwd = 'tests/context/fixtures'; // 테스트용 실존 fixture 경로
+    const state = makeState();
+    const res = assembleGateResumePrompt(2, state, cwd, 'reject', 'P1: fix X\nP1: fix Y');
+    expect(typeof res).toBe('string');
+    if (typeof res === 'string') {
+      expect(res).toMatch(/Updated Artifacts \(Re-Review Requested\)/);
+      expect(res).toMatch(/previous feedback/i);
+      expect(res).toMatch(/P1: fix X/);
+      // REVIEWER_CONTRACT 전문은 포함 안 함
+      expect(res).not.toMatch(/You are an independent technical reviewer/);
+    }
+  });
+});
+
+describe('assembleGateResumePrompt — Variant B (error or approve)', () => {
+  it('omits previous feedback block for error outcome', () => {
+    const cwd = 'tests/context/fixtures';
+    const state = makeState();
+    const res = assembleGateResumePrompt(2, state, cwd, 'error', '');
+    expect(typeof res).toBe('string');
+    if (typeof res === 'string') {
+      expect(res).toMatch(/Continue Review/);
+      expect(res).not.toMatch(/Your Previous Feedback/);
+      expect(res).not.toMatch(/You are an independent technical reviewer/);
+    }
+  });
+
+  it('treats approve as Variant B for safety', () => {
+    const cwd = 'tests/context/fixtures';
+    const state = makeState();
+    const res = assembleGateResumePrompt(4, state, cwd, 'approve', '');
+    expect(typeof res).toBe('string');
+    if (typeof res === 'string') {
+      expect(res).toMatch(/Continue Review/);
+      expect(res).not.toMatch(/Your Previous Feedback/);
+    }
+  });
+});
+```
+
+Fixtures 디렉토리와 파일이 없으면 Step 2에서 생성.
+
+- [ ] **Step 2: 테스트 fixture 생성**
+
+```bash
+mkdir -p tests/context/fixtures
+printf '# Spec\ncontent\n' > tests/context/fixtures/spec.md
+printf '# Plan\ncontent\n' > tests/context/fixtures/plan.md
+printf '# Eval\ncontent\n' > tests/context/fixtures/eval.md
+```
+
+- [ ] **Step 3: 테스트 실행 → 실패 확인 (함수 미구현)**
+
+```bash
+pnpm -s vitest run tests/context/assembler-resume.test.ts
+```
+Expected: `assembleGateResumePrompt is not a function` 류 에러.
+
+- [ ] **Step 4: `assembleGateResumePrompt` 구현**
+
+`src/context/assembler.ts` 파일의 `assembleGatePrompt` 함수 **위**에 (REVIEWER_CONTRACT는 기존 export 없음이지만 resume 경로는 포함 안 하므로 상관없음):
+
+```ts
+function buildResumeSectionsPhase2(state: HarnessState, cwd: string): string | { error: string } {
+  const spec = readArtifactContent(state.artifacts.spec, cwd);
+  if ('error' in spec) return spec;
+  return `<spec>\n${spec.content}\n</spec>\n`;
+}
+
+function buildResumeSectionsPhase4(state: HarnessState, cwd: string): string | { error: string } {
+  const spec = readArtifactContent(state.artifacts.spec, cwd);
+  if ('error' in spec) return spec;
+  const plan = readArtifactContent(state.artifacts.plan, cwd);
+  if ('error' in plan) return plan;
+  return `<spec>\n${spec.content}\n</spec>\n\n<plan>\n${plan.content}\n</plan>\n`;
+}
+
+function buildResumeSectionsPhase7(state: HarnessState, cwd: string): string | { error: string } {
+  // phase 7은 기존 assembleGatePrompt의 buildGatePromptPhase7 로직을 재활용.
+  // 차이점: REVIEWER_CONTRACT가 프롬프트 본문에 포함되지 않음. 여기서는 아티팩트 + diff + metadata만.
+  const spec = readArtifactContent(state.artifacts.spec, cwd);
+  if ('error' in spec) return spec;
+  const plan = readArtifactContent(state.artifacts.plan, cwd);
+  if ('error' in plan) return plan;
+  const evalRep = readArtifactContent(state.artifacts.evalReport, cwd);
+  if ('error' in evalRep) return evalRep;
+  // diff + metadata는 기존 buildGatePromptPhase7과 동일 로직 (중복 제거 위해 헬퍼 분리 권장).
+  // v1에서는 복붙 허용, 이후 리팩토링 태스크.
+  let diffSection: string;
+  let externalSummary = '';
+  if (state.externalCommitsDetected) {
+    let primary = '';
+    if (state.implCommit !== null) {
+      primary += runGit(`git diff ${state.baseCommit}...${state.implCommit}`, cwd);
+      if (state.evalCommit !== null) {
+        primary += '\n' + runGit(`git diff ${state.evalCommit}^..${state.evalCommit}`, cwd);
+      }
+    } else {
+      const target = state.evalCommit ?? 'HEAD';
+      primary = runGit(`git diff ${state.baseCommit}...${target}`, cwd);
+      primary =
+        `⚠️ IMPORTANT: Phase 5 was skipped and external commits were detected. ` +
+        `Focus on the eval report and spec/plan compliance rather than the diff.\n\n` + primary;
+    }
+    const maxDiffBytes = MAX_DIFF_SIZE_KB * 1024;
+    if (primary.length > maxDiffBytes) {
+      primary = truncateDiffPerFile(primary, PER_FILE_DIFF_LIMIT_KB * 1024);
+    }
+    diffSection = `<diff>\n${primary}\n</diff>\n`;
+    const anchor = state.evalCommit ?? state.implCommit ?? state.baseCommit;
+    const externalLog = runGit(`git log ${anchor}..HEAD --oneline`, cwd);
+    if (externalLog.trim().length > 0) {
+      externalSummary = `\n## External Commits (not reviewed)\n\n\`\`\`\n${externalLog}\n\`\`\`\n`;
+    }
+  } else {
+    let diff = runGit(`git diff ${state.baseCommit}...HEAD`, cwd);
+    const maxDiffBytes = MAX_DIFF_SIZE_KB * 1024;
+    if (diff.length > maxDiffBytes) {
+      diff = truncateDiffPerFile(diff, PER_FILE_DIFF_LIMIT_KB * 1024);
+    }
+    diffSection = diff ? `<diff>\n${diff}\n</diff>\n` : '';
+  }
+  const externalNote = state.externalCommitsDetected
+    ? `Note: External commits detected. See '## External Commits (not reviewed)' section below.\nPrimary diff covers harness implementation range only.\n`
+    : '';
+  const implRange = state.implCommit !== null
+    ? `Harness implementation range: ${state.baseCommit}..${state.implCommit} (Phase 1–5 commits).`
+    : `Phase 5 skipped; no implementation commit anchor.`;
+  const metadata = `<metadata>\n${externalNote}${implRange}\nHarness eval report commit: ${state.evalCommit ?? '(none)'} (the commit that last modified the eval report).\nVerified at HEAD: ${state.verifiedAtHead ?? '(none)'} (most recent Phase 6 run).\nFocus review on changes within the harness ranges above.\n</metadata>\n`;
+  return (
+    `<spec>\n${spec.content}\n</spec>\n\n` +
+    `<plan>\n${plan.content}\n</plan>\n\n` +
+    `<eval_report>\n${evalRep.content}\n</eval_report>\n\n` +
+    diffSection + externalSummary + '\n' + metadata
+  );
+}
+
+/**
+ * Assemble resume prompt for an already-open Codex gate session (§4.3 of spec).
+ * Variant A (lastOutcome='reject'): updated artifacts + previous feedback.
+ * Variant B (lastOutcome='error' | 'approve'): continuation without feedback block.
+ * REVIEWER_CONTRACT is NOT included (already in session first turn).
+ */
+export function assembleGateResumePrompt(
+  phase: 2 | 4 | 7,
+  state: HarnessState,
+  cwd: string,
+  lastOutcome: 'approve' | 'reject' | 'error',
+  previousFeedback: string,
+): string | { error: string } {
+  const artifacts =
+    phase === 2 ? buildResumeSectionsPhase2(state, cwd)
+    : phase === 4 ? buildResumeSectionsPhase4(state, cwd)
+    : buildResumeSectionsPhase7(state, cwd);
+  if (typeof artifacts !== 'string') return artifacts;
+
+  let prompt: string;
+  if (lastOutcome === 'reject') {
+    prompt =
+      `## Updated Artifacts (Re-Review Requested)\n\n` +
+      `The artifacts have been updated based on your previous feedback. Re-review the new versions and verify your prior concerns were addressed.\n\n` +
+      artifacts + '\n' +
+      `## Your Previous Feedback (for reference)\n\n${previousFeedback}\n\n` +
+      `## Instructions\n\nReturn a verdict in the same structured format you used before (## Verdict / ## Comments / ## Summary). APPROVE only if zero P0/P1 findings, and especially verify whether your prior P0/P1 concerns have been addressed.\n`;
+  } else {
+    // Variant B (error or approve safety-fallback)
+    prompt =
+      `## Continue Review\n\n` +
+      `The previous review turn did not complete. Here are the artifacts to review (unchanged from the prior turn, unless modifications occurred in the interim):\n\n` +
+      artifacts + '\n' +
+      `## Instructions\n\nReturn a verdict in the same structured format you used before (## Verdict / ## Comments / ## Summary).\n`;
+  }
+
+  if (prompt.length > MAX_PROMPT_SIZE_KB * 1024) {
+    return { error: `Assembled gate resume prompt too large: ${Math.round(prompt.length / 1024)}KB > ${MAX_PROMPT_SIZE_KB}KB limit` };
+  }
+  return prompt;
+}
+```
+
+- [ ] **Step 5: 테스트 재실행 → 통과 확인**
+
+```bash
+pnpm -s vitest run tests/context/assembler-resume.test.ts
+```
+Expected: 3 passed.
+
+- [ ] **Step 6: 기존 assembler 회귀 확인**
+
+```bash
+pnpm -s vitest run tests/context/
+```
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/context/assembler.ts tests/context/assembler-resume.test.ts tests/context/fixtures/
+git commit -m "feat(assembler): add assembleGateResumePrompt with Variant A/B"
+```
+
+---
+
+## Task 4: runners/codex.ts — resume path, error taxonomy, fallback
+
+**Files:**
+- Modify: `src/runners/codex.ts`
+- Create: `tests/runners/codex-resume.test.ts`
+
+- [ ] **Step 1: `runCodexGate` 시그니처 확장 + 내부 refactor**
+
+`src/runners/codex.ts` 상단에 내부 헬퍼 타입 정의:
+
+```ts
+type RawExecCategory =
+  | 'success_verdict'     // exit 0, stdout에 ## Verdict 존재
+  | 'success_no_verdict'  // exit 0인데 ## Verdict 없음 (리뷰 품질 문제)
+  | 'session_missing'     // resume 대상 세션을 찾을 수 없음 (fallback 트리거)
+  | 'timeout'
+  | 'spawn_error'
+  | 'nonzero_exit_other';
+
+interface RawExecResult {
+  category: RawExecCategory;
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  codexSessionId?: string;
+  tokensTotal?: number;
+}
+```
+
+기존 `runCodexGate`를 내부 헬퍼 `runCodexExecRaw`와 공개 래퍼로 분리.
+
+- [ ] **Step 2: `isResumeSessionMissingError` 구현 (Task 0 결과 반영)**
+
+Task 0 Step 3에서 기록된 실제 stderr 문자열을 기반으로 정규식 확정. 초기 보수적 패턴:
+
+```ts
+function isResumeSessionMissingError(stderr: string): boolean {
+  // Task 0 pilot 결과에 따라 갱신. 기본 보수적 패턴.
+  // 다수의 파악된 표현을 |로 엮되, 너무 넓게 잡지 않음 (오탐 시 cost 낭비).
+  return /session\s+(not\s+found|missing|expired|does\s+not\s+exist|unknown)/i.test(stderr)
+      || /no\s+such\s+session/i.test(stderr);
+}
+```
+
+- [ ] **Step 3: `runCodexExecRaw` 내부 헬퍼 구현**
+
+기존 gate `spawn` 로직을 이 함수로 옮기고 metadata 추출 + category 분류 포함. 공개 API (`runCodexGate`)는 뒤에 래퍼로 재구성.
+
+```ts
+import { parseVerdict, extractCodexMetadata } from '../phases/verdict.js';
+
+interface RawExecInput {
+  mode: 'fresh' | 'resume';
+  sessionId?: string;   // mode === 'resume'일 때 required
+  prompt: string;
+  preset: ModelPreset;
+  harnessDir: string;
+  cwd: string;
+  phase: number;        // lock 갱신 등에 사용
+}
+
+async function runCodexExecRaw(input: RawExecInput): Promise<RawExecResult> {
+  const codexBin = resolveCodexBin();
+  const args = input.mode === 'resume'
+    ? ['exec', 'resume',
+       '--model', input.preset.model,
+       '-c', `model_reasoning_effort="${input.preset.effort}"`,
+       input.sessionId!, '-']
+    : ['exec',
+       '--model', input.preset.model,
+       '-c', `model_reasoning_effort="${input.preset.effort}"`,
+       '-'];
+
+  const child = spawn(codexBin, args, { stdio: ['pipe', 'pipe', 'pipe'], detached: true, cwd: input.cwd });
+  const childPid = child.pid!;
+  const startTime = getProcessStartTime(childPid);
+  updateLockChild(input.harnessDir, childPid, input.phase, startTime);
+
+  child.stdin.write(input.prompt);
+  child.stdin.end();
+
+  const stdoutChunks: Buffer[] = [];
+  const stderrChunks: Buffer[] = [];
+  child.stdout.on('data', (c: Buffer) => stdoutChunks.push(c));
+  child.stderr.on('data', (c: Buffer) => {
+    stderrChunks.push(c);
+    const text = c.toString();
+    for (const line of text.split('\n')) {
+      if (line.includes('[codex]')) process.stderr.write(`  ${line}\n`);
+    }
+  });
+
+  // Promise: close/timeout/error 모든 경로에서 metadata 추출 후 resolve
+  const finishResult = await new Promise<{
+    exitCode: number | null; spawnError?: string; timedOut?: boolean;
+  }>((resolve) => {
+    let settled = false;
+    const timeout = setTimeout(async () => {
+      if (settled) return; settled = true;
+      await killProcessGroup(childPid, SIGTERM_WAIT_MS);
+      resolve({ exitCode: null, timedOut: true });
+    }, GATE_TIMEOUT_MS);
+    child.on('close', (code) => {
+      if (settled) return; settled = true;
+      clearTimeout(timeout);
+      resolve({ exitCode: code ?? 1 });
+    });
+    child.on('error', (err) => {
+      if (settled) return; settled = true;
+      clearTimeout(timeout);
+      resolve({ exitCode: null, spawnError: err.message });
+    });
+  });
+  await killProcessGroup(childPid, SIGTERM_WAIT_MS);
+  try { clearLockChild(input.harnessDir); } catch { /* best-effort */ }
+
+  const stdout = Buffer.concat(stdoutChunks).toString('utf-8');
+  const stderr = Buffer.concat(stderrChunks).toString('utf-8');
+  const meta = extractCodexMetadata(stdout);
+
+  let category: RawExecCategory;
+  if (finishResult.spawnError) category = 'spawn_error';
+  else if (finishResult.timedOut) category = 'timeout';
+  else if (finishResult.exitCode !== 0) {
+    category = input.mode === 'resume' && isResumeSessionMissingError(stderr)
+      ? 'session_missing'
+      : 'nonzero_exit_other';
+  } else {
+    category = parseVerdict(stdout) !== null ? 'success_verdict' : 'success_no_verdict';
+  }
+
+  return {
+    category,
+    exitCode: finishResult.exitCode,
+    stdout,
+    stderr,
+    codexSessionId: meta.codexSessionId,
+    tokensTotal: meta.tokensTotal,
+  };
+}
+```
+
+- [ ] **Step 4: 공개 `runCodexGate` 래퍼 재작성**
+
+기존 구현을 다음으로 교체:
+
+```ts
+export async function runCodexGate(
+  phase: number,
+  preset: ModelPreset,
+  prompt: string,
+  harnessDir: string,
+  cwd: string,
+  resumeSessionId?: string | null,
+  buildFreshPromptOnFallback?: () => string | { error: string },
+): Promise<GatePhaseResult> {
+  const phaseState = { current: resumeSessionId ? 'resume' as const : 'fresh' as const };
+
+  const first = await runCodexExecRaw({
+    mode: resumeSessionId ? 'resume' : 'fresh',
+    sessionId: resumeSessionId ?? undefined,
+    prompt, preset, harnessDir, cwd, phase,
+  });
+
+  // session_missing → fresh fallback
+  if (first.category === 'session_missing') {
+    if (!buildFreshPromptOnFallback) {
+      return rawToError(first, `session_missing but no fallback prompt builder provided`, {
+        resumedFrom: resumeSessionId ?? null,
+        resumeFallback: false,
+        preset,
+      });
+    }
+    const promptOrError = buildFreshPromptOnFallback();
+    if (typeof promptOrError !== 'string') {
+      return {
+        type: 'error',
+        error: promptOrError.error,
+        rawOutput: first.stdout,
+        runner: 'codex',
+        durationMs: undefined,
+        tokensTotal: first.tokensTotal,
+        codexSessionId: first.codexSessionId,
+        sourcePreset: { model: preset.model, effort: preset.effort },
+        resumedFrom: resumeSessionId ?? null,
+        resumeFallback: true,
+      };
+    }
+    const fresh = await runCodexExecRaw({
+      mode: 'fresh', prompt: promptOrError, preset, harnessDir, cwd, phase,
+    });
+    return rawToResult(fresh, preset, /* resumedFrom */ resumeSessionId ?? null, /* resumeFallback */ true);
+  }
+
+  return rawToResult(first, preset, resumeSessionId ?? null, /* resumeFallback */ false);
+}
+
+function rawToResult(
+  raw: RawExecResult,
+  preset: ModelPreset,
+  resumedFrom: string | null,
+  resumeFallback: boolean,
+): GatePhaseResult {
+  if (raw.category === 'success_verdict') {
+    const parsed = parseVerdict(raw.stdout)!;
+    return {
+      type: 'verdict',
+      verdict: parsed.verdict,
+      comments: parsed.comments,
+      rawOutput: raw.stdout,
+      runner: 'codex',
+      codexSessionId: raw.codexSessionId,
+      tokensTotal: raw.tokensTotal,
+      sourcePreset: { model: preset.model, effort: preset.effort },
+      resumedFrom,
+      resumeFallback,
+    };
+  }
+  // 그 외 모두 error 취급
+  const msg =
+    raw.category === 'timeout' ? `Codex gate timed out after ${GATE_TIMEOUT_MS}ms` :
+    raw.category === 'spawn_error' ? `Codex spawn error` :
+    raw.category === 'success_no_verdict' ? `Gate output missing ## Verdict header` :
+    `Gate subprocess exited with code ${raw.exitCode ?? -1}`;
+  return rawToError(raw, msg, { resumedFrom, resumeFallback, preset });
+}
+
+function rawToError(
+  raw: RawExecResult,
+  message: string,
+  opts: { resumedFrom: string | null; resumeFallback: boolean; preset: ModelPreset },
+): GatePhaseResult {
+  return {
+    type: 'error',
+    error: message,
+    rawOutput: raw.stdout,
+    runner: 'codex',
+    exitCode: raw.exitCode ?? undefined,
+    codexSessionId: raw.codexSessionId,
+    tokensTotal: raw.tokensTotal,
+    sourcePreset: { model: opts.preset.model, effort: opts.preset.effort },
+    resumedFrom: opts.resumedFrom,
+    resumeFallback: opts.resumeFallback,
+  };
+}
+```
+
+기존 `runCodexInteractive`는 변경 없음 (gate 전용 작업).
+
+- [ ] **Step 5: 실패하는 runner 테스트 작성 (mocked spawn)**
+
+`tests/runners/codex-resume.test.ts` 생성:
+
+```ts
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { runCodexGate } from '../../src/runners/codex.js';
+import type { ModelPreset } from '../../src/config.js';
+
+// child_process.spawn을 모킹해 args/stdout/stderr/exitCode를 제어
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return { ...actual, spawn: vi.fn(), execSync: vi.fn(() => '/usr/local/bin/codex') };
+});
+
+function makeMockChild(opts: {
+  stdout?: string; stderr?: string; exitCode?: number; delayMs?: number;
+}): any {
+  const emitter: any = new EventEmitter();
+  emitter.stdin = { write: vi.fn(), end: vi.fn() };
+  emitter.stdout = new EventEmitter();
+  emitter.stderr = new EventEmitter();
+  emitter.pid = 12345;
+  setTimeout(() => {
+    if (opts.stdout) emitter.stdout.emit('data', Buffer.from(opts.stdout));
+    if (opts.stderr) emitter.stderr.emit('data', Buffer.from(opts.stderr));
+    emitter.emit('close', opts.exitCode ?? 0);
+  }, opts.delayMs ?? 5);
+  return emitter;
+}
+
+const preset: ModelPreset = { id: 'codex-high', runner: 'codex', model: 'gpt-5-codex', effort: 'high', label: 'codex-high' };
+
+const SUCCESS_STDOUT = `session id: abc-session-123\n## Verdict\nAPPROVE\n\n## Comments\n\n## Summary\nAll good.\ntokens used\n1234\n`;
+
+afterEach(() => { vi.clearAllMocks(); });
+
+describe('runCodexGate — fresh path', () => {
+  it('spawns codex exec without resume when no sessionId passed', async () => {
+    const cp = await import('child_process');
+    (cp.spawn as any).mockImplementationOnce(() => makeMockChild({ stdout: SUCCESS_STDOUT }));
+    const result = await runCodexGate(2, preset, 'prompt', '/tmp/h', '/tmp/c');
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.codexSessionId).toBe('abc-session-123');
+      expect(result.resumedFrom).toBeNull();
+      expect(result.resumeFallback).toBe(false);
+      expect(result.sourcePreset).toEqual({ model: 'gpt-5-codex', effort: 'high' });
+    }
+    // 첫 호출 args에 'resume'이 **포함되지 않아야**
+    const args = (cp.spawn as any).mock.calls[0][1] as string[];
+    expect(args).not.toContain('resume');
+  });
+});
+
+describe('runCodexGate — resume path', () => {
+  it('spawns codex exec resume <sessionId> when resumeSessionId provided', async () => {
+    const cp = await import('child_process');
+    (cp.spawn as any).mockImplementationOnce(() => makeMockChild({ stdout: SUCCESS_STDOUT.replace('abc-session-123', 'same-session') }));
+    const result = await runCodexGate(2, preset, 'prompt', '/tmp/h', '/tmp/c', 'same-session');
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.resumedFrom).toBe('same-session');
+      expect(result.resumeFallback).toBe(false);
+    }
+    const args = (cp.spawn as any).mock.calls[0][1] as string[];
+    expect(args).toContain('resume');
+    expect(args).toContain('same-session');
+  });
+});
+
+describe('runCodexGate — session_missing fallback', () => {
+  it('falls back to fresh spawn when resume fails with session_missing stderr', async () => {
+    const cp = await import('child_process');
+    // 1st call: resume fails with session not found
+    (cp.spawn as any).mockImplementationOnce(() =>
+      makeMockChild({ stderr: 'error: session not found\n', exitCode: 1 })
+    );
+    // 2nd call: fresh succeeds
+    (cp.spawn as any).mockImplementationOnce(() =>
+      makeMockChild({ stdout: SUCCESS_STDOUT.replace('abc-session-123', 'new-session') })
+    );
+    const freshPromptBuilder = () => 'fresh prompt body';
+    const result = await runCodexGate(
+      2, preset, 'resume prompt', '/tmp/h', '/tmp/c', 'dead-session', freshPromptBuilder
+    );
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.resumedFrom).toBe('dead-session');
+      expect(result.resumeFallback).toBe(true);
+      expect(result.codexSessionId).toBe('new-session');
+    }
+    // 두 번째 spawn args는 'resume' 없음
+    const args2 = (cp.spawn as any).mock.calls[1][1] as string[];
+    expect(args2).not.toContain('resume');
+  });
+
+  it('does NOT fall back on nonzero_exit_other (non-session-missing stderr)', async () => {
+    const cp = await import('child_process');
+    (cp.spawn as any).mockImplementationOnce(() =>
+      makeMockChild({ stderr: 'error: generic failure\n', exitCode: 1 })
+    );
+    const result = await runCodexGate(
+      2, preset, 'resume prompt', '/tmp/h', '/tmp/c', 'some-session', () => 'fresh'
+    );
+    expect(result.type).toBe('error');
+    if (result.type === 'error') {
+      expect(result.resumeFallback).toBe(false);
+    }
+  });
+
+  it('does NOT fall back on timeout', async () => {
+    const cp = await import('child_process');
+    (cp.spawn as any).mockImplementationOnce(() =>
+      // exit를 안 보내서 timeout 발생 시뮬
+      makeMockChild({ stdout: '', delayMs: 10_000_000 })
+    );
+    // GATE_TIMEOUT_MS를 줄여 테스트 가속화가 필요하면 별도 모킹. 여기서는 개념만 검증.
+  });
+});
+
+describe('runCodexGate — metadata on error paths', () => {
+  it('captures sessionId and tokensTotal on nonzero exit', async () => {
+    const cp = await import('child_process');
+    (cp.spawn as any).mockImplementationOnce(() =>
+      makeMockChild({
+        stdout: `session id: partial-sid\ntokens used\n42\n`,
+        stderr: 'some error\n',
+        exitCode: 1,
+      })
+    );
+    const result = await runCodexGate(2, preset, 'prompt', '/tmp/h', '/tmp/c');
+    expect(result.type).toBe('error');
+    if (result.type === 'error') {
+      expect(result.codexSessionId).toBe('partial-sid');
+      expect(result.tokensTotal).toBe(42);
+    }
+  });
+});
+```
+
+- [ ] **Step 6: 테스트 실행 → 통과 확인**
+
+```bash
+pnpm -s vitest run tests/runners/codex-resume.test.ts
+```
+Expected: 주요 케이스 통과. Timeout 케이스는 별도 타임아웃 주입 필요 시 `vi.useFakeTimers()` 추가.
+
+- [ ] **Step 7: 기존 codex runner 테스트 회귀 확인**
+
+```bash
+pnpm -s vitest run tests/runners/
+```
+Expected: all green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/runners/codex.ts tests/runners/codex-resume.test.ts
+git commit -m "feat(runners/codex): add resume + session_missing fallback"
+```
+
+---
+
+## Task 5: phases/gate.ts — 경로 분기, sidecar replay compatibility gate
+
+**Files:**
+- Modify: `src/phases/gate.ts`
+- Create: `tests/phases/gate-resume.test.ts`
+
+- [ ] **Step 1: `checkGateSidecars`에 `sourcePreset` hydration 추가**
+
+`src/phases/gate.ts`의 `checkGateSidecars` 함수 내 metadata 블록에 한 줄 추가:
+
+```ts
+  const metadata = {
+    runner: gateResult.runner,
+    promptBytes: gateResult.promptBytes,
+    durationMs: gateResult.durationMs,
+    tokensTotal: gateResult.tokensTotal,
+    codexSessionId: gateResult.codexSessionId,
+    sourcePreset: gateResult.sourcePreset,  // NEW
+  };
+```
+
+- [ ] **Step 2: `runGatePhase`에서 sidecar replay compatibility gate 구현**
+
+`runGatePhase`의 Step 1 sidecar replay 블록을 교체:
+
+```ts
+  // Step 1: One-shot sidecar replay
+  if (allowSidecarReplay && allowSidecarReplay.value) {
+    allowSidecarReplay.value = false;
+    const replay = checkGateSidecars(runDir, phase);
+    if (replay !== null) {
+      const currentPreset = getPresetById(state.phasePresets[String(phase)]);
+
+      // (A) Replay-level compatibility gate
+      const replayCompatible = (
+        currentPreset !== undefined &&
+        replay.runner !== undefined &&
+        replay.runner === currentPreset.runner &&
+        (
+          replay.runner === 'claude'
+            ? true
+            : (replay.sourcePreset !== undefined &&
+               replay.sourcePreset.model === currentPreset.model &&
+               replay.sourcePreset.effort === currentPreset.effort)
+        )
+      );
+
+      if (replayCompatible) {
+        // (B) Hydration gate
+        const canHydrate =
+          replay.codexSessionId !== undefined &&
+          replay.runner === 'codex' &&
+          state.phaseCodexSessions[String(phase) as '2'|'4'|'7'] === null &&
+          currentPreset!.runner === 'codex' &&
+          replay.sourcePreset !== undefined &&
+          replay.sourcePreset.model === currentPreset!.model &&
+          replay.sourcePreset.effort === currentPreset!.effort;
+
+        if (canHydrate) {
+          const lastOutcome: 'approve' | 'reject' | 'error' =
+            replay.type === 'verdict'
+              ? (replay.verdict === 'APPROVE' ? 'approve' : 'reject')
+              : 'error';
+          state.phaseCodexSessions[String(phase) as '2'|'4'|'7'] = {
+            sessionId: replay.codexSessionId!,
+            runner: 'codex',
+            model: currentPreset!.model,
+            effort: currentPreset!.effort,
+            lastOutcome,
+          };
+          writeState(runDir, state);
+        }
+        return { ...replay, recoveredFromSidecar: true };
+      }
+      // replayCompatible === false → fall through to live execution path
+    }
+  }
+```
+
+상단 import에 `getPresetById` 추가(아직 없다면).
+
+- [ ] **Step 3: `runGatePhase` 경로 분기 구현 (resume vs fresh)**
+
+`runGatePhase`의 기존 Step 3-5(assemble prompt + dispatch)를 다음으로 교체:
+
+```ts
+  // Step 3: Resolve preset
+  const presetId = state.phasePresets[String(phase)];
+  const preset = getPresetById(presetId);
+  if (!preset) {
+    return { type: 'error', error: `Unknown preset for phase ${phase}: ${presetId}` };
+  }
+
+  // Step 4: Resume-compatibility check + prompt assembly
+  const savedSession = state.phaseCodexSessions[String(phase) as '2'|'4'|'7'];
+  const savedCompatible = (
+    savedSession !== null &&
+    typeof savedSession.sessionId === 'string' &&
+    savedSession.sessionId.trim().length > 0 &&
+    savedSession.runner === 'codex' &&
+    preset.runner === 'codex' &&
+    savedSession.model === preset.model &&
+    savedSession.effort === preset.effort
+  );
+  const useCodexResume = savedCompatible;
+
+  // Defense-in-depth: 비호환이면 저장된 세션 null 처리
+  if (savedSession !== null && !savedCompatible) {
+    state.phaseCodexSessions[String(phase) as '2'|'4'|'7'] = null;
+    writeState(runDir, state);
+  }
+
+  let prompt: string;
+  if (useCodexResume) {
+    const session = savedSession as GateSessionInfo;
+    let previousFeedback = '';
+    if (session.lastOutcome === 'reject') {
+      const feedbackPath = path.join(runDir, `gate-${phase}-feedback.md`);
+      previousFeedback = fs.existsSync(feedbackPath)
+        ? fs.readFileSync(feedbackPath, 'utf-8')
+        : '(feedback file missing despite lastOutcome=reject — spec anomaly)';
+    }
+    const resumeRes = assembleGateResumePrompt(phase, state, cwd, session.lastOutcome, previousFeedback);
+    if (typeof resumeRes !== 'string') return { type: 'error', error: resumeRes.error };
+    prompt = resumeRes;
+  } else {
+    const result = assembleGatePrompt(phase, state, harnessDir, cwd);
+    if (typeof result === 'object' && 'error' in result) {
+      return { type: 'error', error: result.error };
+    }
+    prompt = result as string;
+  }
+
+  const promptBytes = Buffer.byteLength(prompt, 'utf8');
+  const resumeId = useCodexResume ? (savedSession as GateSessionInfo).sessionId : null;
+
+  // Step 5: Dispatch
+  const runner = preset.runner;
+  const runStartedAt = Date.now();
+  const rawResult = runner === 'claude'
+    ? await runClaudeGate(phase, preset, prompt, harnessDir, cwd)
+    : await runCodexGate(
+        phase, preset, prompt, harnessDir, cwd, resumeId,
+        () => {
+          if (state.currentPhase !== phase) {
+            return { error: `phase ${phase} stale (currentPhase=${state.currentPhase})` };
+          }
+          return assembleGatePrompt(phase, state, harnessDir, cwd);
+        },
+      );
+  const durationMs = Date.now() - runStartedAt;
+
+  const result: GatePhaseResult = { ...rawResult, runner, promptBytes, durationMs };
+```
+
+`GateSessionInfo` import 추가 필요 (`src/types.ts`에서).
+
+- [ ] **Step 4: Step 6(세션 저장) 추가**
+
+Dispatch 이후, sidecar 쓰기 전에:
+
+```ts
+  // Step 6: Save session lineage if still on active phase
+  const stillActivePhase = state.currentPhase === phase;
+  if (preset.runner === 'codex' && stillActivePhase) {
+    if (result.resumeFallback) {
+      state.phaseCodexSessions[String(phase) as '2'|'4'|'7'] = null;
+    }
+    const newId = result.codexSessionId;
+    if (typeof newId === 'string' && newId.trim().length > 0) {
+      const lastOutcome: 'approve' | 'reject' | 'error' =
+        result.type === 'verdict'
+          ? (result.verdict === 'APPROVE' ? 'approve' : 'reject')
+          : 'error';
+      state.phaseCodexSessions[String(phase) as '2'|'4'|'7'] = {
+        sessionId: newId,
+        runner: 'codex',
+        model: preset.model,
+        effort: preset.effort,
+        lastOutcome,
+      };
+    }
+    writeState(runDir, state);
+  }
+```
+
+- [ ] **Step 5: Step 5(기존 sidecar 쓰기)를 sourcePreset 포함으로 갱신**
+
+기존 `const gateResult: GateResult = { ... }`에서 `sourcePreset` 필드 추가:
+
+```ts
+  const gateResult: GateResult = {
+    exitCode,
+    timestamp: Date.now(),
+    runner,
+    promptBytes,
+    durationMs,
+    ...(result.tokensTotal !== undefined ? { tokensTotal: result.tokensTotal } : {}),
+    ...(result.codexSessionId !== undefined ? { codexSessionId: result.codexSessionId } : {}),
+    ...(runner === 'codex'
+      ? { sourcePreset: { model: preset.model, effort: preset.effort } }
+      : {}),
+  };
+```
+
+- [ ] **Step 6: 실패하는 gate-resume 테스트 작성**
+
+`tests/phases/gate-resume.test.ts` 생성:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { runGatePhase } from '../../src/phases/gate.js';
+import type { HarnessState, GatePhaseResult } from '../../src/types.js';
+
+vi.mock('../../src/runners/codex.js');
+vi.mock('../../src/runners/claude.js');
+
+import { runCodexGate } from '../../src/runners/codex.js';
+
+function makeState(): HarnessState {
+  return {
+    runId: 'r1',
+    currentPhase: 2,
+    phasePresets: { '2': 'codex-high', '4': 'codex-high', '7': 'codex-high' },
+    phaseCodexSessions: { '2': null, '4': null, '7': null },
+    artifacts: { spec: '.harness/r1/spec.md', plan: '.harness/r1/plan.md', evalReport: '.harness/r1/eval.md', decisionLog: '.harness/r1/decisions.md', checklist: '.harness/r1/checklist.json' },
+    gateRetries: { '2': 0, '4': 0, '7': 0 },
+    /* ...minimally cast */
+  } as unknown as HarnessState;
+}
+
+let runDir: string;
+beforeEach(() => {
+  runDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-gate-'));
+  // fixture spec/plan/eval 파일 준비
+  const dir = path.join(runDir, '.harness/r1'); fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'spec.md'), '# Spec');
+  fs.writeFileSync(path.join(dir, 'plan.md'), '# Plan');
+  fs.writeFileSync(path.join(dir, 'eval.md'), '# Eval');
+});
+afterEach(() => { vi.clearAllMocks(); });
+
+function mockVerdict(overrides: Partial<GatePhaseResult> = {}): GatePhaseResult {
+  return {
+    type: 'verdict', verdict: 'REJECT', comments: 'P1', rawOutput: 'session id: sess-1\n## Verdict\nREJECT',
+    runner: 'codex', codexSessionId: 'sess-1',
+    sourcePreset: { model: 'gpt-5-codex', effort: 'high' },
+    resumedFrom: null, resumeFallback: false,
+    ...overrides,
+  } as GatePhaseResult;
+}
+
+describe('runGatePhase — first call (fresh)', () => {
+  it('calls runCodexGate without resumeSessionId and saves new session', async () => {
+    const state = makeState();
+    (runCodexGate as any).mockResolvedValueOnce(mockVerdict());
+    const res = await runGatePhase(2, state, runDir, runDir, runDir);
+    expect(res.type).toBe('verdict');
+    expect((runCodexGate as any).mock.calls[0][5]).toBeNull(); // resumeSessionId
+    expect(state.phaseCodexSessions['2']).toEqual({
+      sessionId: 'sess-1', runner: 'codex', model: 'gpt-5-codex', effort: 'high', lastOutcome: 'reject',
+    });
+  });
+});
+
+describe('runGatePhase — second call (resume)', () => {
+  it('passes stored sessionId on compatible preset', async () => {
+    const state = makeState();
+    state.phaseCodexSessions['2'] = {
+      sessionId: 'sess-1', runner: 'codex', model: 'gpt-5-codex', effort: 'high', lastOutcome: 'reject',
+    };
+    (runCodexGate as any).mockResolvedValueOnce(
+      mockVerdict({ verdict: 'APPROVE', resumedFrom: 'sess-1', codexSessionId: 'sess-1' })
+    );
+    await runGatePhase(2, state, runDir, runDir, runDir);
+    expect((runCodexGate as any).mock.calls[0][5]).toBe('sess-1');
+  });
+});
+
+describe('runGatePhase — incompatible session', () => {
+  it('nulls saved session and uses fresh path when model differs', async () => {
+    const state = makeState();
+    state.phaseCodexSessions['2'] = {
+      sessionId: 'sess-1', runner: 'codex', model: 'old-model', effort: 'high', lastOutcome: 'reject',
+    };
+    (runCodexGate as any).mockResolvedValueOnce(mockVerdict());
+    await runGatePhase(2, state, runDir, runDir, runDir);
+    expect((runCodexGate as any).mock.calls[0][5]).toBeNull();
+  });
+});
+
+describe('runGatePhase — resumeFallback clears stale id', () => {
+  it('clears stale id when fallback fires with no new id', async () => {
+    const state = makeState();
+    state.phaseCodexSessions['2'] = {
+      sessionId: 'stale', runner: 'codex', model: 'gpt-5-codex', effort: 'high', lastOutcome: 'reject',
+    };
+    (runCodexGate as any).mockResolvedValueOnce({
+      type: 'error', error: 'fallback failed', runner: 'codex',
+      resumedFrom: 'stale', resumeFallback: true, codexSessionId: undefined,
+    });
+    await runGatePhase(2, state, runDir, runDir, runDir);
+    expect(state.phaseCodexSessions['2']).toBeNull();
+  });
+});
+
+describe('runGatePhase — stillActivePhase guard', () => {
+  it('skips session persist if currentPhase changed during call', async () => {
+    const state = makeState();
+    (runCodexGate as any).mockImplementationOnce(async (...args: any[]) => {
+      state.currentPhase = 3; // simulate SIGUSR1 jump during call
+      return mockVerdict({ codexSessionId: 'should-not-save' });
+    });
+    await runGatePhase(2, state, runDir, runDir, runDir);
+    expect(state.phaseCodexSessions['2']).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 7: 테스트 실행 → 통과 확인**
+
+```bash
+pnpm -s vitest run tests/phases/gate-resume.test.ts
+```
+Expected: 5 passed.
+
+- [ ] **Step 8: 기존 gate 테스트 회귀 확인 (+ 필요시 시그니처 갱신)**
+
+```bash
+pnpm -s vitest run tests/phases/gate.test.ts
+```
+시그니처 충돌이 있으면 기존 테스트 업데이트 (예: `runCodexGate` 모킹이 새 시그니처 따르도록).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/phases/gate.ts tests/phases/gate-resume.test.ts tests/phases/gate.test.ts
+git commit -m "feat(gate): add resume path dispatch and sidecar compatibility gate"
+```
+
+---
+
+## Task 6: phases/runner.ts — verdict redirect guard + 로그 필드 전달
+
+**Files:**
+- Modify: `src/phases/runner.ts`
+- Modify: `tests/phases/runner.test.ts` (시그니처 반영 + 신규 테스트)
+
+- [ ] **Step 1: gate dispatch 함수에서 redirect guard를 verdict/error 공통으로 이동**
+
+`src/phases/runner.ts`의 gate dispatch 함수(예: `runGateDispatch` 또는 `runPhase2/4/7Dispatch`에서 `runGatePhase` 호출 직후)를 찾아 구조 변경:
+
+**변경 전 (개념)**:
+```ts
+const result = await runGatePhase(...);
+if (result.type === 'verdict') { ... }
+else {
+  if (state.currentPhase !== phase) { ...redirect... }
+  ...
+}
+```
+
+**변경 후**:
+```ts
+const result = await runGatePhase(...);
+if (state.currentPhase !== phase) {
+  printInfo(`Phase ${phase} interrupted by control signal → phase ${state.currentPhase}`);
+  renderControlPanel(state);
+  return;
+}
+if (result.type === 'verdict') { ... }
+else { /* error 처리 — redirect guard는 위로 이동 */ ... }
+```
+
+(실제 라인 번호는 현재 파일 구조에 따라 다름. `runGatePhase(` 호출 지점을 grep으로 찾아 주변 10줄을 수정.)
+
+- [ ] **Step 2: `gate_verdict`/`gate_error` 이벤트 payload에 `resumedFrom`/`resumeFallback` 전달**
+
+기존 `logger.logEvent({ event: 'gate_verdict', ... })` 호출 지점을 찾아 신규 필드 추가:
+
+```ts
+logger.logEvent({
+  event: 'gate_verdict',
+  phase,
+  retryIndex,
+  runner: result.runner!,
+  verdict: result.verdict,
+  durationMs: result.durationMs,
+  tokensTotal: result.tokensTotal,
+  promptBytes: result.promptBytes,
+  codexSessionId: result.codexSessionId,
+  recoveredFromSidecar: result.recoveredFromSidecar ?? false,
+  resumedFrom: result.resumedFrom,
+  resumeFallback: result.resumeFallback,
+});
+```
+
+`gate_error` 경로에도 동일 패턴 적용.
+
+- [ ] **Step 3: redirect guard 동작 확인 테스트 추가**
+
+`tests/phases/runner.test.ts`에서 gate dispatch에 해당하는 describe 블록에 테스트 추가:
+
+```ts
+it('does not apply verdict when state.currentPhase changed during gate run', async () => {
+  // mock runGatePhase to mutate state.currentPhase then return verdict
+  const state = makeState();
+  state.currentPhase = 2;
+  (runGatePhase as any).mockImplementationOnce(async () => {
+    state.currentPhase = 3; // external jump simulated
+    return {
+      type: 'verdict', verdict: 'APPROVE', comments: '', rawOutput: '', runner: 'codex',
+    };
+  });
+  await runGateDispatch(2, state, runDir, cwd, logger);
+  // phases['2']가 'completed'로 바뀌지 않아야
+  expect(state.phases['2']).not.toBe('completed');
+});
+```
+
+(테스트 파일 구조에 따라 import/setup 조정.)
+
+- [ ] **Step 4: 테스트 실행 + 기존 runner 테스트 회귀 확인**
+
+```bash
+pnpm -s vitest run tests/phases/runner.test.ts
+```
+Expected: 새 테스트 포함 all passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/phases/runner.ts tests/phases/runner.test.ts
+git commit -m "feat(runner): extend gate redirect guard to verdict path and emit resume metadata"
+```
+
+---
+
+## Task 7: State mutation sites — inner.ts + signal.ts
+
+**Files:**
+- Modify: `src/commands/inner.ts`
+- Modify: `src/signal.ts`
+- Modify: `tests/commands/inner.test.ts` (필요 시)
+- Modify: `tests/signal.test.ts` (필요 시)
+
+- [ ] **Step 1: `src/commands/inner.ts`의 `promptModelConfig` 직후 invalidate 호출 추가**
+
+`promptModelConfig(...)` 호출 직후 (기존 `state.phasePresets = ...` 줄):
+
+```ts
+// 변경 전 스냅샷
+const prevPresets = { ...state.phasePresets };
+state.phasePresets = await promptModelConfig(state.phasePresets, inputManager);
+invalidatePhaseSessionsOnPresetChange(state, prevPresets, runDir);
+writeState(runDir, state);
+```
+
+상단 import에 `invalidatePhaseSessionsOnPresetChange` 추가.
+
+- [ ] **Step 2: `consumePendingAction`의 jump 적용 분기에 invalidate 호출 추가**
+
+`consumePendingAction` 함수 내에서 pending action이 `type: 'jump'` (또는 실제 사용되는 jump type)인 분기를 찾아, phase 리셋 로직 뒤에:
+
+```ts
+invalidatePhaseSessionsOnJump(state, targetPhase, runDir);
+```
+
+상단 import에 `invalidatePhaseSessionsOnJump` 추가.
+
+(실제 jump action shape는 기존 `src/commands/inner.ts`에 정의된 `PendingAction` 유니온 참고.)
+
+- [ ] **Step 3: `src/signal.ts` SIGUSR1 jump 핸들러에 invalidate 호출 추가**
+
+SIGUSR1 핸들러가 phase 리셋하는 지점을 찾아:
+
+```ts
+invalidatePhaseSessionsOnJump(state, targetPhase, runDir);
+```
+
+상단 import에 `invalidatePhaseSessionsOnJump` 추가.
+
+- [ ] **Step 4: 기존 테스트 회귀 확인 + 필요 시 inner/signal 테스트 보강**
+
+```bash
+pnpm -s vitest run tests/commands/inner.test.ts tests/signal.test.ts
+```
+시그니처 깨짐이나 새 기대값 추가. 최소 추가:
+
+```ts
+it('consumePendingAction invalidates sessions for jump to earlier phase', async () => {
+  const state = makeState();
+  state.phaseCodexSessions['4'] = { sessionId: 'sess-4', runner: 'codex', model: 'gpt-5-codex', effort: 'high', lastOutcome: 'reject' };
+  state.phaseCodexSessions['7'] = { sessionId: 'sess-7', runner: 'codex', model: 'gpt-5-codex', effort: 'high', lastOutcome: 'reject' };
+  state.pendingAction = { type: 'jump', targetPhase: 3 } as any; // 실제 shape 맞추기
+  await consumePendingAction(state, runDir, /* ... */);
+  expect(state.phaseCodexSessions['2']).not.toBeNull();
+  expect(state.phaseCodexSessions['4']).toBeNull();
+  expect(state.phaseCodexSessions['7']).toBeNull();
+});
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/inner.ts src/signal.ts tests/commands/inner.test.ts tests/signal.test.ts
+git commit -m "feat(state-sites): wire up phaseCodexSessions invalidation on preset change and jumps"
+```
+
+---
+
+## Task 8: 통합 테스트
+
+**Files:**
+- Create: `tests/integration/codex-session-resume.test.ts`
+
+- [ ] **Step 1: 통합 테스트 작성**
+
+`tests/integration/codex-session-resume.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { runGatePhase } from '../../src/phases/gate.js';
+import { invalidatePhaseSessionsOnPresetChange, invalidatePhaseSessionsOnJump } from '../../src/state.js';
+import type { HarnessState, GatePhaseResult } from '../../src/types.js';
+
+vi.mock('../../src/runners/codex.js');
+import { runCodexGate } from '../../src/runners/codex.js';
+
+function makeState(): HarnessState { /* ...same helper as gate-resume.test.ts... */ return ({} as any); }
+
+let runDir: string;
+beforeEach(() => { runDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-int-')); });
+afterEach(() => { vi.clearAllMocks(); });
+
+describe('End-to-end: reject loop uses resume', () => {
+  it('first call fresh, second call resumes same session', async () => {
+    const state = makeState();
+    (runCodexGate as any)
+      .mockResolvedValueOnce({
+        type: 'verdict', verdict: 'REJECT', comments: 'P1', rawOutput: 'session id: s1',
+        runner: 'codex', codexSessionId: 's1',
+        sourcePreset: { model: 'gpt-5-codex', effort: 'high' },
+        resumedFrom: null, resumeFallback: false,
+      } as GatePhaseResult)
+      .mockResolvedValueOnce({
+        type: 'verdict', verdict: 'APPROVE', comments: '', rawOutput: '',
+        runner: 'codex', codexSessionId: 's1',
+        sourcePreset: { model: 'gpt-5-codex', effort: 'high' },
+        resumedFrom: 's1', resumeFallback: false,
+      } as GatePhaseResult);
+
+    await runGatePhase(2, state, runDir, runDir, runDir);
+    expect((runCodexGate as any).mock.calls[0][5]).toBeNull();
+    expect(state.phaseCodexSessions['2']?.sessionId).toBe('s1');
+
+    await runGatePhase(2, state, runDir, runDir, runDir);
+    expect((runCodexGate as any).mock.calls[1][5]).toBe('s1');
+  });
+});
+
+describe('End-to-end: session_missing triggers fallback and new session id saved', () => {
+  it('fallback response updates state with new session id', async () => {
+    const state = makeState();
+    state.phaseCodexSessions['2'] = {
+      sessionId: 'dead', runner: 'codex', model: 'gpt-5-codex', effort: 'high', lastOutcome: 'reject',
+    };
+    (runCodexGate as any).mockResolvedValueOnce({
+      type: 'verdict', verdict: 'APPROVE', comments: '', rawOutput: '',
+      runner: 'codex', codexSessionId: 'new-sess',
+      sourcePreset: { model: 'gpt-5-codex', effort: 'high' },
+      resumedFrom: 'dead', resumeFallback: true,
+    } as GatePhaseResult);
+    await runGatePhase(2, state, runDir, runDir, runDir);
+    expect(state.phaseCodexSessions['2']?.sessionId).toBe('new-sess');
+  });
+});
+
+describe('End-to-end: preset change invalidates session + sidecars', () => {
+  it('subsequent gate call uses fresh path after preset change', async () => {
+    const state = makeState();
+    state.phaseCodexSessions['2'] = {
+      sessionId: 's1', runner: 'codex', model: 'gpt-5-codex', effort: 'high', lastOutcome: 'reject',
+    };
+    // create fake sidecars + feedback
+    fs.writeFileSync(path.join(runDir, 'gate-2-raw.txt'), 'x');
+    fs.writeFileSync(path.join(runDir, 'gate-2-result.json'), '{}');
+    fs.writeFileSync(path.join(runDir, 'gate-2-feedback.md'), 'prior');
+
+    const prev = { '2': 'codex-high', '4': 'codex-high', '7': 'codex-high' };
+    state.phasePresets['2'] = 'codex-medium';
+    invalidatePhaseSessionsOnPresetChange(state, prev, runDir);
+
+    expect(state.phaseCodexSessions['2']).toBeNull();
+    expect(fs.existsSync(path.join(runDir, 'gate-2-raw.txt'))).toBe(false);
+    expect(fs.existsSync(path.join(runDir, 'gate-2-feedback.md'))).toBe(true); // preserved
+
+    (runCodexGate as any).mockResolvedValueOnce({
+      type: 'verdict', verdict: 'APPROVE', comments: '', rawOutput: '',
+      runner: 'codex', codexSessionId: 'new',
+      sourcePreset: { model: 'gpt-5-codex', effort: 'medium' },
+      resumedFrom: null, resumeFallback: false,
+    } as GatePhaseResult);
+    await runGatePhase(2, state, runDir, runDir, runDir);
+    expect((runCodexGate as any).mock.calls[0][5]).toBeNull(); // fresh
+  });
+});
+
+describe('End-to-end: jump invalidates downstream sessions', () => {
+  it('jump to phase 3 invalidates gate 4 and 7 sessions', async () => {
+    const state = makeState();
+    state.phaseCodexSessions['4'] = { sessionId: 's4', runner: 'codex', model: 'gpt-5-codex', effort: 'high', lastOutcome: 'reject' };
+    state.phaseCodexSessions['7'] = { sessionId: 's7', runner: 'codex', model: 'gpt-5-codex', effort: 'high', lastOutcome: 'reject' };
+    invalidatePhaseSessionsOnJump(state, 3, runDir);
+    expect(state.phaseCodexSessions['4']).toBeNull();
+    expect(state.phaseCodexSessions['7']).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: 전체 테스트 스위트 실행**
+
+```bash
+pnpm -s vitest run
+```
+Expected: all green (unit + integration).
+
+- [ ] **Step 3: TypeScript 빌드 최종 확인**
+
+```bash
+pnpm -s tsc --noEmit
+```
+Expected: 에러 없음.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/codex-session-resume.test.ts
+git commit -m "test(integration): end-to-end codex session resume scenarios"
+```
+
+---
+
+## Task 9: 린트 + 최종 검증
+
+- [ ] **Step 1: 린트 통과 확인**
+
+```bash
+pnpm -s lint
+```
+Expected: 에러 없음.
+
+- [ ] **Step 2: 전체 스위트 한 번 더**
+
+```bash
+pnpm -s test
+```
+
+- [ ] **Step 3: 실행 흐름 sanity-check (수동)**
+
+다음 명령으로 로컬 smoke test:
+```bash
+pnpm -s build && node ./bin/harness.js --help
+```
+출력에 기존 플래그가 그대로 살아있는지 확인.
+
+- [ ] **Step 4: Commit (필요 시 마이너 수정만)**
+
+```bash
+# 필요 시에만
+git add -u && git commit -m "chore: lint fixes for codex session resume"
+```
+
+---
+
+## Eval Checklist
+
+각 항목은 실행 가능한 커맨드와 pass 조건을 갖는다. `harness-verify.sh`가 이 체크리스트를 소비한다.
+
+### Objective criteria (기계 검증)
+
+- [ ] **EC-1**: `pnpm -s tsc --noEmit` exit 0
+  - Pass: stdout 비어있음 + exit 0
+- [ ] **EC-2**: `pnpm -s vitest run tests/state-invalidation.test.ts` all passed
+  - Pass: summary `Tests  6 passed (6)` 이상
+- [ ] **EC-3**: `pnpm -s vitest run tests/context/assembler-resume.test.ts` all passed
+  - Pass: summary에 fail 0
+- [ ] **EC-4**: `pnpm -s vitest run tests/runners/codex-resume.test.ts` all passed
+  - Pass: summary에 fail 0
+- [ ] **EC-5**: `pnpm -s vitest run tests/phases/gate-resume.test.ts` all passed
+  - Pass: summary에 fail 0
+- [ ] **EC-6**: `pnpm -s vitest run tests/integration/codex-session-resume.test.ts` all passed
+  - Pass: summary에 fail 0
+- [ ] **EC-7**: `pnpm -s vitest run` (전체) — 기존 회귀 없음
+  - Pass: total tests 이전 수 이상 + fail 0
+- [ ] **EC-8**: `pnpm -s lint` exit 0
+  - Pass: stdout에 error 0
+- [ ] **EC-9**: Spec 링크 검증 — plan 상단 "관련 문서" spec 경로 존재
+  - Check: `test -f docs/specs/2026-04-18-codex-session-resume-design.md`
+- [ ] **EC-10**: State migration 호환성 — legacy state.json이 깨지지 않음
+  - Command: `pnpm -s vitest run tests/state.test.ts -t "migrateState"` all passed
+- [ ] **EC-11**: `grep -r "phaseCodexSessions" src/ | wc -l`가 4 이상
+  - Pass: 최소 types.ts, state.ts, phases/gate.ts, 합해서 4+ occurrences (실제 정착 확인)
+- [ ] **EC-12**: `grep -r "invalidatePhaseSessions" src/ | wc -l`가 4 이상
+  - Pass: state.ts (정의 2) + inner.ts (2 호출) + signal.ts (1 호출) = 5+
+- [ ] **EC-13**: resume-sensitive 코드 경로 존재 확인
+  - Check: `grep -l "resume" src/runners/codex.ts`와 `grep -l "buildFreshPromptOnFallback" src/phases/gate.ts` 각각 hit
+
+### Spec traceability (spec 요구사항 → 구현 태스크 매핑)
+
+| Spec section | 요구사항 요약 | 구현 태스크 | 검증 EC |
+|--------------|--------------|-------------|---------|
+| §4.1 State 스키마 | `GateSessionInfo`, `phaseCodexSessions` | Task 1, 2 | EC-1, EC-10, EC-11 |
+| §4.2 Runner 시그니처 | `resumeSessionId`, `buildFreshPromptOnFallback` | Task 4 | EC-4, EC-13 |
+| §4.3 Resume 프롬프트 Variant A/B | `assembleGateResumePrompt` | Task 3 | EC-3 |
+| §4.4 Control flow | resume dispatch, stillActivePhase | Task 5 | EC-5, EC-6 |
+| §4.5 Fallback | session_missing 감지 + closure | Task 4, 5 | EC-4, EC-6 |
+| §4.6 Logging | resumedFrom/resumeFallback 필드 | Task 1, 6 | EC-1, EC-7 |
+| §4.7 Sidecar replay compat gate | replay-level + hydration-level | Task 5 | EC-5 |
+| §4.8 Preset 변경 invalidation | helper + mutation sites | Task 2, 7 | EC-2, EC-12 |
+| §4.9 Jump invalidation | helper + SIGUSR1 + consumePendingAction | Task 2, 7 | EC-2, EC-12 |
+| §4.10 Verdict redirect guard | runner.ts 공통 guard | Task 6 | EC-7 |
+| §9 Open questions | pilot 결과 spec 기록 | Task 0 | EC-9 |
+
+### Subjective criteria (리뷰어 판단)
+
+- [ ] **SC-1**: 코드 품질 — 새 모듈들이 기존 스타일(mod 구조, 에러 반환 패턴, 로깅 방식)을 따르는가
+- [ ] **SC-2**: 스펙 §4의 세부 규칙이 구현 주석이나 변수명에 녹아들었는가 (예: `savedCompatible`, `replayCompatible` 명명)
+- [ ] **SC-3**: 장기 관찰 metric — `--enable-logging`으로 실제 run 한 번 수행 후 `events.jsonl`에 `resumedFrom` 값이 정상 기록되는가 (수동 검증, optional)
+
+### 성능 샘플 (선택적, 수치 기록만)
+
+Spec §1의 "시간/토큰 절감" 목표를 실측 자료로 남기기 위한 optional 단계. pass/fail 기준 아니라 기록 목적.
+
+- [ ] **PS-1**: 가짜 reject 루프(reject 3회 → approve) 시나리오에서 `--enable-logging` 활성화 run 수행. events.jsonl에서 phase 2 `gate_verdict` 이벤트들의 `durationMs`, `tokensTotal`을 추출해 평균/총합 기록
+- [ ] **PS-2**: 동일 시나리오를 resume 비활성화(환경변수 또는 임시 패치) 버전으로도 측정해 비교. 차이를 eval report에 숫자로 기록
+
+---
+
+## Notes for Implementer
+
+- TDD 원칙: 각 Task의 Step 순서(test → fail → impl → pass → commit)를 지켜.
+- `src/runners/codex.ts`의 기존 `runCodexInteractive`는 건드리지 않아. 본 작업은 gate 경로 한정.
+- Task 4의 mocked spawn 패턴은 기존 `tests/runners/codex.test.ts`가 이미 쓰고 있다면 거기의 helper를 import해 중복 줄여.
+- Task 5 테스트의 `makeState()` helper는 기존 테스트 파일에 유사한 것이 있으면 `tests/helpers/` 하위로 뽑아 공유 권장(YAGNI 범위 밖이면 복붙 허용).
+- Session ID 정규식(`isResumeSessionMissingError`)은 Task 0 pilot 결과가 가장 중요. 실제 stderr 문자열을 확인한 뒤 Task 4 Step 2의 정규식을 그에 맞춰 **좁게** 갱신.
+- 각 커밋은 `git status` 확인 후 이루어져야. 공백 변경이나 IDE 자동 포맷 제외.

--- a/docs/plans/2026-04-18-dogfood-ux-quickwins.md
+++ b/docs/plans/2026-04-18-dogfood-ux-quickwins.md
@@ -1,0 +1,353 @@
+# Dog-Fooding UX Quick-Wins — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**관련 문서:**
+- Spec: `docs/specs/2026-04-18-dogfood-ux-quickwins-design.md`
+- Eval checklist: 본 문서 §Eval Checklist
+- Eval report (작성 예정): `docs/process/evals/2026-04-18-dogfood-ux-quickwins-eval.md`
+
+**Goal:** Dog-fooding QA에서 식별된 UX 이슈 3건(pane 비율, 거짓 sentinel contract, 슬러그 길이)을 한 번에 묶어 수정한다.
+
+**Architecture:** 세 이슈 모두 표면 텍스트/상수 변경. 공유 상태 없음, 코드 면 분리 → 독립 작업 3개를 순차 commit. resume 작업 코드 면(`src/runners/codex.ts`, `src/phases/verdict.ts`)은 건드리지 않아 `codex-optimization` 브랜치와 충돌 없음.
+
+**Tech Stack:** TypeScript (Node.js), vitest, tmux split-window CLI.
+
+---
+
+## File Structure
+
+### 수정 파일
+- `src/commands/inner.ts` — `splitPane(..., 'h', 70)` → `60` 한 곳
+- `src/context/prompts/phase-1.md` — CRITICAL 라인 교체
+- `src/context/prompts/phase-3.md` — CRITICAL 라인 교체
+- `src/context/prompts/phase-5.md` — CRITICAL 라인 교체
+- `src/git.ts` — `generateRunId`의 max 50 → 25 (주석 2곳 + 코드 1곳)
+- `tests/git.test.ts` — `truncates slug to 50 chars` → 25 기대값 갱신
+
+### 신규 파일
+없음.
+
+---
+
+## Task 1: 컨트롤 pane 비율 60:40으로 변경 (#6)
+
+**Files:**
+- Modify: `src/commands/inner.ts:56`
+
+`tests/commands/inner.test.ts`의 `splitPane` mock은 percent 인자를 assert하지 않으므로 테스트 업데이트 불필요. 회귀만 확인.
+
+- [ ] **Step 1: `splitPane` percent 상수 변경**
+
+`src/commands/inner.ts:56` 한 줄:
+
+변경 전:
+```ts
+    const workspacePaneId = splitPane(state.tmuxSession, controlPaneId, 'h', 70);
+```
+
+변경 후:
+```ts
+    const workspacePaneId = splitPane(state.tmuxSession, controlPaneId, 'h', 60);
+```
+
+- [ ] **Step 2: 기존 테스트 회귀 확인**
+
+```bash
+pnpm -s vitest run tests/commands/inner.test.ts
+```
+Expected: 기존 테스트 전부 통과 (splitPane mock은 인자에 불관여).
+
+- [ ] **Step 3: TypeScript 빌드 확인**
+
+```bash
+pnpm -s tsc --noEmit
+```
+Expected: 에러 없음.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/inner.ts
+git commit -m "fix(ui): widen control pane to 40% (splitPane 70 -> 60)"
+```
+
+---
+
+## Task 2: Phase 프롬프트 sentinel 거짓 contract 정정 (#8)
+
+**Files:**
+- Modify: `src/context/prompts/phase-1.md:10`
+- Modify: `src/context/prompts/phase-3.md:21`
+- Modify: `src/context/prompts/phase-5.md:14`
+
+CRITICAL 라인은 세 파일에서 구조가 동일하며 `phase-N.done`의 N만 다르다. 각 파일에서 같은 규칙으로 교체.
+
+- [ ] **Step 1: `phase-1.md` CRITICAL 라인 교체**
+
+`src/context/prompts/phase-1.md:10`
+
+변경 전:
+```
+**CRITICAL: sentinel 파일(phase-1.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 즉시 이 세션이 자동 종료된다. sentinel 이후에는 어떤 작업도 실행되지 않는다.**
+```
+
+변경 후:
+```
+**CRITICAL: sentinel 파일(phase-1.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 이후 하네스는 다음 단계(리뷰/피드백)로 넘어가므로 추가 작업을 하지 말 것.**
+```
+
+- [ ] **Step 2: `phase-3.md` CRITICAL 라인 교체**
+
+`src/context/prompts/phase-3.md:21`
+
+변경 전:
+```
+**CRITICAL: sentinel 파일(phase-3.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 즉시 이 세션이 자동 종료된다. sentinel 이후에는 어떤 작업도 실행되지 않는다.**
+```
+
+변경 후:
+```
+**CRITICAL: sentinel 파일(phase-3.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 이후 하네스는 다음 단계(리뷰/피드백)로 넘어가므로 추가 작업을 하지 말 것.**
+```
+
+- [ ] **Step 3: `phase-5.md` CRITICAL 라인 교체**
+
+`src/context/prompts/phase-5.md:14`
+
+변경 전:
+```
+**CRITICAL: sentinel 파일(phase-5.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 즉시 이 세션이 자동 종료된다. sentinel 이후에는 어떤 작업도 실행되지 않는다.**
+```
+
+변경 후:
+```
+**CRITICAL: sentinel 파일(phase-5.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 이후 하네스는 다음 단계(리뷰/피드백)로 넘어가므로 추가 작업을 하지 말 것.**
+```
+
+- [ ] **Step 4: 거짓 문구가 전부 사라졌는지 grep 확인**
+
+```bash
+grep -rn "자동 종료" src/context/prompts/ || echo "No matches — clean."
+grep -rn "sentinel 이후에는 어떤 작업도" src/context/prompts/ || echo "No matches — clean."
+```
+Expected: 두 grep 모두 "No matches — clean." 출력.
+
+- [ ] **Step 5: 프롬프트 관련 테스트 회귀 확인**
+
+```bash
+pnpm -s vitest run tests/context/ tests/phases/interactive.test.ts
+```
+Expected: 전부 통과. (기존 테스트는 프롬프트 텍스트를 assert하지 않음.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/context/prompts/phase-1.md src/context/prompts/phase-3.md src/context/prompts/phase-5.md
+git commit -m "fix(prompts): remove false sentinel auto-termination claim"
+```
+
+---
+
+## Task 3: Run ID 슬러그 cap 50 → 25 (#12)
+
+**Files:**
+- Modify: `src/git.ts:87-123` (주석 2곳 + 코드 1곳)
+- Modify: `tests/git.test.ts:182-190` (기대값 갱신)
+
+TDD 순서: 기존 테스트를 25로 갱신 → 실패 확인 → 구현 변경 → 통과 확인.
+
+- [ ] **Step 1: `tests/git.test.ts`의 cap 기대값 50 → 25로 갱신 (실패하는 상태로 둠)**
+
+`tests/git.test.ts:182-190` 교체. describe 테스트 이름도 동기화.
+
+변경 전:
+```ts
+  it('truncates slug to 50 chars at word boundary', () => {
+    // Create a task that produces a slug longer than 50 chars
+    const task = 'implement the full authentication and authorization system for users';
+    const id = generateRunId(task, harnessDir);
+    const slug = id.slice('YYYY-MM-DD-'.length);
+    expect(slug.length).toBeLessThanOrEqual(50);
+    // Should not end with a partial word (no trailing -)
+    expect(slug).not.toMatch(/-$/);
+  });
+```
+
+변경 후:
+```ts
+  it('truncates slug to 25 chars at word boundary', () => {
+    // Create a task that produces a slug longer than 25 chars
+    const task = 'implement the full authentication and authorization system for users';
+    const id = generateRunId(task, harnessDir);
+    const slug = id.slice('YYYY-MM-DD-'.length);
+    expect(slug.length).toBeLessThanOrEqual(25);
+    // Should not end with a partial word (no trailing -)
+    expect(slug).not.toMatch(/-$/);
+  });
+```
+
+- [ ] **Step 2: 테스트 실행 → 실패 확인 (현 코드는 50 cap)**
+
+```bash
+pnpm -s vitest run tests/git.test.ts -t "truncates slug"
+```
+Expected: FAIL. 현재 코드가 50-char cap이므로 "implement-the-full-authentication-and-authorization-system-for-users"를 50자로 자름 → 25자 기대와 불일치.
+
+- [ ] **Step 3: `src/git.ts`의 cap 상수 50 → 25로 변경**
+
+`src/git.ts:87-94` 주석 블록에서:
+
+변경 전:
+```ts
+// Generate a runId from task description.
+// Rules:
+// 1. Lowercase
+// 2. Unicode NFD normalize, remove non-ASCII
+// 3. Replace non-alphanumeric with -
+// 4. Collapse consecutive -
+// 5. Trim leading/trailing -
+// 6. Max 50 chars (cut at word boundary = last -)
+// 7. Empty → "untitled"
+// Format: YYYY-MM-DD-<slug>[-N] (N if directory exists)
+```
+
+변경 후 (6번 줄만):
+```ts
+// 6. Max 25 chars (cut at word boundary = last -)
+```
+
+`src/git.ts:118-123` 코드 블록에서:
+
+변경 전:
+```ts
+  // 6. Max 50 chars, cut at word boundary (last -)
+  if (slug.length > 50) {
+    const truncated = slug.slice(0, 50);
+    const lastDash = truncated.lastIndexOf('-');
+    slug = lastDash > 0 ? truncated.slice(0, lastDash) : truncated;
+  }
+```
+
+변경 후:
+```ts
+  // 6. Max 25 chars, cut at word boundary (last -)
+  if (slug.length > 25) {
+    const truncated = slug.slice(0, 25);
+    const lastDash = truncated.lastIndexOf('-');
+    slug = lastDash > 0 ? truncated.slice(0, lastDash) : truncated;
+  }
+```
+
+- [ ] **Step 4: 테스트 실행 → 통과 확인**
+
+```bash
+pnpm -s vitest run tests/git.test.ts
+```
+Expected: `generateRunId` 스위트 전부 통과 (5/5).
+
+- [ ] **Step 5: TypeScript 빌드 확인**
+
+```bash
+pnpm -s tsc --noEmit
+```
+Expected: 에러 없음.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/git.ts tests/git.test.ts
+git commit -m "fix(git): tighten runId slug cap to 25 chars for shorter paths"
+```
+
+---
+
+## Task 4: 최종 전체 검증
+
+- [ ] **Step 1: 전체 테스트 스위트 실행**
+
+```bash
+pnpm -s vitest run
+```
+Expected: 전체 green, fail 0. 이전 수 이상의 테스트.
+
+- [ ] **Step 2: 린트 통과 확인**
+
+```bash
+pnpm -s lint
+```
+Expected: 에러 0.
+
+- [ ] **Step 3: TypeScript 최종 확인**
+
+```bash
+pnpm -s tsc --noEmit
+```
+Expected: 에러 0.
+
+- [ ] **Step 4: 커밋 히스토리 확인**
+
+```bash
+git log --oneline -5
+```
+Expected: 최근 3 커밋이 Task 1/2/3 순서로 남아있음 (+ 이전 spec/plan doc 커밋 위).
+
+---
+
+## Eval Checklist
+
+### Objective criteria (기계 검증)
+
+- [ ] **EC-1**: `pnpm -s tsc --noEmit` exit 0
+  - Pass: stdout 비어있음 + exit 0
+- [ ] **EC-2**: `pnpm -s lint` exit 0
+  - Pass: error 0
+- [ ] **EC-3**: `pnpm -s vitest run` 전체 통과
+  - Pass: fail 0
+- [ ] **EC-4**: `pnpm -s vitest run tests/git.test.ts -t "truncates slug"` 통과
+  - Pass: 1 passed
+- [ ] **EC-5**: pane 비율 변경이 코드에 반영됨
+  - Command: `grep -n "'h', 60" src/commands/inner.ts`
+  - Pass: 정확히 1건 hit
+- [ ] **EC-6**: pane 비율 구 값이 완전 제거됨
+  - Command: `grep -n "'h', 70" src/commands/inner.ts || echo "clean"`
+  - Pass: "clean" 출력 또는 0 hits
+- [ ] **EC-7**: sentinel 거짓 문구 전원 제거
+  - Command: `grep -rn "자동 종료" src/context/prompts/ || echo "clean"`
+  - Pass: "clean" 출력 또는 0 hits
+- [ ] **EC-8**: sentinel 대체 문구 세 파일 모두 적용
+  - Command: `grep -l "다음 단계(리뷰/피드백)로 넘어가므로" src/context/prompts/phase-1.md src/context/prompts/phase-3.md src/context/prompts/phase-5.md | wc -l`
+  - Pass: 3
+- [ ] **EC-9**: slug cap 25 상수 반영
+  - Command: `grep -n "slug.length > 25" src/git.ts`
+  - Pass: 1 hit
+- [ ] **EC-10**: slug cap 50 구 값 제거
+  - Command: `grep -n "slug.length > 50" src/git.ts || echo "clean"`
+  - Pass: "clean" 또는 0 hits
+- [ ] **EC-11**: Spec 링크 유효
+  - Command: `test -f docs/specs/2026-04-18-dogfood-ux-quickwins-design.md`
+  - Pass: exit 0
+
+### Spec traceability
+
+| Spec section | 요구사항 | 구현 태스크 | 검증 EC |
+|--------------|----------|-------------|---------|
+| §2/§4.1 #6 pane ratio | splitPane 70→60 | Task 1 | EC-5, EC-6 |
+| §2/§4.2 #8 sentinel contract | 세 phase 프롬프트 교체 | Task 2 | EC-7, EC-8 |
+| §2/§4.3 #12 slug cap | 50→25 + 테스트 갱신 | Task 3 | EC-4, EC-9, EC-10 |
+| §5 테스트 전략 | 회귀 green | Task 4 | EC-1, EC-2, EC-3 |
+
+### Subjective criteria
+
+- [ ] **SC-1**: 세 변경이 서로 간섭 없이 독립적으로 적용됨 (파일 면 분리)
+- [ ] **SC-2**: 커밋 3개가 각 이슈 단위로 분리되어 블레임 추적 용이
+- [ ] **SC-3**: 수동 smoke (optional): `harness start "long task name here that exceeds twenty five chars"` 실행 시 runId가 `2026-04-18-long-task-name-here` 수준으로 축약되는지 확인
+
+---
+
+## Notes for Implementer
+
+- Task 1/2는 TDD가 필요 없음(표면 변경). Task 3만 TDD 순서(test 먼저 갱신 → fail 확인 → 구현).
+- 커밋은 이슈 단위로 분리. 메시지는 `fix(<scope>): <imperative>` 형식.
+- Task 2의 세 phase 프롬프트는 교체 규칙 단일 — 텍스트를 복붙하지 말고 각 파일 열어 CRITICAL 라인만 정확히 교체.
+- `pnpm -s vitest run` 결과가 이전 커밋 대비 테스트 수/fail 변화 없는지 확인. resume 작업 merge 전까지 이 브랜치는 main + 3 spec/plan 커밋 + 3 fix 커밋만 존재.

--- a/docs/specs/2026-04-18-codex-session-resume-design.md
+++ b/docs/specs/2026-04-18-codex-session-resume-design.md
@@ -1,0 +1,900 @@
+# Per-Phase Codex Session Resume — Design Spec
+
+- 상태: draft
+- 작성일: 2026-04-18
+- 담당: Claude Code (engineer), Codex (reviewer)
+- 관련 문서:
+  - Impl plan: `docs/plans/2026-04-18-codex-session-resume.md` (작성 예정)
+  - Eval report: `docs/process/evals/2026-04-18-codex-session-resume-eval.md` (작성 예정)
+  - 배경: `docs/HOW-IT-WORKS.md`, `docs/specs/2026-04-18-session-logging-design.md`
+
+## 1. 배경과 목표
+
+harness-cli의 gate phase(2/4/7)는 Codex를 독립 리뷰어로 호출한다. 현재 `src/runners/codex.ts`의 `runCodexGate`는 매 호출마다 `spawn(codexBin, ['exec', ...])`로 cold start하며, 세션 재사용 로직이 없다. 결과:
+
+- Gate reject 루프에서 같은 아티팩트(spec/plan/diff)를 매 retry마다 처음부터 재전송 → 매번 reviewer contract를 다시 읽고, 아티팩트를 파싱하고, Phase 7의 경우 관련 파일을 재탐색한다.
+- 사용자가 관찰한 사례: 같은 gate가 N회 reject될 때 N번의 완전 cold 시행이 발생한다.
+- 특히 Phase 7은 프롬프트에 `<spec> + <plan> + <eval_report> + <diff>`가 모두 포함되고, Codex가 그 위에서 파일 탐색 도구를 사용한다. 재호출마다 같은 탐색이 반복된다.
+
+**목표**: Codex CLI의 네이티브 `codex exec resume <SESSION_ID> [PROMPT]` 기능을 활용해, 동일 gate phase의 reject 루프 내에서는 세션을 재사용하여 redundant work를 제거한다. **리뷰 품질은 유지하면서** 시간/토큰 소모만 줄이는 것이 핵심.
+
+**비목표**:
+- 전체 harness run에 걸친 global Codex 세션 공유. (각 phase는 독립된 성격의 리뷰이므로 phase 간에는 격리.)
+- Claude runner에 대한 세션 재사용. (Claude gate는 `--print` 일회성 호출로, 동등한 resume 메커니즘이 없음.)
+- 파일 레벨 prompt caching 또는 토큰 최적화의 다른 축. 본 작업은 오직 "같은 세션 재사용"에만 집중.
+
+## 2. Context & Decisions
+
+### 핵심 결정사항
+
+- **Session scope = phase 단위**: `phaseCodexSessions: Record<'2'|'4'|'7', GateSessionInfo | null>`을 `HarnessState`에 추가 (canonical shape — §4.1 참고. `GateSessionInfo`는 `{ sessionId, runner, model, effort, lastOutcome }` 구조). 각 phase의 첫 Codex 호출에서 lineage 전체를 저장하고, 이후 같은 phase의 retry에서는 resume한다. 다른 phase로 넘어가면 fresh 세션.
+- **Codex runner 전용**: phasePresets에서 runner가 'codex'인 gate에만 적용. 'claude' runner는 기존 동작 유지.
+- **Resume 프롬프트 전략 C (사용자 승인)**: resume 호출의 프롬프트 = `updated artifacts + previous feedback`. REVIEWER_CONTRACT는 세션에 이미 있으므로 재전송하지 않는다. 아티팩트는 매 retry마다 Claude Code가 수정할 수 있으므로 full 재전송(stale 방지). 세션 이득은 Codex의 prior reasoning chain + Phase 7 파일 탐색 캐시.
+- **적용 범위 = Gate 2/4/7 전체**: Phase 2/4도 세션 재사용 이득이 있음(prior reasoning, output format 확립). Phase 7이 파일 탐색 이득이 가장 크지만 2/4를 제외할 이유 없음.
+- **Resume 실패 시 제한된 자동 fallback**: `codex exec resume`이 **"session not found/missing/expired" 카테고리**로 실패한 경우에만 자동 fresh spawn으로 재시도한다. Timeout, Ctrl-C, 일반 리뷰 실패(모델 내부 에러 등), prompt 크기 초과 등 "리뷰 자체 문제"는 fallback하지 않고 error 그대로 반환한다 (사용자가 재시도 판단). Error taxonomy는 §4.5에서 정의. fallback 이벤트는 로깅에 기록.
+- **모델/effort 재지정 허용**: resume 호출도 `--model`, `-c model_reasoning_effort=` 플래그를 현 호출과 동일하게 넘긴다. 이는 `codex exec resume --help`로 지원 확인됨.
+- **Lifecycle invalidation**: preset 변경(§4.8)과 backward jump(§4.9) 두 경로에서 (1) `phaseCodexSessions[phase] = null`로 세션 무효화 + (2) **replay 사이드카**(`gate-${phase}-{raw,result,error}`) 삭제. **Feedback 파일(`gate-${phase}-feedback.md`)은 삭제하지 않는다** — 기존 reopen/escalation 경로가 이 파일을 참조하기 때문. Replay sidecar를 삭제하는 이유: `harness resume` 시 `runGatePhase`의 one-shot sidecar replay가 stale verdict를 반환해 invalidation 의도를 우회하는 것을 방지. Session 무효화만으로도 다음 **live** gate 호출이 fresh 경로를 타지만, replay 경로는 session 체크보다 먼저 발동하므로 sidecar 자체를 제거해야 안전. Sidecar replay hydration은 sidecar에 기록된 `sourcePreset`과 현재 preset이 일치할 때만 수행(§4.7)한다. `runGatePhase`의 lineage 호환성 재확인(§4.4)은 **preset mismatch 방어만** 커버 — jump/artifact 변화에 대한 방어는 invalidation 훅의 정확성에 의존하며 테스트로 보증한다.
+
+### 제약 조건
+
+- **세션 영속성**: Codex는 `~/.codex/sessions/` 하위에 year 기반 디렉토리 구조로 세션을 디스크 저장한다. 프로세스 재시작/크래시 후에도 resume 가능. 단, Codex 자체의 cleanup 정책(만료, 삭제)은 harness가 제어할 수 없다 → 반드시 fallback 필요.
+- **Phase 간 격리**: Gate 2 세션에 spec만 있고 plan/code는 없다. Gate 4로 넘어갈 때 그 세션을 재사용하면 plan을 새로 로드해야 하고, Codex가 "이전 리뷰의 관점"을 이어가서 편향을 일으킬 수 있다 → phase마다 fresh 세션이 정답.
+- **REVIEWER_CONTRACT 중복 방지**: 첫 호출(fresh)에만 전문 포함. resume 호출에는 "return verdict in the same format you used before" 같은 간결한 지시만.
+- **아티팩트 업데이트 전달 필수**: Gate reject 후 Claude Code가 spec/plan/code를 수정하므로, resume 프롬프트에 **반드시** 업데이트된 아티팩트를 다시 포함시킨다. 세션의 과거 메시지는 stale 상태임을 명시.
+- **`codex exec resume` CLI 계약**:
+  - 인자: `[SESSION_ID] [PROMPT]`. `-`를 prompt 자리에 쓰면 stdin에서 읽음.
+  - 지원 플래그: `-m/--model`, `-c key=value`, `-c model_reasoning_effort=...`, `--json`, `-o`, `--last`, `--skip-git-repo-check`, `--ephemeral`, `--full-auto`, `--dangerously-bypass-approvals-and-sandbox`.
+  - 미지원: 명시적 `--sandbox` 플래그. 단 현 `runCodexGate`는 `--sandbox`를 애초에 붙이지 않으므로 무관(gate는 read-only 디폴트로 충분).
+
+### 해소된 모호성
+
+- **세션 재사용이 정확성에 해를 끼치지 않는가?** → 아티팩트를 매 retry마다 업데이트된 full 버전으로 재전송하기 때문에, Codex는 항상 현재 상태를 본다. 세션 히스토리는 "내가 이전에 이 점을 지적했다 → 이번에 반영됐는지 확인" 같은 맥락만 제공. 품질 유지.
+- **크래시 후 harness resume과의 상호작용은?** → **Graceful 종료 경로만** sessionId 영속성 보장. `state.phaseCodexSessions[phase]`는 `runGatePhase`가 `runCodexGate` 반환 후 writeState를 호출한 시점에만 persist된다. In-flight 크래시(Codex가 sessionId를 stdout에 찍은 직후 + runGatePhase가 state 업데이트 전에 프로세스가 죽는 경우)에서는 id가 유실될 수 있다 → 이 경우 다음 gate 호출은 fresh spawn (품질/정확성 영향 없음, 단지 최적화 이득을 못 봄). Graceful 경로(success, timeout, error-with-stdout-parsed)는 모두 id를 보존. 이는 spec에서 의도된 tradeoff로, 추가 write-through 복잡도를 도입하지 않는다.
+- **Sidecar replay(`checkGateSidecars`)와 충돌 여부** → §4.7에서 두 단계 gate 추가: (A) Replay-level compatibility gate — sidecar의 runner/sourcePreset이 현재 preset과 호환되어야 replay 수용; legacy sidecar(metadata 없음)는 skip. (B) State hydration gate — (A)를 통과한 replay만 state에 세션 id를 주입. 또한 §4.8/§4.9 invalidation 훅이 replay sidecar를 물리적으로 삭제해 jump/preset 변경 후 replay가 아예 발생하지 않도록 한다. Replay 이후 같은 phase에서 다시 reject → retry가 발생하면 정상 resume 또는 fresh 경로를 탄다.
+- **Gate 통과 후 세션 id는?** → 유지. 현 run에서 그 phase는 더 이상 호출되지 않지만, 디버깅/감사 목적으로 state에 남겨둠. 메모리 비용 없음(문자열 하나).
+- **첫 호출이 error로 끝난 경우(timeout 등) 세션 id를 저장할 것인가?** → 저장 (단, 모든 종료 경로가 accumulated stdout을 파싱해야 함 — §4.4 구현 요구사항 참고). Codex가 sessionId를 stdout에 찍었다면 세션은 시작된 것. 다음 재시도에서 resume 시도 → 실패 시 §4.5의 error taxonomy에 따라 fallback 또는 error 반환.
+- **Preset이 run 중 변경되면 기존 세션은 어떻게 되는가?** → 변경 감지 시 무효화. `src/commands/inner.ts`와 `src/ui.ts`는 사용자가 mid-run에 phase preset을 바꿀 수 있게 허용한다 (re-prompt model config, individual preset replacement). 변경 케이스별 규칙:
+  - Codex → Claude: `phaseCodexSessions[phase] = null` (해당 phase는 이후 Claude runner 사용, Codex session 의미 없음)
+  - Codex(modelA/effortA) → Codex(modelB/effortB): 같은 phase에서 모델/effort가 바뀌면 `phaseCodexSessions[phase] = null`. 이유: 이전 세션은 다른 설정으로 열렸고, resume 시 설정 미스매치 거동을 보장할 수 없음. 새 fresh spawn으로 시작.
+  - Claude → Codex: 영향 없음(기존 `phaseCodexSessions[phase]`가 이미 null일 것).
+  - 무효화 시점: preset 변경 커밋 경로에서 직접 수행 (§4.8 참고).
+
+### 구현 시 주의사항
+
+- `runCodexGate` 시그니처에 `resumeSessionId?: string | null` 파라미터 추가. null/undefined면 fresh spawn, 값이 있으면 `codex exec resume <id> -` 경로.
+- 프롬프트 조립은 `assembler.ts`에 새 함수 추가: `assembleGateResumePrompt(phase, state, cwd, lastOutcome, previousFeedback)`. 기존 `assembleGatePrompt`는 fresh 경로 그대로 유지. 변형 선택은 `lastOutcome`으로 결정 (§4.3 참고).
+- `previousFeedback` 소스: `lastOutcome === 'reject'`일 때만 `gate-${phase}-feedback.md`를 읽어 전달. `lastOutcome === 'error'`이면 feedback 파일이 stale일 수 있으므로 빈 문자열을 전달 (변형 B).
+- state migration: `migrateState`에 `phaseCodexSessions` 기본값 삽입 (`{ "2": null, "4": null, "7": null }`). 기존 state.json과 호환.
+- `runGatePhase` 내부에서 resume 경로 선택 로직은 §4.4 참고. 요약하면: 저장된 세션의 lineage(runner/model/effort)가 현재 preset과 호환될 때만 resume 경로, 아니면 fresh. 호출 후에는 현재 phase가 여전히 active한지 확인한 뒤 `GateSessionInfo` 객체 전체(sessionId/runner/model/effort/lastOutcome)를 저장.
+- resume 실패 감지: `runCodexGate` 내부에서 수행. 모든 종료 경로(close/timeout/error)가 accumulated stdout과 stderr를 보존하고 metadata + error classification을 추출한 다음 resolve해야 함. 현재 `buildGateResult`는 stderr를 버리므로, resume 경로용 내부 헬퍼는 `buildGateResult` 호출 **전에** stderr를 검사해 "session missing" 분류를 내야 한다 (§4.5 구현 상세).
+- session id 보존: 현재 `runCodexGate`의 timeout/error 브랜치는 accumulated stdoutChunks를 파싱하지 않고 바로 resolve한다. 본 작업에서 이 브랜치들도 `Buffer.concat(stdoutChunks).toString()` → `extractCodexMetadata` 호출 → `codexSessionId`/`tokensTotal`을 `GateError`에 포함시키도록 수정한다. `GateError` 타입은 이미 이 필드들을 optional로 가지고 있음(변경 없음).
+- 로깅 확장: `gate_verdict`/`gate_error` 이벤트에 `resumedFrom?: string | null`, `resumeFallback?: boolean` 필드 추가. 기존 `codexSessionId`와의 관계:
+  - `resumedFrom = null` + `codexSessionId = <uuid>` → fresh spawn
+  - `resumedFrom = <prev_id>` + `codexSessionId = <prev_id>` → 성공적 resume
+  - `resumedFrom = <prev_id>` + `resumeFallback = true` + `codexSessionId = <new_uuid>` → resume 실패 → fresh fallback
+- sidecar(`gate-${phase}-result.json`)에는 `codexSessionId`만 기록(기존 동작 유지). `resumedFrom` 등은 이벤트 로그에만.
+- `runClaudeGate` 경로는 변경 없음. preset.runner !== 'codex'일 때는 `phaseCodexSessions` 읽기/쓰기도 스킵.
+
+## 3. 현 구조 분석
+
+### 관련 파일과 역할
+
+※ 파일 역할/변경 요약표. `src/commands/inner.ts`는 preset 변경 invalidation과 jump invalidation 두 목적 모두 건드림.
+
+| 파일 | 현 역할 | 본 작업에서의 변경 |
+|------|---------|--------------------|
+| `src/runners/codex.ts` | `runCodexGate`가 `codex exec`로 cold spawn | resume 파라미터 수용, 모든 종료 경로에서 metadata 추출, error taxonomy 분류, session_missing 시 fresh fallback |
+| `src/phases/gate.ts` | `runGatePhase`가 프롬프트 조립 + 러너 디스패치 + sidecar 관리 | codex runner일 때 resume id 주입, 반환된 id로 state 업데이트, sidecar replay 시 state hydration |
+| `src/context/assembler.ts` | `assembleGatePrompt` (fresh only) | `assembleGateResumePrompt` 추가 |
+| `src/types.ts` | `HarnessState`, `GateOutcome`, `GateError` | `phaseCodexSessions` 필드, `resumedFrom`/`resumeFallback` 로그 필드 |
+| `src/state.ts` | `migrateState`, `createInitialState` | `phaseCodexSessions` 기본값 추가 (`GateSessionInfo` lineage 포함), sessionId validation, `invalidatePhaseSessionsOnPresetChange`/`invalidatePhaseSessionsOnJump` helper (session만 null; feedback 파일은 유지) |
+| `src/commands/inner.ts` | **State mutation 소유자**: `promptModelConfig` 후 `state.phasePresets` 갱신 + `consumePendingAction`에서 offline jump action 적용(실제 state 변경) | **authoritative invalidation 지점**. (1) preset 교체 전 snapshot 저장, 교체 후 `invalidatePhaseSessionsOnPresetChange(state, prevPresets, runDir)`. (2) `consumePendingAction`의 jump 적용 분기에서 `invalidatePhaseSessionsOnJump(state, targetPhase, runDir)` |
+| `src/ui.ts` | UI 레이어 — 사용자 입력으로 preset map을 **반환만** (state mutation 없음) | **변경 없음**. Invalidation 호출은 호출자(inner.ts)에서 state를 쓸 때 수행 |
+| `src/commands/jump.ts` | CLI 엔트리 — `pending-action.json`만 씀, state.json 건드리지 않음 | **변경 없음**. 실제 state mutation은 `harness resume` 경로에서 `consumePendingAction`이 수행 (inner.ts 행 참고) |
+| `src/signal.ts` | SIGUSR1 handler — state mutation 소유자 중 하나 (currentPhase 등) | **authoritative invalidation 지점**. SIGUSR1 jump handler에서 phase 리셋과 함께 `invalidatePhaseSessionsOnJump(state, targetPhase, runDir)` 호출 |
+| `src/phases/runner.ts` | `handleGateReject`가 피드백 저장 + reopen, gate dispatch handler의 redirect guard는 error 경로에만 존재 | (1) redirect guard를 verdict 경로까지 포괄하도록 이동 (§4.10). (2) gate_verdict/gate_error emit 시 `resumedFrom`/`resumeFallback` 전달 |
+| `src/phases/verdict.ts` | `extractCodexMetadata`로 stdout에서 sessionId 추출, `buildGateResult` | 변경 없음. 단, runner 내부에서 stderr 기반 분류 후 `buildGateResult` 호출 |
+| `src/logger.ts` (session-logging) | `logEvent` | `resumedFrom`/`resumeFallback` 필드 수용 |
+
+### 현 호출 경로 (reject 루프 기준, 변경 전)
+
+```
+runGatePhase(phase, state)
+  ↓ assembleGatePrompt(phase, state, cwd)    ← 전체 아티팩트 포함 프롬프트
+  ↓ runCodexGate(phase, preset, prompt, ...)  ← cold spawn
+  ↓ [REJECT] handleGateReject → saveGateFeedback → reopen interactive phase
+  ↓ Claude가 아티팩트 수정
+  ↓ runGatePhase(phase, state) 재호출       ← 또 cold spawn, 같은 작업 반복
+```
+
+### 새 호출 경로 (reject 루프 기준, 변경 후)
+
+```
+runGatePhase(phase, state)
+  ↓ if (runner === 'codex' AND savedCompatible session in state.phaseCodexSessions[phase]):
+  ↓   prompt = assembleGateResumePrompt(..., lastOutcome, feedback)  ← Variant A/B by lastOutcome
+  ↓   runCodexGate(..., resumeSessionId=<id>, buildFreshPromptOnFallback=closure)
+  ↓ else:
+  ↓   if savedSession exists but incompatible → null it out (defense-in-depth)
+  ↓   prompt = assembleGatePrompt(...)                               ← 기존 full 프롬프트
+  ↓   runCodexGate(..., resumeSessionId=null)                        ← cold spawn
+  ↓ [stillActivePhase check → GateSessionInfo { sessionId, runner, model, effort, lastOutcome }
+  ↓   를 state.phaseCodexSessions[phase]에 저장]
+  ↓ [REJECT] 동일 (handleGateReject → saveGateFeedback → reopen)
+  ↓ 다음 runGatePhase 호출 → resume 경로 활성
+```
+
+## 4. 설계 상세
+
+### 4.1 State 스키마
+
+세션 ID만 저장하는 대신, **lineage 정보**(runner, model, effort)를 함께 저장한다. 이렇게 하면 `runGatePhase`가 resume 경로 진입 전에 현재 preset과 저장된 lineage의 호환성을 체크할 수 있어, invalidation 훅이 놓친 경우에도 잘못된 resume을 차단할 수 있다 (defense-in-depth). Lineage 불일치 감지 시 저장된 id를 null로 간주하고 fresh로 진행.
+
+```ts
+// src/types.ts
+export interface GateSessionInfo {
+  sessionId: string;                       // non-empty
+  runner: 'claude' | 'codex';              // reserved — 현재는 'codex'만 저장됨
+  model: string;                           // 해당 세션이 열릴 때의 preset.model
+  effort: string;                          // 해당 세션이 열릴 때의 preset.effort
+  lastOutcome: 'approve' | 'reject' | 'error';
+                                           //   - 'approve': APPROVE verdict. 정상 흐름에선 state.phases[phase]='completed'로
+                                           //     바뀌고 runPhaseLoop가 건너뛰므로 재호출되지 않음. 단 state 저장 후
+                                           //     phase status 저장 전 crash 등 edge case를 위해 정확히 기록.
+                                           //     만약 이 값으로 resume 경로에 진입하게 되면 Variant B 사용(stale 우려 없음).
+                                           //   - 'reject': REJECT verdict (gate-N-feedback.md 존재 보증)
+                                           //   - 'error': error 반환 (feedback 파일 없을 수 있음)
+}
+
+export interface HarnessState {
+  // 기존 필드들...
+  phaseCodexSessions: Record<'2' | '4' | '7', GateSessionInfo | null>;
+}
+```
+
+`createInitialState`:
+```ts
+phaseCodexSessions: { '2': null, '4': null, '7': null }
+```
+
+`migrateState`:
+```ts
+if (!raw.phaseCodexSessions || typeof raw.phaseCodexSessions !== 'object') {
+  raw.phaseCodexSessions = { '2': null, '4': null, '7': null };
+}
+for (const k of ['2', '4', '7']) {
+  const v = raw.phaseCodexSessions[k];
+  // Validate: must be null or a proper GateSessionInfo with non-empty sessionId
+  if (v === undefined || v === null) {
+    raw.phaseCodexSessions[k] = null;
+    continue;
+  }
+  if (
+    typeof v !== 'object' ||
+    typeof v.sessionId !== 'string' ||
+    v.sessionId.trim().length === 0 ||
+    typeof v.runner !== 'string' ||
+    typeof v.model !== 'string' ||
+    typeof v.effort !== 'string' ||
+    (v.lastOutcome !== 'approve' && v.lastOutcome !== 'reject' && v.lastOutcome !== 'error')
+  ) {
+    raw.phaseCodexSessions[k] = null;  // malformed → discard
+  }
+}
+```
+
+**ID 유효성 규칙** (모든 사용 지점에 적용): `sessionId`는 `typeof === 'string' && sessionId.trim().length > 0`일 때만 유효. 이 조건을 만족하지 않으면 저장/resume/hydration 대상이 아니다. 이 검증은 resume 시점과 sidecar hydration 시점 모두에서 수행.
+
+### 4.2 Runner 시그니처 변경
+
+```ts
+// src/runners/codex.ts
+export async function runCodexGate(
+  phase: number,
+  preset: ModelPreset,
+  prompt: string,
+  harnessDir: string,
+  cwd: string,
+  resumeSessionId?: string | null,
+  // Closure for lazy fresh-prompt build (only called on session_missing fallback).
+  // Returns the prompt string or { error } on size/IO failure.
+  buildFreshPromptOnFallback?: () => string | { error: string },
+): Promise<GatePhaseResult> { ... }
+```
+
+Closure 기반이기 때문에 (1) 사전에 fresh 프롬프트를 조립/검증하지 않아 resume 경로의 지연을 추가하지 않고, (2) fallback이 실제 필요할 때만 `assembleGatePrompt`의 크기 검증이 수행되어, 정상 resume이 "speculative fallback 프롬프트가 너무 크다"는 이유로 차단되지 않는다.
+
+내부 분기:
+```ts
+const args = resumeSessionId
+  ? ['exec', 'resume', resumeSessionId,
+     '--model', preset.model,
+     '-c', `model_reasoning_effort="${preset.effort}"`,
+     '-']
+  : ['exec',
+     '--model', preset.model,
+     '-c', `model_reasoning_effort="${preset.effort}"`,
+     '-'];
+
+const child = spawn(codexBin, args, { stdio: ['pipe', 'pipe', 'pipe'], detached: true, cwd });
+```
+
+### 4.3 Resume 프롬프트 (Strategy C)
+
+새 함수 `assembleGateResumePrompt(phase, state, cwd, lastOutcome, previousFeedback)`:
+
+**변형 A — Retry after reject (기본)**: `lastOutcome === 'reject'` (이전 호출이 REJECT verdict를 반환해 `gate-${phase}-feedback.md`가 저장된 상태, `previousFeedback`에 해당 내용 전달됨).
+
+```
+## Updated Artifacts (Re-Review Requested)
+
+The artifacts have been updated based on your previous feedback. Re-review the new versions and verify your prior concerns were addressed.
+
+<spec>
+{최신 spec 내용}
+</spec>
+
+[Phase 4/7에 plan 포함]
+<plan>
+{최신 plan 내용}
+</plan>
+
+[Phase 7에 eval_report, diff, metadata 포함]
+<eval_report>
+{최신 eval_report 내용}
+</eval_report>
+
+<diff>
+{최신 git diff}
+</diff>
+
+<metadata>
+{기존 Phase 7 메타데이터 블록}
+</metadata>
+
+## Your Previous Feedback (for reference)
+
+{gate-${phase}-feedback.md 전체 내용}
+
+## Instructions
+
+Return a verdict in the same structured format you used before (## Verdict / ## Comments / ## Summary). APPROVE only if zero P0/P1 findings, and especially verify whether your prior P0/P1 concerns have been addressed.
+```
+
+**변형 B — Retry after error (no fresh feedback)**: `lastOutcome === 'error'` (이전 호출이 error로 끝남). 예: 첫 호출 타임아웃 또는 nonzero_exit_other로 실패 → sessionId는 저장됐지만 **현재 retry 관점에서는 새로운 feedback이 없음**. 이전 reject의 feedback 파일이 디스크에 남아있을 수 있으나, 그것은 이 세션의 직전 turn에 해당하지 않으므로 무시하고 변형 B 사용.
+
+```
+## Continue Review
+
+The previous review turn did not complete. Here are the artifacts to review (unchanged from the prior turn, unless modifications occurred in the interim):
+
+<spec>...</spec>
+(and plan/eval_report/diff/metadata per phase, as in 변형 A)
+
+## Instructions
+
+Return a verdict in the same structured format you used before (## Verdict / ## Comments / ## Summary).
+```
+
+**구별 규칙**: `GateSessionInfo.lastOutcome`으로 판단한다.
+- `lastOutcome === 'reject'` → 직전 호출이 REJECT verdict였고 `gate-${phase}-feedback.md`가 보증됨 → 변형 A 선택, feedback 파일 내용을 프롬프트에 삽입
+- `lastOutcome === 'error'` → 직전 호출이 error였음 → 변형 B 선택 (feedback 파일이 있더라도 그것은 더 이전 retry의 stale feedback이므로 무시)
+- `lastOutcome === 'approve'` → 정상 흐름에선 도달하지 않음. 안전 fallback으로 변형 B 선택 (stale 주장 없이 단순 재요청).
+
+`assembleGateResumePrompt`는 `lastOutcome` 파라미터를 추가로 받아 분기한다. `retryIndex`는 프롬프트에 포함하지 않는다 (현재 `state.gateRetries`는 REJECT count만 세므로 error 시퀀스에서 의미가 모호해짐, §4.3 Variant B 참고):
+```ts
+export function assembleGateResumePrompt(
+  phase: 2 | 4 | 7,
+  state: HarnessState,
+  cwd: string,
+  lastOutcome: 'approve' | 'reject' | 'error',
+  previousFeedback: string,   // lastOutcome !== 'reject'면 빈 문자열
+): string | { error: string } { ... }
+```
+
+`runGatePhase`는 `savedSession.lastOutcome`과 (lastOutcome==='reject'일 때만) `gate-${phase}-feedback.md`를 읽어 assembler에 전달.
+
+REVIEWER_CONTRACT 전문은 **포함하지 않는다** (두 변형 모두). 세션의 첫 turn에 이미 있음.
+
+### 4.4 Control Flow in `runGatePhase`
+
+```ts
+// src/phases/gate.ts
+export async function runGatePhase(phase, state, harnessDir, runDir, cwd, allowSidecarReplay?) {
+  // 1. sidecar replay (기존)
+  // 2. sidecar cleanup (기존)
+
+  // 3. Resolve preset
+  const preset = getPresetById(state.phasePresets[String(phase)]);
+
+  // 4. 프롬프트 조립 분기
+  const savedSession = state.phaseCodexSessions[String(phase) as '2'|'4'|'7'];
+  const savedCompatible = (
+    savedSession !== null &&
+    typeof savedSession.sessionId === 'string' &&
+    savedSession.sessionId.trim().length > 0 &&
+    savedSession.runner === 'codex' &&
+    preset.runner === 'codex' &&
+    savedSession.model === preset.model &&
+    savedSession.effort === preset.effort
+  );
+  const useCodexResume = savedCompatible;
+  // 비호환 감지 시 저장된 id는 신뢰하지 않음 (invalidation 훅 miss에 대한 방어)
+  if (savedSession !== null && !savedCompatible) {
+    state.phaseCodexSessions[String(phase) as '2'|'4'|'7'] = null;
+    writeState(runDir, state);
+  }
+
+  let prompt: string;
+  if (useCodexResume) {
+    const session = savedSession as GateSessionInfo;
+    let previousFeedback = '';
+    if (session.lastOutcome === 'reject') {
+      const feedbackPath = path.join(runDir, `gate-${phase}-feedback.md`);
+      previousFeedback = fs.existsSync(feedbackPath)
+        ? fs.readFileSync(feedbackPath, 'utf-8')
+        : '(feedback file missing despite lastOutcome=reject — spec anomaly)';
+    }
+    // Variant A/B 선택은 lastOutcome으로만 결정 (feedback 파일 존재 여부가 아님).
+    // lastOutcome === 'approve'는 정상 흐름에서 도달하지 않는 edge case이나, safety-fallback으로 Variant B 처리.
+    const resumeRes = assembleGateResumePrompt(
+      phase, state, cwd, session.lastOutcome, previousFeedback
+    );
+    if (typeof resumeRes !== 'string') return { type: 'error', error: resumeRes.error };
+    prompt = resumeRes;
+    // fallback fresh prompt는 closure로 전달(§4.5 lazy). Eager assembly 불필요.
+  } else {
+    const result = assembleGatePrompt(phase, state, harnessDir, cwd);
+    if (typeof result !== 'string') return { type: 'error', error: result.error };
+    prompt = result;
+  }
+
+  // 5. Dispatch
+  const resumeId = useCodexResume ? (savedSession as GateSessionInfo).sessionId : null;
+  // fallbackFreshPrompt는 caller가 미리 조립하지 않고 **closure**로 전달 (§4.5 lazy fallback).
+  const rawResult = preset.runner === 'codex'
+    ? await runCodexGate(
+        phase, preset, prompt, harnessDir, cwd, resumeId,
+        /* buildFreshPromptOnFallback */ () => assembleGatePrompt(phase, state, harnessDir, cwd),
+      )
+    : await runClaudeGate(phase, preset, prompt, harnessDir, cwd);
+
+  // 6. **Redirect guard (verdict application 포함)**: gate 실행 중 SIGUSR1 jump(§4.9)으로
+  //    `state.currentPhase !== phase`가 된 경우, 반환된 verdict/error 모두 stale이다.
+  //    이 경우:
+  //      - sessionId를 state에 저장하지 않음 (invalidation을 덮어쓰지 않도록)
+  //      - 호출한 phase handler(runner.ts의 gate handler)가 verdict 반영/reopen을 일으키지 않도록
+  //        `runGatePhase` 자체가 이 상태를 호출자에게 전달해야 함
+  //    구현 선택: `runGatePhase`가 redirect 감지 시 특수 sentinel 결과 반환.
+  //    ```
+  //    if (state.currentPhase !== phase) {
+  //      return { type: 'error', error: `phase ${phase} redirected to ${state.currentPhase} mid-run`,
+  //               exitCode: undefined };
+  //      // caller(gate handler in runner.ts)는 이 error를 보고 verdict 반영 스킵.
+  //      // 기존 코드에 이미 "error 경로에서 state.currentPhase !== phase면 redirect"
+  //      // 처리가 runner.ts:415에 있으므로 같은 패턴 활용.
+  //    }
+  //    ```
+  //    (verdict 반영 스킵은 runner.ts에 이미 있는 redirect guard가 커버한다 — 관련 수정은 §4.10.)
+  //
+  //    단, resumeFallback=true면 원래의 stale lineage는 무조건 지운 뒤 새 id를 저장한다.
+  //    이유: fresh fallback이 실패해 새 id를 못 얻은 경우에도 stale lineage를 남기면 안 됨
+  //    (다음 retry가 또 dead session을 resume 시도 → 같은 session_missing 에러 반복).
+  const stillActivePhase = state.currentPhase === phase;
+  if (preset.runner === 'codex' && stillActivePhase) {
+    if (rawResult.resumeFallback) {
+      state.phaseCodexSessions[String(phase) as '2'|'4'|'7'] = null;
+    }
+    const newId = rawResult.codexSessionId;
+    if (typeof newId === 'string' && newId.trim().length > 0) {
+      // lastOutcome 결정: verdict 타입이면 APPROVE/REJECT 구분, error면 'error'.
+      const lastOutcome: 'approve' | 'reject' | 'error' =
+        rawResult.type === 'verdict'
+          ? (rawResult.verdict === 'APPROVE' ? 'approve' : 'reject')
+          : 'error';
+      state.phaseCodexSessions[String(phase) as '2'|'4'|'7'] = {
+        sessionId: newId,
+        runner: 'codex',
+        model: preset.model,
+        effort: preset.effort,
+        lastOutcome,
+      };
+    }
+    writeState(runDir, state);
+  }
+
+  // 7. sidecar 기록, metadata 부착 (기존)
+  ...
+}
+```
+
+### 4.5 Resume 실패 시 Fallback
+
+**Error taxonomy** (authoritative — §2와 아래 로직 모두 이 분류를 따름):
+
+| 카테고리 | 감지 방법 | 조치 |
+|----------|-----------|------|
+| `session_missing` | stderr에 "session not found", "no such session", "unknown session id" 등 Codex가 세션을 찾지 못했음을 시사하는 패턴 | 자동 fresh fallback (sessionId 초기화 + fresh prompt로 재실행) |
+| `timeout` | `runCodexGate` 내부 setTimeout이 트리거 | fallback 안 함. `GateError` 반환 |
+| `nonzero_exit_other` | non-zero exit이지만 session_missing 패턴 아님 (모델 에러, prompt 파싱 실패 등) | fallback 안 함. `GateError` 반환 |
+| `spawn_error` | child.on('error') (CLI 자체 실행 실패) | fallback 안 함. `GateError` 반환 |
+| `success_verdict` | exit 0 + stdout에 `## Verdict` 섹션 존재 | 정상 반환 |
+| `success_no_verdict` | exit 0 + `## Verdict` 섹션 미발견 | fallback 안 함. `GateError` 반환 (리뷰 품질 문제) |
+
+`session_missing` 정확한 패턴은 구현 시 실험으로 확정(§9 Open Question #1). 안전한 기본은 "매우 좁게" 잡는 것: 확실한 session-missing 패턴만 fallback, 애매하면 error 반환. 오탐으로 fallback하면 비용 낭비, 누락하면 사용자 경험 약간 나빠지지만 안전.
+
+**내부 구조** (의사 코드):
+
+```ts
+async function runCodexGate(phase, preset, prompt, harnessDir, cwd, resumeSessionId) {
+  if (!resumeSessionId) {
+    // Fresh 경로
+    return await runCodexExecRaw({ mode: 'fresh', prompt, preset, ... });
+  }
+
+  // Resume 경로
+  const rawResume = await runCodexExecRaw({ mode: 'resume', sessionId: resumeSessionId, prompt, preset, ... });
+
+  // rawResume은 stdout/stderr/exitCode/timedOut 등의 원시 정보를 포함
+  // (GatePhaseResult로 collapse 전에 분류)
+
+  if (rawResume.category === 'session_missing') {
+    // Lazy fresh-prompt build via closure. assembleGatePrompt runs its own size check.
+    // Caller(runGatePhase)는 closure 안에서 stillActivePhase 체크를 수행해 SIGUSR1 jump로 인해
+    // 현 gate가 이미 stale해진 경우 fallback 실행을 중단한다 (§4.5 closure 계약).
+    if (!buildFreshPromptOnFallback) {
+      return { type: 'error', error: 'session_missing but no fallback prompt builder provided',
+               resumedFrom: resumeSessionId };
+    }
+    const freshPromptOrError = buildFreshPromptOnFallback();
+    if (typeof freshPromptOrError !== 'string') {
+      // Fresh prompt can't be assembled. 발생 원인:
+      //   1) 크기 초과 (MAX_PROMPT_SIZE_KB) → `assembleGatePrompt`가 error 반환
+      //   2) 현 phase가 jump로 stale → closure가 `{ error: 'phase stale' }` 반환 (§4.5 계약)
+      //
+      // **현재 assembler 계약 유지**: 개별 아티팩트 read 실패(파일 부재/IO)는 error가 아니라
+      // placeholder(`(file not found: <path>)`)로 주입된다 (`assembler.ts:75` 기존 동작).
+      // 본 작업은 이 계약을 바꾸지 않으며, 위 목록의 1번/2번만 error 원인이다.
+      //
+      // 어느 경우든 stale 세션 복구 불가 → error 반환 (fallback flag은 켠다).
+      return { type: 'error', error: freshPromptOrError.error,
+               resumedFrom: resumeSessionId, resumeFallback: true };
+    }
+    const rawFresh = await runCodexExecRaw({ mode: 'fresh', prompt: freshPromptOrError, preset, ... });
+    const fresh = buildGateResultFromRaw(rawFresh);
+    return { ...fresh, resumeFallback: true, resumedFrom: resumeSessionId };
+  }
+
+  // session_missing 아니면 그대로 반환 (fallback 없음)
+  return { ...buildGateResultFromRaw(rawResume), resumedFrom: resumeSessionId };
+}
+```
+
+**타입**:
+```ts
+interface RawExecResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  spawnError?: string;
+  category: 'session_missing' | 'timeout' | 'nonzero_exit_other'
+          | 'spawn_error' | 'success_verdict' | 'success_no_verdict';
+  codexSessionId?: string;   // extractCodexMetadata로 stdout에서 파싱
+  tokensTotal?: number;
+}
+```
+
+이 내부 타입은 `src/runners/codex.ts` 안에서만 쓰고 외부에 노출하지 않는다. 외부 API(`runCodexGate`)의 반환 타입은 기존 `GatePhaseResult` 유지.
+
+**Lazy fallback prompt**: `runGatePhase`는 resume 경로일 때 resume 프롬프트만 미리 조립/검증하고, fresh 프롬프트는 **closure**로 감싸 `runCodexGate`에 넘긴다. Closure는 session_missing이 감지된 시점에만 호출되어 `assembleGatePrompt(phase, state, ...)`를 실행 — 이 시점에 크기 체크도 함께 수행된다. 정상 resume 성공 시에는 fresh 프롬프트 조립 비용을 지불하지 않음.
+
+```ts
+// src/phases/gate.ts, runGatePhase (resume 경로)
+if (useCodexResume) {
+  const resumeResult = assembleGateResumePrompt(...);  // 크기 체크 포함
+  if (typeof resumeResult !== 'string') return { type: 'error', error: resumeResult.error };
+  const rawResult = await runCodexGate(
+    phase, preset, resumeResult, harnessDir, cwd, resumeId,
+    // Closure 계약: 호출 시점에 state.currentPhase가 여전히 phase인지 확인한 뒤
+    // fresh 프롬프트 조립. SIGUSR1 jump로 stale해졌으면 `{ error }` 반환.
+    /* buildFreshPromptOnFallback */ () => {
+      if (state.currentPhase !== phase) {
+        return { error: `phase ${phase} stale (currentPhase=${state.currentPhase})` };
+      }
+      return assembleGatePrompt(phase, state, harnessDir, cwd);
+    },
+  );
+  // ...
+}
+```
+
+**중요**: fallback 경로가 발동하면 이후 §4.4의 sessionId 저장 로직에 의해 `state.phaseCodexSessions[phase]`는 새 fresh 세션의 id로 덮어써진다 (다음 retry는 새 세션에서 resume). Fresh 프롬프트는 `assembleGatePrompt`이 조립하므로 자동으로 `REVIEWER_CONTRACT`를 포함 — REVIEWER_CONTRACT를 별도로 export/prepend할 필요 없음.
+
+### 4.6 로깅 확장
+
+`LogEvent` 타입(`src/types.ts`):
+```ts
+| (LogEventBase & {
+    event: 'gate_verdict';
+    // 기존 필드...
+    resumedFrom?: string | null;     // 신규: resume 시 이전 세션 id, fresh면 null
+    resumeFallback?: boolean;         // 신규: resume 실패 후 fresh fallback 여부
+  })
+| (LogEventBase & {
+    event: 'gate_error';
+    // 기존 필드...
+    resumedFrom?: string | null;
+    resumeFallback?: boolean;
+  })
+```
+
+`runner.ts`의 gate_verdict/gate_error emit 지점에서 `result.resumedFrom`, `result.resumeFallback`을 결과에서 꺼내 이벤트에 포함.
+
+`GatePhaseResult` 타입 확장:
+```ts
+export interface GateOutcome {
+  // 기존...
+  resumedFrom?: string | null;
+  resumeFallback?: boolean;
+}
+export interface GateError {
+  // 기존...
+  resumedFrom?: string | null;
+  resumeFallback?: boolean;
+}
+```
+
+### 4.7 Sidecar replay 경로
+
+**Sidecar + GatePhaseResult 스키마 확장**: 기존 `GateResult`는 `runner` 필드만 가지지만, session hydration 시 preset 호환성을 판단하기 위해 `sourcePreset?: { model: string; effort: string }` 필드를 추가한다. 이는 해당 gate 실행 시점의 preset 스냅샷이다. 기존 sidecar(필드 없음)는 hydration에서 제외된다(보수적 동작).
+
+또한 `checkGateSidecars`가 반환하는 `GatePhaseResult`에도 동일한 필드를 전파해야 한다 (replay 경로의 hydration이 이 값을 읽어야 하기 때문). 즉 `GateOutcome`과 `GateError`에도 `sourcePreset?` 추가.
+
+```ts
+// src/types.ts
+export interface GateResult {
+  // 기존 필드...
+  runner?: 'claude' | 'codex';
+  sourcePreset?: { model: string; effort: string };  // NEW
+  // ...
+}
+
+export interface GateOutcome {
+  // 기존 필드...
+  sourcePreset?: { model: string; effort: string };  // NEW (replay hydration)
+}
+
+export interface GateError {
+  // 기존 필드...
+  sourcePreset?: { model: string; effort: string };  // NEW (replay hydration)
+}
+```
+
+`checkGateSidecars`는 이미 `gate-N-result.json`을 JSON.parse해서 `GateResult`로 읽은 뒤 metadata 필드를 `GatePhaseResult`에 hydrate하는 로직(`src/phases/gate.ts:52`의 metadata 블록)을 가지고 있으므로, 여기에 `sourcePreset`을 한 줄 추가하면 됨.
+
+**Sidecar replay 자체의 preset 호환성 gate**: replay가 **반환되는 조건**도 preset 호환성에 의해 제한된다. 즉 sidecar에 기록된 `sourcePreset`(또는 `runner`)이 현재 `state.phasePresets[phase]`의 preset과 호환되지 않으면 replay를 건너뛰고 live gate 실행으로 진행한다. 이는 preset이 변경된 경우 캐시된 verdict를 재사용하지 않도록 하기 위함(§4.8 invalidation 의도 존중).
+
+**호환 판단 규칙 (authoritative, 단일)**: Replay는 **sidecar가 versioned compatibility 메타데이터를 완전히 갖췄을 때만** 수용한다. 즉 다음 모두를 만족해야 `replayCompatible = true`:
+
+1. `replay.runner !== undefined` (legacy pre-session-logging sidecar는 자동 skip)
+2. `replay.runner === currentPreset.runner`
+3. `replay.runner === 'claude'`이면 (2)만 충족해도 통과 (Claude는 resume 대상 아님)
+4. `replay.runner === 'codex'`이면 추가로:
+   - `replay.sourcePreset !== undefined`
+   - `replay.sourcePreset.model === currentPreset.model`
+   - `replay.sourcePreset.effort === currentPreset.effort`
+
+이 규칙은 **legacy sidecar(runner나 sourcePreset 없음)를 일괄 skip**하므로 안전. 기존 동작보다 엄격한 방향이지만, 본 작업 이전 sidecar가 크게 쌓여있을 일이 거의 없고(run 단위), 최악의 경우 한 번의 live 실행만 추가됨.
+
+비호환 판정 시 sidecar를 물리적으로 삭제할 필요는 없다 — fall through된 뒤 runGatePhase의 Step 2(pre-run sidecar cleanup)에서 삭제되고 Step 5에서 현 preset 기준 새 sidecar로 대체됨.
+
+**State hydration 로직** (위 호환성 gate를 통과한 replay에만 적용): `runGatePhase`가 sidecar replay로 조기 리턴하기 직전에:
+1. replay된 `GatePhaseResult.codexSessionId`가 존재하고
+2. replay된 `runner === 'codex'`이고
+3. `state.phaseCodexSessions[phase]`가 null이고
+4. replay된 `sourcePreset`이 현재 `state.phasePresets[phase]`의 model/effort와 일치
+
+위 네 조건이 모두 충족될 때만 state를 하이드레이트한다.
+
+```ts
+// src/phases/gate.ts, runGatePhase 내 sidecar replay 분기
+if (allowSidecarReplay?.value) {
+  allowSidecarReplay.value = false;
+  const replay = checkGateSidecars(runDir, phase);
+  if (replay !== null) {
+    const currentPreset = getPresetById(state.phasePresets[String(phase)]);
+
+    // (A) Replay-level compatibility gate: 위 authoritative 규칙의 구현.
+    // Legacy sidecar (runner undefined 또는 codex sourcePreset 없음) → 전부 skip.
+    const replayCompatible = (
+      currentPreset !== undefined &&
+      replay.runner !== undefined &&
+      replay.runner === currentPreset.runner &&
+      (
+        replay.runner === 'claude'
+          ? true  // Claude: runner 일치만으로 통과
+          : (replay.sourcePreset !== undefined &&
+             replay.sourcePreset.model === currentPreset.model &&
+             replay.sourcePreset.effort === currentPreset.effort)
+      )
+    );
+    if (!replayCompatible) {
+      // replay 건너뛰고 live 실행으로. sidecar 파일은 지우지 않음 — step 5에서 overwrite.
+      // 아래 "Step 2: Pre-run sidecar cleanup"이 어차피 이들을 삭제함.
+      // falls through to live execution path
+    } else {
+      // (B) Hydration gate (기존 로직)
+      const canHydrate =
+        replay.codexSessionId !== undefined &&
+        replay.runner === 'codex' &&
+        state.phaseCodexSessions[String(phase) as '2'|'4'|'7'] === null &&
+        currentPreset?.runner === 'codex' &&
+        replay.sourcePreset !== undefined &&
+        replay.sourcePreset.model === currentPreset.model &&
+        replay.sourcePreset.effort === currentPreset.effort;
+
+      if (canHydrate) {
+      // replay.codexSessionId는 위 검증에서 non-empty string 확인됨.
+      // lastOutcome 결정: verdict 타입이면 APPROVE/REJECT 구분, error면 'error'.
+      const lastOutcome: 'approve' | 'reject' | 'error' =
+        replay.type === 'verdict'
+          ? (replay.verdict === 'APPROVE' ? 'approve' : 'reject')
+          : 'error';
+        state.phaseCodexSessions[String(phase) as '2'|'4'|'7'] = {
+          sessionId: replay.codexSessionId!,
+          runner: 'codex',
+          model: currentPreset!.model,
+          effort: currentPreset!.effort,
+          lastOutcome,
+        };
+        writeState(runDir, state);
+      }
+      return { ...replay, recoveredFromSidecar: true };
+    } // end replayCompatible
+  }
+}
+```
+
+**Sidecar 쓰기 시에도 preset 기록**: `runGatePhase` step 5(sidecar 쓰기)에서 현재 preset을 `sourcePreset`으로 기록한다.
+
+```ts
+const gateResult: GateResult = {
+  exitCode,
+  timestamp: Date.now(),
+  runner,
+  sourcePreset: runner === 'codex' ? { model: preset.model, effort: preset.effort } : undefined,
+  // ...
+};
+```
+
+단, replay 자체에서는 Codex가 호출되지 않으므로 `resumedFrom`/`resumeFallback`은 replay 결과에는 포함되지 않는다 (`recoveredFromSidecar: true`만 표시).
+
+### 4.8 Preset 변경 시 Session 무효화
+
+Harness 현 구조상 사용자는 mid-run에 phasePresets를 바꿀 수 있다 (`src/commands/inner.ts`의 `promptModelConfig`, `src/ui.ts`의 개별 preset 교체 UI). preset 변경 시 해당 phase의 저장된 Codex 세션이 무효화되어야 한다 — 세션이 이전 모델/effort로 열렸기 때문에 resume 시 설정 미스매치가 발생할 수 있음.
+
+**무효화 규칙** (§2 해소된 모호성과 동일):
+- 변경 후 `runner === 'claude'` → `phaseCodexSessions[phase] = null`
+- 변경 후 `runner === 'codex'`지만 `model` 또는 `effort`가 이전 preset과 다름 → `phaseCodexSessions[phase] = null`
+- 변경 후 preset이 이전과 identical (change가 no-op) → 변경 없음
+
+**구현 위치**: preset을 수정하는 모든 호출 사이트. 현 코드 기준:
+1. `inner.ts`에서 `state.phasePresets = await promptModelConfig(...)` 직후 (전체 re-prompt)
+2. `ui.ts`에서 개별 preset 교체 직후
+
+두 경로 모두에서, 변경 전 preset 스냅샷과 변경 후 preset을 비교해 `phaseCodexSessions`를 갱신하는 헬퍼 함수를 호출한다:
+
+```ts
+// src/state.ts 또는 별도 helper에 추가
+// feedback 파일(gate-N-feedback.md)은 건드리지 않는다 (reopen/escalation flow가 참조).
+// 단 replay용 sidecar(gate-N-raw.txt, gate-N-result.json, gate-N-error.md)는 삭제 —
+// 세션과 같은 freshness domain이며, 남겨두면 `harness resume`의 one-shot 사이드카 replay가
+// preset 변경을 우회하고 stale verdict를 반환할 수 있음.
+export function invalidatePhaseSessionsOnPresetChange(
+  state: HarnessState,
+  prevPresets: Record<string, string>,
+  runDir: string,
+): void {
+  for (const phase of ['2', '4', '7'] as const) {
+    const prevId = prevPresets[phase];
+    const currId = state.phasePresets[phase];
+    if (prevId === currId) continue;
+    const prev = getPresetById(prevId);
+    const curr = getPresetById(currId);
+    if (
+      !prev || !curr ||
+      prev.runner !== curr.runner ||
+      (curr.runner === 'codex' && (prev.model !== curr.model || prev.effort !== curr.effort))
+    ) {
+      state.phaseCodexSessions[phase] = null;
+      // Replay sidecar 삭제 (feedback은 건드리지 않음)
+      for (const filename of [`gate-${phase}-raw.txt`, `gate-${phase}-result.json`, `gate-${phase}-error.md`]) {
+        try { fs.unlinkSync(path.join(runDir, filename)); } catch { /* 없으면 무시 */ }
+      }
+    }
+  }
+}
+```
+
+호출 사이트(inner.ts, ui.ts)에서 변경 전 snapshot을 유지하고 변경 후 이 helper 호출 → writeState.
+
+**왜 feedback 파일을 삭제하지 않는가?**: 기존 reopen/escalation 흐름(`src/phases/runner.ts handleGateReject`, `src/resume.ts show_escalation`, `src/context/assembler.ts assembleInteractivePrompt`)이 `pendingAction.feedbackPaths`의 파일 경로를 계속 참조한다. Invalidation이 이 파일을 삭제하면 reopen된 interactive phase가 빈 경로를 읽어 Claude Code에 피드백이 전달되지 않는다. Session(`phaseCodexSessions`)만 null로 비우면 다음 gate 호출은 fresh spawn을 타고 Variant A/B 분기 자체가 발생하지 않으므로, stale feedback 이슈도 자연스럽게 해소된다. **Feedback 파일은 별도 lifecycle**: 다음 REJECT에서 `saveGateFeedback`이 덮어쓰거나, phase가 APPROVE로 최종 통과하면 그대로 남는다 (gate 단위 artifact).
+
+**Test**: preset 변경 시 `phaseCodexSessions`가 기대대로 갱신되는지 단위 테스트.
+
+### 4.9 Backward phase movement 시 Session 무효화
+
+사용자는 `harness jump <phase>` 또는 SIGUSR1 control signal로 run을 이전 phase로 되돌릴 수 있다 (`src/commands/jump.ts`, `src/signal.ts`). 이때 이후 gate의 입력(spec/plan/code)이 바뀔 수 있으므로 저장된 gate 세션이 stale이 된다. 방치하면 Gate는 이전 리뷰 컨텍스트로 resume하여 현재 상태와 맞지 않는 피드백을 주거나 자동 APPROVE 편향을 발생시킬 수 있다.
+
+**규칙**: phase K로 jump할 때, `phaseCodexSessions[P]`를 모든 gate phase P (2, 4, 7 중) 에 대해 `P >= K`인 경우 null로 초기화.
+
+| jump 대상 K | 무효화되는 gate session |
+|------------|------------------------|
+| K=1 | 2, 4, 7 |
+| K=2 | 2, 4, 7 |
+| K=3 | 4, 7 |
+| K=4 | 4, 7 |
+| K=5 | 7 |
+| K=6 | 7 |
+| K=7 | 7 |
+
+**구현 위치 (authoritative — state mutation이 실제로 일어나는 지점에만)**:
+
+1. **Online jump (active session, SIGUSR1 경로)** — `src/signal.ts` SIGUSR1 핸들러에서 phase 리셋과 동시에 `invalidatePhaseSessionsOnJump(state, targetPhase, runDir)` 호출.
+2. **Offline jump 적용 (pending-action consume 시)** — `src/commands/inner.ts`의 `consumePendingAction`의 jump 적용 분기에서 `invalidatePhaseSessionsOnJump(state, targetPhase, runDir)` 호출.
+
+**주의**: `src/commands/jump.ts`와 `src/ui.ts`는 UI/CLI 엔트리 레이어로 state.json을 직접 수정하지 않으므로 invalidation 호출 **대상 아님**. (`jump.ts`는 `pending-action.json`만 쓰고 state mutation은 위 (2)에서 수행.)
+
+```ts
+// src/state.ts
+// feedback 파일(gate-N-feedback.md)은 건드리지 않는다.
+// Replay sidecar는 §4.8과 같은 이유로 삭제 — jump 이후 사이드카 replay가 stale verdict를
+// 반환해 jump 의도를 우회하는 것을 방지.
+export function invalidatePhaseSessionsOnJump(
+  state: HarnessState,
+  targetPhase: number,
+  runDir: string,
+): void {
+  for (const phase of [2, 4, 7] as const) {
+    if (phase >= targetPhase) {
+      state.phaseCodexSessions[String(phase) as '2'|'4'|'7'] = null;
+      for (const filename of [`gate-${phase}-raw.txt`, `gate-${phase}-result.json`, `gate-${phase}-error.md`]) {
+        try { fs.unlinkSync(path.join(runDir, filename)); } catch { /* 없으면 무시 */ }
+      }
+    }
+  }
+}
+```
+
+**Test**: jump 시 기대되는 session이 null로 초기화되는지. SIGUSR1 핸들러 경로도 유사하게.
+
+**주의**: `harness skip <phase>` (현 phase 강제 통과)는 phase status만 'completed'로 바꾸며 backward 이동이 아니므로 session 무효화 대상이 아니다. 다만 skip 이후 이전 phase로 돌아오는 jump가 발생하면 §4.9 규칙이 적용된다.
+
+### 4.10 Jump race 시 Verdict 반영 방지
+
+기존 코드는 `src/phases/runner.ts`의 gate handler(`runGatePhase` 직후 약 line 352)에서 error 결과일 때만 `state.currentPhase !== phase`를 체크해 redirect 처리하고(line 415 근처), verdict 결과일 때는 체크 없이 바로 반영한다. 이는 다음 race를 열어둔다:
+
+1. Gate 2 실행 중 Codex 리뷰 진행
+2. 사용자 SIGUSR1 jump → `state.currentPhase` 변경
+3. Gate 2가 APPROVE verdict 반환
+4. gate handler가 state.phases['2']='completed'로 덮어쓰고 다음 phase로 진행 → jump 의도 덮어씀
+
+**규칙**: `runGatePhase`가 반환된 직후, verdict/error를 반영하기 **전에** `state.currentPhase === phase`를 확인한다. 불일치면 stale 결과로 취급하고 반영 없이 즉시 return.
+
+**구현 위치**: `src/phases/runner.ts`의 gate dispatch 함수(현재 `handleGatePhase` 근처, runGatePhase 호출 직후). 현재 error 경로에만 있는 redirect guard를 verdict 경로에도 공통으로 앞쪽에 배치:
+
+```ts
+const result = await runGatePhase(phase, state, harnessDir, runDir, cwd, sidecarReplayAllowed);
+
+// NEW: redirect guard — verdict/error 어느 쪽이든 stale이면 반영 안 함
+if (state.currentPhase !== phase) {
+  printInfo(`Phase ${phase} interrupted by control signal → phase ${state.currentPhase}`);
+  renderControlPanel(state);
+  return;
+}
+
+if (result.type === 'verdict') { /* 기존 처리 */ }
+else { /* 기존 error 처리 — redirect guard는 위로 이동했으니 여기서는 중복 제거 */ }
+```
+
+**Test**: gate runner mock이 SIGUSR1 jump를 중간에 시뮬레이트하고, verdict 반환 시 gate handler가 verdict를 반영하지 않는지 (state.phases, currentPhase 둘 다 변하지 않음) 확인.
+
+## 5. Harness Resume 및 크래시 복구와의 상호작용
+
+| 시나리오 | 동작 |
+|----------|------|
+| Gate 2 호출 완료 (success/timeout/error) 후 state persist → crash → `harness resume` | `state.phaseCodexSessions['2']`에 id가 persist됨. 재진입한 __inner가 같은 runId로 state 로드 → sidecar replay가 실패하거나 존재하지 않으면 runGatePhase가 다시 호출 → 저장된 id로 resume 시도 → Codex 디스크에 세션이 살아있으면 이어서, 없으면 fallback. |
+| Gate 2 호출 중 Codex가 sessionId 찍은 **직후** + runGatePhase가 state 저장 **전** crash → `harness resume` | sessionId 유실 → `phaseCodexSessions['2']`는 null 상태 → 재호출 시 fresh spawn. 정확성 영향 없음, 최적화 이득만 포기. 의도된 tradeoff (§2 해소된 모호성). |
+| Gate 2 reject 후 Claude가 spec 수정 중 crash → resume | 같음. Phase 1(interactive)로 돌아가 있을 것이고, 완료 후 Gate 2 재호출 시 저장된 id로 resume. |
+| Gate 2 approve 후 Gate 4 진입 중 crash → resume | Gate 4는 `phaseCodexSessions['4'] = null` 상태로 시작 → fresh spawn. Gate 2의 세션 id는 state에 남지만 사용되지 않음. |
+| 장기간 방치 후 resume (예: Codex 세션 만료) | `state.phaseCodexSessions[phase]`에 lineage는 있지만 디스크에서 세션이 사라짐 → `codex exec resume <id>` 실패(category=session_missing) → `runCodexGate`가 closure를 호출해 `assembleGatePrompt`로 fresh 프롬프트 조립(REVIEWER_CONTRACT 자동 포함, 크기 체크 자동 수행) → fresh 호출. 새 sessionId가 state에 저장됨. |
+
+## 6. 테스트 전략
+
+### 6.1 단위 테스트
+
+- **`assembleGateResumePrompt`** 신규 함수:
+  - Phase 2/4/7 각각 필요한 섹션만 포함되는지
+  - 변형 A (`lastOutcome === 'reject'`, previousFeedback 전달됨): "The artifacts have been updated based on your previous feedback" 섹션 포함, `## Your Previous Feedback` 블록 포함
+  - 변형 B (`lastOutcome === 'error'`, previousFeedback 빈 문자열): "The previous review turn did not complete" 메시지, `## Your Previous Feedback` 블록 **미포함**
+  - Stale feedback 시나리오: `gate-N-feedback.md`가 디스크에 존재하지만 `session.lastOutcome === 'error'`일 때, 변형 B가 선택되고 feedback 파일 내용은 프롬프트에 포함되지 않는지
+  - REVIEWER_CONTRACT가 **포함되지 않는지** (resume 세션 중복 방지 검증, 두 변형 모두)
+  - 크기 제한(MAX_PROMPT_SIZE_KB) 적용 확인
+- **`migrateState`**: 기존 state.json(phaseCodexSessions 없음)을 로드했을 때 기본값이 주입되는지
+- **`extractCodexMetadata`**: 이미 테스트되어 있음. 변경 없음.
+
+### 6.2 Runner 테스트
+
+Codex CLI는 모킹이 어려우므로, `src/runners/codex.ts`의 테스트는 기존 패턴(child_process.spawn 모킹)을 따른다.
+
+- `resumeSessionId` 파라미터가 주어졌을 때 `codex exec resume <id>` 인자로 전달되는지
+- 정상 resume 시 `resumedFrom: <id>` 반환, `resumeFallback`이 false 또는 미설정
+- Resume 실패 카테고리별 분류:
+  - stderr에 "session not found" → category = `session_missing` → closure 호출되어 `assembleGatePrompt` 결과로 fresh 호출 → `resumeFallback: true` + 결과에 새 `codexSessionId` (또는 fresh도 실패 시 `resumeFallback: true`인 error)
+  - stderr에 일반 에러 → category = `nonzero_exit_other` → fallback 없음, error 반환
+  - Timeout 트리거 → category = `timeout` → fallback 없음, error 반환
+- 모든 종료 경로에서 stdout의 `codexSessionId`가 `GateError`에도 포함되는지 (timeout, nonzero, success_no_verdict 포함)
+
+### 6.3 통합 테스트
+
+- Mock runner(`runCodexGate`를 MSW처럼 swap)를 써서 `runGatePhase`의 선택 로직 검증:
+  - 첫 호출: `resumeSessionId = undefined` + 전체 프롬프트
+  - 반환값 sessionId가 state에 저장
+  - 둘째 호출: `resumeSessionId = <저장된 id>` + resume 프롬프트
+  - runner='claude'일 때는 resume 로직 건너뜀 (state.phaseCodexSessions 불변)
+- Sidecar replay hydration:
+  - 기존 sidecar에 `codexSessionId`와 `sourcePreset`이 있고 state에는 없을 때, 현재 preset과 sourcePreset이 일치하면 hydration 발생
+  - 현재 preset의 model/effort가 sourcePreset과 다르면 hydration **발생 안 함**
+  - legacy sidecar (sourcePreset 필드 없음)는 hydration 발생 안 함 (보수적)
+- Jump/SIGUSR1 invalidation (feedback 파일은 건드리지 않음):
+  - `jump targetPhase=3` (online, SIGUSR1 경로) → `phaseCodexSessions['4']`, `['7']`이 null로 초기화. `['2']`는 유지. **모든 `gate-N-feedback.md` 파일은 건드리지 않음**
+  - `jump targetPhase=1` (online) → 모두 null. feedback 파일 유지
+  - Offline jump → resume 경로: `pending-action.json`이 jump action을 담은 상태에서 `consumePendingAction` 적용 시 동일 invalidation (feedback 파일 유지). `pendingAction.feedbackPaths`의 파일이 여전히 읽을 수 있는지 확인
+  - skip phase는 session 무효화 대상 아님
+- Preset 변경 invalidation (feedback 파일은 건드리지 않음): session만 null, feedback 파일 유지
+- Runtime lineage 호환성 체크 (defense-in-depth, preset mismatch만 커버):
+  - state에 `{ model: codex-high }` 세션이 저장된 상태에서 `preset.effort`가 `medium`으로 변경된 뒤 invalidation 훅이 호출되지 않은 경우(simulated miss)에도, `runGatePhase`가 resume 경로를 타지 않고 fresh spawn으로 전환되는지
+  - 빈 문자열/whitespace sessionId는 저장/resume 대상이 아닌지 (migration 및 runtime 모두에서 검증)
+- SIGUSR1 jump race:
+  - Gate가 실행 중이고 Codex가 sessionId를 반환한 직후, `state.currentPhase`가 SIGUSR1로 다른 값으로 바뀐 상태라면, §4.4 step 6이 sessionId를 저장하지 않고 스킵하는지 확인 (stillActivePhase 가드)
+  - §4.10 verdict 반영 guard: gate가 APPROVE를 반환해도 `state.currentPhase !== phase`이면 gate handler가 `state.phases`를 업데이트하지 않고 다음 phase로 진행하지 않는지 (jump 의도가 유지됨)
+  - Sidecar replay compatibility gate: preset이 변경된 후 resume하면, legacy sidecar(`sourcePreset` 없음) 또는 불일치하는 sourcePreset의 sidecar가 replay되지 않고 live 실행으로 진행하는지
+- Session_missing fallback 상태 관리:
+  - State에 stale id가 있는 상태에서 session_missing 감지 → 먼저 id를 null로 clear → fresh fallback 수행 → 성공 시 새 id 저장
+  - Fresh fallback도 실패(sessionId 없이 error)한 경우 → state에 dead id 남지 않고 null 상태 유지 (다음 retry는 fresh spawn)
+- Preset 변경 시 session 무효화:
+  - Gate 2 Codex 세션이 저장된 상태에서 preset을 `codex-high` → `codex-medium`으로 교체 → `phaseCodexSessions['2']`이 null로 초기화
+  - Gate 2 Codex 세션이 저장된 상태에서 preset을 Codex → Claude로 교체 → `phaseCodexSessions['2']`이 null
+  - 같은 preset으로 "교체" (no-op) 시 세션 유지
+  - 다른 phase의 세션은 영향받지 않음
+
+### 6.4 엔드-투-엔드 (수동 또는 로깅 기반)
+
+- `--enable-logging`으로 실제 run 실행, reject을 유도해 `gate_verdict` 이벤트에 `resumedFrom`이 기대대로 찍히는지 확인
+- 듀레이션 비교: fresh vs resume의 `durationMs` 차이가 의미있게 줄어드는지 (품질 유지는 comments 내용 수동 검토)
+
+## 7. 마이그레이션 및 호환성
+
+- 기존 `state.json`(phaseCodexSessions 없음) → `migrateState`가 자동으로 기본값 주입. 하위 호환 보장.
+- 기존 sidecar(`gate-${phase}-result.json`) 파일 포맷: `codexSessionId` 필드 이미 optional. 변경 없음.
+- `--enable-logging`이 없는 run에서도 resume 최적화는 동작(상태는 state.json에 저장되므로 로깅 off와 무관).
+
+## 8. YAGNI / 범위 밖
+
+다음은 **이번 작업에 포함하지 않는다**:
+
+- Codex 세션의 사용자 접근 가능한 inspect 명령(`harness codex-sessions` 같은 CLI). 필요해지면 v2.
+- Phase 간 세션 공유(예: Gate 2 세션을 Gate 4에서 이어받기). 설계상 의도적으로 분리.
+- 대체 gate transport(HTTP, IPC 등). Codex CLI stdin/stdout 기반 유지.
+- Resume 이득의 자동 측정/리포트. 로그 필드만 추가하고 분석은 수동.
+- `codex exec resume --last`로 id 없이 재개하는 경로. state에 id 저장하므로 `--last`는 불필요하고 덜 안전.
+- Claude runner에도 유사 메커니즘 추가(현재 Claude `--print`는 세션 개념 노출 없음).
+
+## 9. Open Questions (구현 시 확정)
+
+1. **`codex exec resume` 세션 유실 에러의 정확한 문자열/exit code** — 구현 시 실존하지 않는 UUID로 호출해서 stderr/exit 패턴 확인 필요. 결과에 따라 §4.5의 `session_missing` 감지 정규식을 확정한다. 안전 기본: 패턴이 확실할 때만 매칭, 애매하면 non-match(= fallback 없음).
+2. **Codex가 resume 시에도 동일 sessionId를 stdout에 찍는지, 또는 fork해서 새 id를 만드는지** — 실험으로 확인. `codexSessionId` 저장 로직이 둘 다 커버하도록 defensive하게 작성 (§4.4: "반환된 id를 늘 덮어씀"). fork라면 새 id로 갱신되어 이후 retry는 새 id로 resume.
+3. **resume 중 `--model`/`effort`가 원 세션과 다른 설정으로 전달된 경우 실제 동작** — §4.8에서 preset 변경 시 session을 무효화하도록 정책을 잡았으므로, 실전에서 이 케이스는 발생하지 않는다. 단, 구현 태스크에서 확인 테스트로 1회 실행 (다른 모델로 resume이 성공하는지/에러를 뱉는지 기록)해서 향후 안전 마진 판단 자료로 남긴다.
+
+위 세 가지는 impl plan의 첫 태스크(Codex CLI 동작 실험 태스크)에서 해소한다.

--- a/docs/specs/2026-04-18-dogfood-ux-quickwins-design.md
+++ b/docs/specs/2026-04-18-dogfood-ux-quickwins-design.md
@@ -1,0 +1,209 @@
+# Dog-Fooding UX Quick-Wins — Design Spec
+
+- 상태: draft
+- 작성일: 2026-04-18
+- 담당: Claude Code (engineer)
+- 관련 문서:
+  - 근거 QA 관찰: `qa-observations.md` (Priority 2 #6, Priority 3 #8 #12)
+  - 세션 맥락: `SESSION_CONTEXT.md` §5 (저난도 번들 권장)
+  - Impl plan: `docs/plans/2026-04-18-dogfood-ux-quickwins.md` (작성 예정)
+  - Eval report: `docs/process/evals/2026-04-18-dogfood-ux-quickwins-eval.md` (작성 예정)
+
+## 1. 배경과 목표
+
+`todo-manager` dog-fooding run(2026-04-18)에서 식별된 저난도 UX 이슈 3건을 한 번에 묶어 고친다. 모두 코드 면/파일이 분리되어 있어 동시에 처리해도 충돌 위험이 없고, 각각 수십 줄 이하의 표면 변경이다.
+
+**범위에 포함**:
+
+- **#6**: 컨트롤 pane이 좁아 모델 설정/게이트 피드백/escalation 문구가 심하게 word-wrap.
+- **#8**: Phase 프롬프트(phase-1/3/5.md)에 "sentinel 생성 즉시 세션이 자동 종료된다"는 거짓 contract.
+- **#12**: Run ID 슬러그가 과도하게 길어 경로/파일명이 비대해짐.
+
+**비목표**:
+
+- `#9 tokensTotal undefined` — SESSION_CONTEXT §5에서 resume 작업에 끼워 넣기 권장. 본 작업과 같은 Codex stdout 파서 코드 면을 건드리므로 병합 충돌 회피 위해 제외.
+- `#4 venv checklist`, `#7 clarify dialog`, `#5 37분 폭주`, `#10 advisor 타이밍`, `#11 escalation 키입력` — 설계 논의 또는 재현 실험이 추가로 필요하므로 별도 작업.
+
+**성공 기준**:
+
+- 114 cols 터미널에서 컨트롤 pane이 45 cols 이상 확보되어 한국어/영어 혼용 문구의 word-wrap이 실질적으로 감소.
+- Phase 프롬프트의 거짓 mechanism 주장 제거. 단, "sentinel은 마지막 단계" 행동 신호(AI가 commit 전 sentinel 먼저 쓰는 실수 방지)는 유지.
+- Run ID 총 길이가 기존 대비 40% 이상 감축(예: 59자 → 33자 수준).
+- 기존 테스트 전부 green, 회귀 0.
+
+## 2. Context & Decisions
+
+### 핵심 결정사항
+
+- **#6 pane ratio**: `splitPane` percent 파라미터 값을 **70 → 60**으로 변경. 동적 계산(tmux width 측정) 도입하지 않음 — 와이드 터미널에서 workspace가 과하게 좁아지는 테스트 매트릭스 확장 비용을 이번 작업이 감수하지 않음. 필요해지면 후속 작업.
+- **#8 sentinel contract**: CRITICAL 라인의 거짓 문구만 **교체**(삭제 아님). "sentinel 생성 즉시 자동 종료 / 이후 어떤 작업도 실행되지 않는다" → "sentinel 생성 이후 하네스는 다음 단계(리뷰/피드백)로 넘어가므로 추가 작업을 하지 말 것." AI가 "sentinel은 마지막 단계" 개념을 유지하되, 시스템이 kill을 보장한다는 거짓 주장은 제거.
+- **#12 slug cap**: `generateRunId`의 max 50 → **25**. Word-boundary cut 로직과 dedup 루프(`-2`, `-3`)는 그대로 유지. Hash 방식은 채택하지 않음 — `ls .harness/` 가독성 손실이 명확한 이득 없이 도입됨.
+
+### 제약 조건
+
+- **후속 resume 작업과의 병합**: `gate-convergence` 브랜치는 `main`(70c8e5a) 베이스, `codex-optimization` 브랜치의 resume 작업과 독립. 본 작업은 `src/runners/codex.ts`, `src/phases/verdict.ts`, `src/phases/gate.ts`를 **건드리지 않는다** → resume 브랜치 머지 시 파일 단위 conflict 없음.
+- **한국어 프롬프트 정합성**: phase-1/3/5.md가 모두 한국어 혼용 스타일 → 교체 문구도 기존 톤/어휘 따름.
+- **slug 길이 하한**: 25자면 "build-a-terminal-based"(22자 word-boundary cut) 수준 가능. 3~5단어 태스크 기술이면 가독성 유지. 극단 1-2단어 태스크("fix bug" 7자)도 잘 동작(cap 미발동).
+
+### 해소된 모호성
+
+- **왜 동적 pane 계산이 아닌가?**: 대부분의 터미널이 80-120 cols 범위(노트북 개발 기본). 고정 60:40은 이 범위 전부에서 control 32~48 cols 확보 → 현 상황(34 cols 불만) 개선에 충분. 와이드 모니터 사용자는 workspace가 충분히 커서 60% 비율도 합리적.
+- **왜 CRITICAL 라인 통삭제(B1) 대신 교체(B2)인가?**: "sentinel 마지막 생성" 순서 지시는 여전히 유효한 행동 신호. AI가 sentinel 먼저 쓰고 뒤에 commit을 누락하는 실수를 방지. 삭제하면 이 신호도 함께 잃음.
+- **왜 25자인가, 30이나 20이 아닌가?**: 25 × 0.7 ≈ 17자 정도가 word-boundary cut 후 실질 남는 길이. 관찰된 dog-fooding 태스크들("harness jump integration", "codex session resume" 등 대부분 20자 내외) 기준 원형 보존. 20은 too short(`terminal-based-todo` 수준이 이미 그 길이). 30은 감축 효과 미미(관찰 사례 48자 → 30자, 아직 길음).
+
+### 구현 시 주의사항
+
+- `src/commands/inner.ts:56` 한 곳만 수정. `splitPane(...)` 호출부. `src/tmux.ts`의 `splitPane` 함수 자체는 건드리지 않음(타 호출자 영향 없음).
+- `src/context/prompts/phase-{1,3,5}.md` 세 파일 모두 동일 CRITICAL 라인 교체. grep로 다른 prompt 파일에 같은 문구 있는지 확인하고 있으면 동일 처리.
+- `src/git.ts:119`의 `if (slug.length > 50)` 상수만 변경. 주석(`// 6. Max 50 chars...`)도 25로 동기화. 테스트 `tests/git.test.ts`에 slug length 검증 있으면 기대값 업데이트.
+
+## 3. 현 구조 분석
+
+### 관련 파일과 역할
+
+| 파일 | 현 역할 | 본 작업에서의 변경 |
+|------|---------|--------------------|
+| `src/commands/inner.ts` | `__inner` 커맨드, pane 생성 + 세션 루프 진입 | `splitPane(..., 'h', 70)` → `'h', 60` |
+| `src/context/prompts/phase-1.md` | Phase 1(spec 작성) 프롬프트 템플릿 | CRITICAL 라인 교체 |
+| `src/context/prompts/phase-3.md` | Phase 3(plan 작성) 프롬프트 템플릿 | CRITICAL 라인 교체 |
+| `src/context/prompts/phase-5.md` | Phase 5(구현) 프롬프트 템플릿 | CRITICAL 라인 교체 |
+| `src/git.ts` | `generateRunId` 슬러그 생성 | 50 → 25, 주석 동기화 |
+| `tests/git.test.ts` | `generateRunId` 테스트 | cap 변경 반영 |
+| `tests/commands/inner.test.ts` | inner splitPane 호출 검증 | percent 인자 기대값 갱신 |
+
+## 4. 설계 상세
+
+### 4.1 #6 컨트롤 pane 비율
+
+**변경 전** (`src/commands/inner.ts:56`):
+
+```ts
+const workspacePaneId = splitPane(state.tmuxSession, controlPaneId, 'h', 70);
+```
+
+**변경 후**:
+
+```ts
+const workspacePaneId = splitPane(state.tmuxSession, controlPaneId, 'h', 60);
+```
+
+**효과**:
+
+| 터미널 너비 | 변경 전 control cols | 변경 후 control cols |
+|-------------|---------------------|---------------------|
+| 80          | 24                  | 32                  |
+| 114         | 34                  | **~45**             |
+| 160         | 48                  | 64                  |
+| 200         | 60                  | 80                  |
+
+60 cols 미만 환경에선 여전히 빡빡하지만 dog-fooding 관찰 114 cols에서 명확히 완화. Workspace는 여전히 60% 확보.
+
+**테스트**: `tests/commands/inner.test.ts`에 `splitPane` mock의 인자 검증이 있으면 `70` → `60` 업데이트. 없으면 수동 smoke 확인으로 충분(렌더링은 tmux 몫, unit test 대상 아님).
+
+### 4.2 #8 Phase 프롬프트 거짓 contract 교체
+
+세 파일(`src/context/prompts/phase-{1,3,5}.md`) 모두 동일 구조의 라인 존재(각 파일에서 `N`은 해당 phase 번호로 1/3/5). 교체 규칙 단일:
+
+**변경 전** (모든 phase, `N`은 파일별 해당 숫자):
+
+```
+**CRITICAL: sentinel 파일(phase-N.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 즉시 이 세션이 자동 종료된다. sentinel 이후에는 어떤 작업도 실행되지 않는다.**
+```
+
+**변경 후** (모든 phase):
+
+```
+**CRITICAL: sentinel 파일(phase-N.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 이후 하네스는 다음 단계(리뷰/피드백)로 넘어가므로 추가 작업을 하지 말 것.**
+```
+
+차이점: `sentinel 생성 즉시 이 세션이 자동 종료된다. sentinel 이후에는 어떤 작업도 실행되지 않는다` → `sentinel 생성 이후 하네스는 다음 단계(리뷰/피드백)로 넘어가므로 추가 작업을 하지 말 것`.
+
+**행동 의도 보존**:
+
+- ✅ sentinel은 "마지막 단계" — AI가 commit 전 sentinel 쓰는 실수 방지.
+- ✅ sentinel 이후 추가 작업 자제 — 여전히 지시됨(mechanism 아닌 행동 지시).
+- ❌ "세션이 kill된다"는 거짓 주장 — 제거.
+
+**테스트**: 프롬프트 교체는 정적 텍스트 변경. 기존 템플릿 렌더 테스트가 이 문자열을 하드코드 assert하고 있지 않으면 추가 테스트 불필요. Grep로 확인.
+
+### 4.3 #12 Run ID 슬러그 cap
+
+**변경 전** (`src/git.ts:87-143`):
+
+```ts
+// Rules:
+// ...
+// 6. Max 50 chars (cut at word boundary = last -)
+// ...
+  // 6. Max 50 chars, cut at word boundary (last -)
+  if (slug.length > 50) {
+    const truncated = slug.slice(0, 50);
+    const lastDash = truncated.lastIndexOf('-');
+    slug = lastDash > 0 ? truncated.slice(0, lastDash) : truncated;
+  }
+```
+
+**변경 후**:
+
+```ts
+// Rules:
+// ...
+// 6. Max 25 chars (cut at word boundary = last -)
+// ...
+  // 6. Max 25 chars, cut at word boundary (last -)
+  if (slug.length > 25) {
+    const truncated = slug.slice(0, 25);
+    const lastDash = truncated.lastIndexOf('-');
+    slug = lastDash > 0 ? truncated.slice(0, lastDash) : truncated;
+  }
+```
+
+**효과** (dog-fooding 실제 케이스):
+
+| Task 입력 | 변경 전 runId | 변경 후 runId |
+|-----------|--------------|---------------|
+| `"Build a terminal-based todo manager for personal use"` | `2026-04-18-build-a-terminal-based-todo-manager-for-personal` (59자) | `2026-04-18-build-a-terminal-based` (33자) |
+| `"Add codex session resume"` | `2026-04-18-add-codex-session-resume` (35자) | `2026-04-18-add-codex-session` (28자) |
+| `"fix bug"` | `2026-04-18-fix-bug` (18자) | `2026-04-18-fix-bug` (18자, cap 미발동) |
+
+**Edge case**: 25자 cap이 첫 단어조차 못 담는 경우 (예: 단일 단어 `supercalifragilisticexpialidocious` 34자) → `lastDash > 0` 조건이 false → `slug = truncated` (25자 그대로). 기존 50-cap에서도 같은 로직이므로 회귀 아님.
+
+**테스트**: `tests/git.test.ts`에 `generateRunId` 테스트 있으면 cap 50 → 25 기대값 업데이트. Word-boundary cut/dedup 테스트는 로직 불변이라 그대로 통과.
+
+## 5. 테스트 전략
+
+### 5.1 단위 테스트
+
+- **#6**: `tests/commands/inner.test.ts` — `splitPane` mock 인자 검증 존재 시 `70` → `60`.
+- **#8**: 정적 텍스트 변경. 기존 테스트가 CRITICAL 문자열을 assert하지 않으면 추가 없음. 있으면 기대값 업데이트.
+- **#12**: `tests/git.test.ts` — `generateRunId` 테스트에서 50자 경계 케이스가 있으면 25자 경계로 갱신. 신규 테스트: long-task 입력 시 총 length 확인.
+
+### 5.2 회귀
+
+- `pnpm -s vitest run` 전체 green.
+- `pnpm -s tsc --noEmit` 에러 0.
+- `pnpm -s lint` 에러 0.
+
+### 5.3 수동 smoke (선택)
+
+- 실제 `harness start "Long task name here that exceeds the cap"` 실행 → `.harness/2026-04-18-long-task-name-here-that/` 생성 확인.
+- tmux 세션에서 control pane이 기존보다 넓어진 것을 시각 확인(114 cols 기준).
+
+## 6. 마이그레이션 및 호환성
+
+- **기존 `.harness/<old-long-runid>/` 디렉토리**: 영향 없음. `generateRunId`는 신규 run만 생성. 기존 디렉토리는 그대로 읽힘(runId는 state.json에 저장되어 이름과 무관).
+- **기존 Phase 프롬프트 텍스트를 비교/assert하는 외부 코드**: 없음(내부 template만 사용).
+- **pane ratio**: 런타임 프로세스에만 영향. 기존 세션 이어가기(`harness resume`)에서는 pane 재생성이 없으면 기존 비율 유지(state에 pane ID 저장됨). 새 세션/새 pane 생성 시점부터 60:40 적용.
+
+## 7. YAGNI / 범위 밖
+
+다음은 **이번 작업에 포함하지 않는다**:
+
+- 동적 pane width 계산(A2). 현 변화로 충분.
+- Slug hash 접미사(C2) / 완전 hash runId(C3). dedup 루프가 충돌 처리 중.
+- phase-1/3/5 프롬프트의 다른 톤/구조 개선. CRITICAL 라인만 타깃.
+- 기타 dog-fooding 이슈(#4, #5, #7, #9, #10, #11) — 본 spec 바깥.
+
+## 8. Open Questions
+
+- 없음. 세 변경 모두 mechanism이 명확하고 관찰 데이터로 값이 결정됨.

--- a/src/commands/inner.ts
+++ b/src/commands/inner.ts
@@ -53,7 +53,7 @@ export async function innerCommand(runId: string, options: InnerOptions = {}): P
   if (controlValid && workspaceValid) {
     // Both panes valid and distinct — reuse
   } else if (controlValid) {
-    const workspacePaneId = splitPane(state.tmuxSession, controlPaneId, 'h', 70);
+    const workspacePaneId = splitPane(state.tmuxSession, controlPaneId, 'h', 60);
     state.tmuxWorkspacePane = workspacePaneId;
   } else {
     process.stderr.write(`Fatal: control pane ${controlPaneId} does not exist.\n`);

--- a/src/context/prompts/phase-1.md
+++ b/src/context/prompts/phase-1.md
@@ -7,7 +7,7 @@
 spec을 {{spec_path}}에, decision log를 {{decisions_path}}에 저장하고,
 `.harness/{{runId}}/phase-1.done` 파일을 생성하되 내용으로 '{{phaseAttemptId}}' 한 줄만 기록하라.
 
-**CRITICAL: sentinel 파일(phase-1.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 즉시 이 세션이 자동 종료된다. sentinel 이후에는 어떤 작업도 실행되지 않는다.**
+**CRITICAL: sentinel 파일(phase-1.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 이후 하네스는 다음 단계(리뷰/피드백)로 넘어가므로 추가 작업을 하지 말 것.**
 
 spec 문서는 "{{spec_path}}" 경로에 작성하고, 상단에 "## Context & Decisions" 섹션을 포함하라.
 decisions.md는 "{{decisions_path}}" 경로에 작성하라.

--- a/src/context/prompts/phase-3.md
+++ b/src/context/prompts/phase-3.md
@@ -18,4 +18,4 @@ eval checklist를 {{checklist_path}}에 아래 JSON 스키마로 저장하라:
 
 `.harness/{{runId}}/phase-3.done` 파일을 생성하되 내용으로 '{{phaseAttemptId}}' 한 줄만 기록하라.
 
-**CRITICAL: sentinel 파일(phase-3.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 즉시 이 세션이 자동 종료된다. sentinel 이후에는 어떤 작업도 실행되지 않는다.**
+**CRITICAL: sentinel 파일(phase-3.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 이후 하네스는 다음 단계(리뷰/피드백)로 넘어가므로 추가 작업을 하지 말 것.**

--- a/src/context/prompts/phase-5.md
+++ b/src/context/prompts/phase-5.md
@@ -11,4 +11,4 @@
 
 구현 완료 후 `.harness/{{runId}}/phase-5.done` 파일을 생성하되 내용으로 '{{phaseAttemptId}}' 한 줄만 기록하라.
 
-**CRITICAL: sentinel 파일(phase-5.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 즉시 이 세션이 자동 종료된다. sentinel 이후에는 어떤 작업도 실행되지 않는다.**
+**CRITICAL: sentinel 파일(phase-5.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 이후 하네스는 다음 단계(리뷰/피드백)로 넘어가므로 추가 작업을 하지 말 것.**

--- a/src/git.ts
+++ b/src/git.ts
@@ -91,7 +91,7 @@ export function getFileStatus(filePath: string, cwd?: string): string {
 // 3. Replace non-alphanumeric with -
 // 4. Collapse consecutive -
 // 5. Trim leading/trailing -
-// 6. Max 50 chars (cut at word boundary = last -)
+// 6. Max 25 chars (cut at word boundary = last -)
 // 7. Empty → "untitled"
 // Format: YYYY-MM-DD-<slug>[-N] (N if directory exists)
 export function generateRunId(task: string, harnessDir: string): string {
@@ -115,9 +115,9 @@ export function generateRunId(task: string, harnessDir: string): string {
     // 5. Trim leading/trailing -
     .replace(/^-+|-+$/g, '');
 
-  // 6. Max 50 chars, cut at word boundary (last -)
-  if (slug.length > 50) {
-    const truncated = slug.slice(0, 50);
+  // 6. Max 25 chars, cut at word boundary (last -)
+  if (slug.length > 25) {
+    const truncated = slug.slice(0, 25);
     const lastDash = truncated.lastIndexOf('-');
     slug = lastDash > 0 ? truncated.slice(0, lastDash) : truncated;
   }

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -179,12 +179,12 @@ describe('generateRunId', () => {
     expect(id).toMatch(/^\d{4}-\d{2}-\d{2}-cafe-au-lait$/);
   });
 
-  it('truncates slug to 50 chars at word boundary', () => {
-    // Create a task that produces a slug longer than 50 chars
+  it('truncates slug to 25 chars at word boundary', () => {
+    // Create a task that produces a slug longer than 25 chars
     const task = 'implement the full authentication and authorization system for users';
     const id = generateRunId(task, harnessDir);
     const slug = id.slice('YYYY-MM-DD-'.length);
-    expect(slug.length).toBeLessThanOrEqual(50);
+    expect(slug.length).toBeLessThanOrEqual(25);
     // Should not end with a partial word (no trailing -)
     expect(slug).not.toMatch(/-$/);
   });


### PR DESCRIPTION
## Summary

Two thematic bundles:

**UX quick-wins** (dog-fooding QA #6, #8, #12 from `qa-observations.md`):
- `fix(ui)`: widen control pane to 40% (`splitPane` 70 → 60)
- `fix(prompts)`: replace false sentinel auto-termination claim in `phase-1/3/5.md` with accurate "harness moves on" wording
- `fix(git)`: tighten `runId` slug cap 50 → 25 for shorter `.harness/` paths (test expectation updated)

**Design docs (no code)**:
- `docs(spec)`: per-phase Codex session resume design (8-review-round refined, brought over from `codex-optimization` branch)
- `docs(plan)`: impl plan for session resume
- `docs(spec)`: UX quick-wins design + impl plan (above)

The session-resume design docs are duplicated on `codex-optimization` (that branch has started implementing Task 3). Landing the docs on `main` here gives a shared anchor; when `codex-optimization` rebases, git should see identical content as no-op.

## Test Plan

- [x] `pnpm -s vitest run` → 427 passed, 1 skipped, 0 fail
- [x] `pnpm -s lint` → clean
- [x] `pnpm -s tsc --noEmit` → clean
- [x] EC checklist (spec §Eval Checklist) EC-1..EC-11 all green via grep + test runs
- [ ] Manual smoke: run `harness start "long task name…"` → verify runId ≤ 33 chars total
- [ ] Manual smoke: open a run → verify control pane visibly wider than before in 114-col terminals