### PR TITLE
fix: dog-fooding UX quick-wins batch 2 (plan prompt env, advisor timing, key input)

### DIFF
--- a/docs/plans/2026-04-18-dogfood-ux-quickwins-2.md
+++ b/docs/plans/2026-04-18-dogfood-ux-quickwins-2.md
@@ -1,0 +1,625 @@
+# Dog-Fooding UX Quick-Wins 2 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**관련 문서:**
+- Spec: `docs/specs/2026-04-18-dogfood-ux-quickwins-2-design.md`
+- Eval checklist: 본 문서 §Eval Checklist
+- Eval report (작성 예정): `docs/process/evals/2026-04-18-dogfood-ux-quickwins-2-eval.md`
+
+**Goal:** Dog-fooding QA에서 식별된 독립 이슈 3건(plan prompt env 격리 문구, advisor reminder 타이밍, InputManager pending-key 버퍼)을 한 번에 처리한다.
+
+**Architecture:** 세 변경 모두 resume 작업 코드 면(`src/runners/codex.ts`, `src/phases/gate.ts`, `src/phases/runner.ts`, `src/commands/inner.ts`, `src/signal.ts`, `src/state.ts`, `src/types.ts`, `src/context/assembler.ts`)을 건드리지 않는다. 세 파일만 수정(`src/context/prompts/phase-3.md`, `src/phases/interactive.ts`, `src/input.ts`) + 각각 테스트. 이슈 단위 commit 3개.
+
+**Tech Stack:** TypeScript (Node.js), vitest, 기존 InputManager private 메서드 `(im as any).onData(...)`로 테스트 인젝션.
+
+---
+
+## File Structure
+
+### 수정 파일
+- `src/context/prompts/phase-3.md` — checks 스키마 설명 뒤에 env 격리 제약 문장 1개 추가
+- `src/phases/interactive.ts` — advisor reminder 호출 위치 이동 + 300ms sleep 제거
+- `src/input.ts` — `pendingKey` 슬롯 + TTL 상수 + onData 버퍼링 분기 + waitForKey 사전 확인
+- `tests/input.test.ts` — 5 pendingKey 케이스 추가
+- `tests/phases/interactive.test.ts` — advisor reminder 순서 테스트 반전
+
+### 신규 파일
+없음.
+
+---
+
+## Task 1: Plan 프롬프트에 env 격리 제약 추가 (#4)
+
+**Files:**
+- Modify: `src/context/prompts/phase-3.md:17`
+
+프롬프트는 정적 텍스트이므로 TDD 불필요. 한 문장 삽입만.
+
+- [ ] **Step 1: `phase-3.md`에 env 격리 제약 문장 추가**
+
+변경 전 (라인 17 주변):
+```
+`checks` 배열은 비어있지 않아야 하며 각 항목에 `name`(string)과 `command`(string)이 필수다.
+
+`.harness/{{runId}}/phase-3.done` 파일을 생성하되 내용으로 '{{phaseAttemptId}}' 한 줄만 기록하라.
+```
+
+변경 후:
+```
+`checks` 배열은 비어있지 않아야 하며 각 항목에 `name`(string)과 `command`(string)이 필수다.
+
+각 check command는 격리된 셸 환경에서 실행된다. venv/node_modules 등 의존성을 요구하는 검증은 절대경로 바이너리(`.venv/bin/python -m pytest`, `./node_modules/.bin/eslint`)나 env-aware 래퍼(`make test`, `pnpm test`)를 사용하라.
+
+`.harness/{{runId}}/phase-3.done` 파일을 생성하되 내용으로 '{{phaseAttemptId}}' 한 줄만 기록하라.
+```
+
+- [ ] **Step 2: grep 확인**
+
+```bash
+grep -n "격리된 셸 환경" src/context/prompts/phase-3.md
+```
+Expected: 1 hit.
+
+- [ ] **Step 3: 프롬프트 관련 테스트 회귀 확인**
+
+```bash
+pnpm -s vitest run tests/context/
+```
+Expected: 전부 green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/context/prompts/phase-3.md
+git commit -m "fix(prompts): add env-isolated check command constraint to phase-3"
+```
+
+---
+
+## Task 2: Advisor reminder 호출 위치 이동 (#10)
+
+**Files:**
+- Modify: `src/phases/interactive.ts:197-205`
+- Modify: `tests/phases/interactive.test.ts:574-603`
+
+TDD 순서: 테스트부터 기대 순서 뒤집기 → fail 확인 → 구현 이동 → pass 확인.
+
+- [ ] **Step 1: 테스트 describe/it 이름 + assertion 반전**
+
+`tests/phases/interactive.test.ts:574-603`의 describe 블록을 다음으로 교체:
+
+변경 전:
+```ts
+// ─── runInteractivePhase: advisor reminder ordering ──────────────────────────
+
+describe('runInteractivePhase — advisor reminder fires before sendKeysToPane', () => {
+  it('printAdvisorReminder is called before sendKeysToPane', async () => {
+    const { sendKeysToPane } = await import('../../src/tmux.js');
+    const { printAdvisorReminder } = await import('../../src/ui.js');
+    const { runInteractivePhase } = await import('../../src/phases/interactive.js');
+
+    const runDir = makeTmpDir();
+    const harnessDir = makeTmpDir();
+    const repoDir = createTestRepo();
+
+    const state = makeState({ tmuxSession: 'test-session', tmuxWorkspacePane: '%1', tmuxControlPane: '%0' });
+
+    // Clear any previous call records from other tests
+    vi.mocked(printAdvisorReminder).mockClear();
+    vi.mocked(sendKeysToPane).mockClear();
+
+    // Run; it will resolve as 'failed' (no sentinel, PID dies immediately) — that's fine
+    await runInteractivePhase(1, state, harnessDir, runDir, repoDir, 'test-attempt-id');
+
+    const reminderOrder = vi.mocked(printAdvisorReminder).mock.invocationCallOrder[0];
+    // sendKeysToPane is called twice: C-c pre-clear, then the actual command
+    const sendKeysToPaneOrder = vi.mocked(sendKeysToPane).mock.invocationCallOrder[0];
+
+    expect(reminderOrder).toBeDefined();
+    expect(sendKeysToPaneOrder).toBeDefined();
+    expect(reminderOrder).toBeLessThan(sendKeysToPaneOrder);
+    expect(vi.mocked(printAdvisorReminder)).toHaveBeenCalledWith(1, 'claude');
+  });
+```
+
+변경 후:
+```ts
+// ─── runInteractivePhase: advisor reminder ordering ──────────────────────────
+
+describe('runInteractivePhase — advisor reminder fires after runClaudeInteractive', () => {
+  it('printAdvisorReminder is called after all sendKeysToPane calls', async () => {
+    const { sendKeysToPane } = await import('../../src/tmux.js');
+    const { printAdvisorReminder } = await import('../../src/ui.js');
+    const { runInteractivePhase } = await import('../../src/phases/interactive.js');
+
+    const runDir = makeTmpDir();
+    const harnessDir = makeTmpDir();
+    const repoDir = createTestRepo();
+
+    const state = makeState({ tmuxSession: 'test-session', tmuxWorkspacePane: '%1', tmuxControlPane: '%0' });
+
+    // Clear any previous call records from other tests
+    vi.mocked(printAdvisorReminder).mockClear();
+    vi.mocked(sendKeysToPane).mockClear();
+
+    // Run; it will resolve as 'failed' (no sentinel, PID dies immediately) — that's fine
+    await runInteractivePhase(1, state, harnessDir, runDir, repoDir, 'test-attempt-id');
+
+    const reminderOrder = vi.mocked(printAdvisorReminder).mock.invocationCallOrder[0];
+    // sendKeysToPane is called multiple times (C-c pre-clear, wrapped cmd);
+    // reminder should fire after all of them (post-dispatch).
+    const sendKeysCalls = vi.mocked(sendKeysToPane).mock.invocationCallOrder;
+    const lastSendKeysOrder = sendKeysCalls[sendKeysCalls.length - 1];
+
+    expect(reminderOrder).toBeDefined();
+    expect(lastSendKeysOrder).toBeDefined();
+    expect(reminderOrder).toBeGreaterThan(lastSendKeysOrder);
+    expect(vi.mocked(printAdvisorReminder)).toHaveBeenCalledWith(1, 'claude');
+  });
+```
+
+(두 번째 `it` "sendKeysToPane command includes --dangerously-skip-permissions and --effort"는 변경 없음.)
+
+- [ ] **Step 2: 테스트 실행 → 실패 확인 (구현 미변경)**
+
+```bash
+pnpm -s vitest run tests/phases/interactive.test.ts -t "advisor reminder"
+```
+Expected: FAIL — `reminderOrder`가 아직 `lastSendKeysOrder`보다 작음.
+
+- [ ] **Step 3: `interactive.ts`에서 호출 위치 이동**
+
+`src/phases/interactive.ts`의 `runInteractivePhase` 함수 안, Claude 분기 처리 직전 라인들.
+
+변경 전 (라인 197-224 근방):
+```ts
+  printAdvisorReminder(phase, preset.runner);
+  await new Promise<void>((resolve) => setTimeout(resolve, 300));
+
+  // Dispatch to runner
+  if (preset.runner === 'claude') {
+    const { pid: claudePid } = await runClaudeInteractive(
+      phase, updatedState, preset, harnessDir, runDir, promptFile,
+    );
+    const sentinelPath = path.join(runDir, `phase-${phase}.done`);
+    const resolvedAttemptId = updatedState.phaseAttemptId[String(phase)] ?? attemptId;
+    const result = await waitForPhaseCompletion(
+      sentinelPath, resolvedAttemptId, claudePid, phase, updatedState, cwd, runDir
+    );
+    return { ...result, attemptId };
+  } else {
+    // Codex runner
+    const { runCodexInteractive } = await import('../runners/codex.js');
+    const result = await runCodexInteractive(
+      phase, updatedState, preset, harnessDir, runDir, promptFile, cwd,
+    );
+    if (result.status === 'failed') {
+      return { status: 'failed', attemptId };
+    }
+    // Validate artifacts after Codex completes
+    const valid = validatePhaseArtifacts(phase, updatedState, cwd);
+    return { status: valid ? 'completed' : 'failed', attemptId };
+  }
+```
+
+변경 후:
+```ts
+  // Dispatch to runner
+  if (preset.runner === 'claude') {
+    const { pid: claudePid } = await runClaudeInteractive(
+      phase, updatedState, preset, harnessDir, runDir, promptFile,
+    );
+    printAdvisorReminder(phase, preset.runner);
+    const sentinelPath = path.join(runDir, `phase-${phase}.done`);
+    const resolvedAttemptId = updatedState.phaseAttemptId[String(phase)] ?? attemptId;
+    const result = await waitForPhaseCompletion(
+      sentinelPath, resolvedAttemptId, claudePid, phase, updatedState, cwd, runDir
+    );
+    return { ...result, attemptId };
+  } else {
+    // Codex runner — printAdvisorReminder is a no-op for codex, omit call
+    const { runCodexInteractive } = await import('../runners/codex.js');
+    const result = await runCodexInteractive(
+      phase, updatedState, preset, harnessDir, runDir, promptFile, cwd,
+    );
+    if (result.status === 'failed') {
+      return { status: 'failed', attemptId };
+    }
+    // Validate artifacts after Codex completes
+    const valid = validatePhaseArtifacts(phase, updatedState, cwd);
+    return { status: valid ? 'completed' : 'failed', attemptId };
+  }
+```
+
+(기존 `printAdvisorReminder(phase, preset.runner);` + `await new Promise<void>((resolve) => setTimeout(resolve, 300));` 두 줄 제거. Claude 분기 안에 reminder 한 줄 추가.)
+
+- [ ] **Step 4: 테스트 실행 → 통과 확인**
+
+```bash
+pnpm -s vitest run tests/phases/interactive.test.ts
+```
+Expected: 전체 interactive 테스트 green (34 passed). advisor reminder 테스트 포함.
+
+- [ ] **Step 5: TypeScript 빌드 확인**
+
+```bash
+pnpm -s tsc --noEmit
+```
+Expected: 에러 없음.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/phases/interactive.ts tests/phases/interactive.test.ts
+git commit -m "fix(interactive): move advisor reminder to post-Claude-launch"
+```
+
+---
+
+## Task 3: InputManager pendingKey 버퍼 (#11)
+
+**Files:**
+- Modify: `src/input.ts`
+- Modify: `tests/input.test.ts`
+
+TDD 순서: 실패하는 테스트 5개 추가 → fail 확인 → 구현 → pass 확인.
+
+- [ ] **Step 1: `tests/input.test.ts`에 5 신규 케이스 추가**
+
+`tests/input.test.ts` 끝부분에 신규 describe 블록 추가:
+
+```ts
+describe('InputManager — pendingKey buffer', () => {
+  it('waitForKey resolves immediately with pending key pressed during idle', async () => {
+    const im = new InputManager();
+    im.enterPhaseLoop(); // state -> idle
+    // Inject a key while idle (private onData via any-cast)
+    (im as any).onData(Buffer.from('s'));
+    const key = await im.waitForKey(new Set(['s', 'c', 'q']));
+    expect(key).toBe('S');
+  });
+
+  it('waitForKey ignores pending key outside validKeys', async () => {
+    const im = new InputManager();
+    im.enterPhaseLoop();
+    (im as any).onData(Buffer.from('x'));
+    // pending is 'x' which is not valid; waitForKey should clear it and wait.
+    // Feed a valid key via handler (synthesize by directly invoking handler after Promise starts)
+    const p = im.waitForKey(new Set(['s', 'c', 'q']));
+    // Simulate later keypress in prompt-single state
+    (im as any).handler?.('s');
+    const key = await p;
+    expect(key).toBe('S');
+  });
+
+  it('waitForKey ignores stale pending key older than TTL', async () => {
+    const im = new InputManager();
+    im.enterPhaseLoop();
+    (im as any).onData(Buffer.from('s'));
+    // Manually age the pending entry beyond TTL (1000ms)
+    (im as any).pendingKey.timestamp = Date.now() - 2000;
+    const p = im.waitForKey(new Set(['s', 'c', 'q']));
+    // pending is stale → cleared; waitForKey is now waiting on handler.
+    (im as any).handler?.('c');
+    const key = await p;
+    expect(key).toBe('C');
+  });
+
+  it('onData does not buffer ESC sequences or control chars in pending', () => {
+    const im = new InputManager();
+    im.enterPhaseLoop();
+    (im as any).onData(Buffer.from('\x1b[A')); // arrow up
+    expect((im as any).pendingKey).toBeNull();
+    (im as any).onData(Buffer.from('\x7f')); // DEL
+    expect((im as any).pendingKey).toBeNull();
+  });
+
+  it('waitForKey normal path unchanged when no pending', async () => {
+    const im = new InputManager();
+    im.enterPhaseLoop();
+    // No pre-emptive key; waitForKey enters normal wait.
+    const p = im.waitForKey(new Set(['s', 'c', 'q']));
+    (im as any).handler?.('q');
+    const key = await p;
+    expect(key).toBe('Q');
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → 실패 확인 (pendingKey 미구현)**
+
+```bash
+pnpm -s vitest run tests/input.test.ts -t "pendingKey buffer"
+```
+Expected: FAIL — `pendingKey` 프로퍼티 없음 / `onData`가 키를 드롭.
+
+- [ ] **Step 3: `src/input.ts`에 pendingKey 슬롯 + TTL 상수 추가**
+
+파일 최상단 타입 선언 영역(라인 1-3 근방)에 추가:
+
+```ts
+interface PendingKey {
+  key: string;
+  timestamp: number;
+}
+```
+
+`InputManager` 클래스 본문 필드 섹션 (라인 4-10 근방)에 추가:
+
+```ts
+  private pendingKey: PendingKey | null = null;
+  private static readonly PENDING_KEY_TTL_MS = 1000;
+```
+
+- [ ] **Step 4: `onData`에 pending 버퍼링 분기 추가**
+
+`onData` 메서드(라인 81-102)를 다음으로 교체:
+
+변경 전:
+```ts
+  private onData(buf: Buffer): void {
+    const str = buf.toString();
+
+    // Ctrl+C / Ctrl+D
+    if (str === '\x03' || str === '\x04') {
+      if (this.isPreLoop) {
+        this.onConfigCancel?.();
+      } else {
+        process.kill(process.pid, 'SIGINT');
+      }
+      return;
+    }
+
+    // ESC sequences (arrow keys, F-keys, etc.)
+    if (str.startsWith('\x1b')) return;
+
+    // Idle/configuring without active prompt
+    if (this.state === 'idle' || this.state === 'configuring') return;
+
+    // Forward to active handler
+    this.handler?.(str);
+  }
+```
+
+변경 후:
+```ts
+  private onData(buf: Buffer): void {
+    const str = buf.toString();
+
+    // Ctrl+C / Ctrl+D
+    if (str === '\x03' || str === '\x04') {
+      if (this.isPreLoop) {
+        this.onConfigCancel?.();
+      } else {
+        process.kill(process.pid, 'SIGINT');
+      }
+      return;
+    }
+
+    // ESC sequences (arrow keys, F-keys, etc.)
+    if (str.startsWith('\x1b')) return;
+
+    // Idle/configuring without active prompt — buffer single printable ASCII
+    // so a pre-emptive keystroke (typed while escalation prompt was printing)
+    // is not lost on the next waitForKey.
+    if (this.state === 'idle' || this.state === 'configuring') {
+      if (str.length === 1 && str.charCodeAt(0) >= 0x20 && str.charCodeAt(0) < 0x7f) {
+        this.pendingKey = { key: str, timestamp: Date.now() };
+      }
+      return;
+    }
+
+    // Forward to active handler
+    this.handler?.(str);
+  }
+```
+
+- [ ] **Step 5: `waitForKey`에 pending 사전 확인 추가**
+
+`waitForKey` 메서드(라인 47-59)를 다음으로 교체:
+
+변경 전:
+```ts
+  waitForKey(validKeys: Set<string>): Promise<string> {
+    return new Promise((resolve) => {
+      this.state = 'prompt-single';
+      this.handler = (key: string) => {
+        const lower = key.toLowerCase();
+        if (validKeys.has(lower)) {
+          this.handler = null;
+          this.state = this.isPreLoop ? 'configuring' : 'idle';
+          resolve(lower.toUpperCase());
+        }
+      };
+    });
+  }
+```
+
+변경 후:
+```ts
+  waitForKey(validKeys: Set<string>): Promise<string> {
+    return new Promise((resolve) => {
+      this.state = 'prompt-single';
+
+      // Consume pending key from idle-state buffer if still fresh and valid.
+      if (this.pendingKey !== null) {
+        const { key, timestamp } = this.pendingKey;
+        this.pendingKey = null;
+        if (
+          Date.now() - timestamp <= InputManager.PENDING_KEY_TTL_MS &&
+          validKeys.has(key.toLowerCase())
+        ) {
+          this.state = this.isPreLoop ? 'configuring' : 'idle';
+          resolve(key.toLowerCase().toUpperCase());
+          return;
+        }
+      }
+
+      this.handler = (key: string) => {
+        const lower = key.toLowerCase();
+        if (validKeys.has(lower)) {
+          this.handler = null;
+          this.state = this.isPreLoop ? 'configuring' : 'idle';
+          resolve(lower.toUpperCase());
+        }
+      };
+    });
+  }
+```
+
+- [ ] **Step 6: `stop`에 pendingKey cleanup 추가**
+
+`stop` 메서드(라인 25-36)의 끝부분 교체:
+
+변경 전:
+```ts
+  stop(): void {
+    if (!this.started) return;
+    if (this.onDataBound) {
+      process.stdin.removeListener('data', this.onDataBound);
+      this.onDataBound = null;
+    }
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(false);
+    }
+    process.stdin.pause();
+    this.started = false;
+  }
+```
+
+변경 후:
+```ts
+  stop(): void {
+    if (!this.started) return;
+    if (this.onDataBound) {
+      process.stdin.removeListener('data', this.onDataBound);
+      this.onDataBound = null;
+    }
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(false);
+    }
+    process.stdin.pause();
+    this.pendingKey = null;
+    this.started = false;
+  }
+```
+
+- [ ] **Step 7: 테스트 실행 → 통과 확인**
+
+```bash
+pnpm -s vitest run tests/input.test.ts
+```
+Expected: 전체 input 테스트 green (기존 7개 + 신규 5개 = 12 이상).
+
+- [ ] **Step 8: TypeScript 빌드 확인**
+
+```bash
+pnpm -s tsc --noEmit
+```
+Expected: 에러 없음.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/input.ts tests/input.test.ts
+git commit -m "fix(input): buffer pre-emptive keystrokes to avoid drops at prompts"
+```
+
+---
+
+## Task 4: 최종 전체 검증
+
+- [ ] **Step 1: 전체 테스트 스위트 실행**
+
+```bash
+pnpm -s vitest run
+```
+Expected: 전체 green, fail 0. 이전 수(427) 이상.
+
+- [ ] **Step 2: 린트 통과 확인**
+
+```bash
+pnpm -s lint
+```
+Expected: 에러 0.
+
+- [ ] **Step 3: TypeScript 최종 확인**
+
+```bash
+pnpm -s tsc --noEmit
+```
+Expected: 에러 0.
+
+- [ ] **Step 4: 커밋 히스토리 확인**
+
+```bash
+git log --oneline -6
+```
+Expected: 최근 3 fix 커밋 + 1 spec 커밋 + PR 머지 커밋.
+
+---
+
+## Eval Checklist
+
+### Objective criteria (기계 검증)
+
+- [ ] **EC-1**: `pnpm -s tsc --noEmit` exit 0
+  - Pass: stdout 비어있음 + exit 0
+- [ ] **EC-2**: `pnpm -s lint` exit 0
+  - Pass: error 0
+- [ ] **EC-3**: `pnpm -s vitest run` 전체 통과
+  - Pass: fail 0, 총 테스트 수 ≥ 432 (427 baseline + 최소 5 신규)
+- [ ] **EC-4**: #4 env 격리 문구 반영
+  - Command: `grep -n "격리된 셸 환경" src/context/prompts/phase-3.md`
+  - Pass: 1 hit
+- [ ] **EC-5**: #10 advisor reminder 이동 완료 (원 위치 삭제)
+  - Command: `grep -n "setTimeout(resolve, 300)" src/phases/interactive.ts || echo "clean"`
+  - Pass: "clean" 또는 0 hits
+- [ ] **EC-6**: #10 advisor reminder가 Claude 분기 안에 위치
+  - Command: `awk '/if \(preset.runner === .claude.\)/,/waitForPhaseCompletion/' src/phases/interactive.ts | grep -c printAdvisorReminder`
+  - Pass: 1
+- [ ] **EC-7**: #11 pendingKey 슬롯 선언됨
+  - Command: `grep -n "pendingKey: PendingKey" src/input.ts`
+  - Pass: 1 hit
+- [ ] **EC-8**: #11 TTL 상수 선언됨
+  - Command: `grep -n "PENDING_KEY_TTL_MS" src/input.ts`
+  - Pass: 최소 2 hits (선언 1 + 사용 1)
+- [ ] **EC-9**: #11 onData 버퍼링 분기 존재
+  - Command: `grep -n "this.pendingKey = { key: str" src/input.ts`
+  - Pass: 1 hit
+- [ ] **EC-10**: Interactive reminder 순서 테스트 pass
+  - Command: `pnpm -s vitest run tests/phases/interactive.test.ts -t "advisor reminder"`
+  - Pass: 1 passed (describe 이름 변경 포함)
+- [ ] **EC-11**: Input pendingKey 테스트 pass
+  - Command: `pnpm -s vitest run tests/input.test.ts -t "pendingKey buffer"`
+  - Pass: 5 passed
+- [ ] **EC-12**: Spec 링크 유효
+  - Command: `test -f docs/specs/2026-04-18-dogfood-ux-quickwins-2-design.md`
+  - Pass: exit 0
+
+### Spec traceability
+
+| Spec section | 요구사항 | 구현 태스크 | 검증 EC |
+|--------------|----------|-------------|---------|
+| §2/§4.1 #4 env 격리 | phase-3.md 한 문장 추가 | Task 1 | EC-4 |
+| §2/§4.2 #10 reminder 이동 | interactive.ts 호출 위치 + 테스트 반전 | Task 2 | EC-5, EC-6, EC-10 |
+| §2/§4.3 #11 pendingKey | input.ts 필드/TTL/onData/waitForKey/stop | Task 3 | EC-7, EC-8, EC-9, EC-11 |
+| §5 테스트 전략 | 회귀 green | Task 4 | EC-1, EC-2, EC-3 |
+
+### Subjective criteria
+
+- [ ] **SC-1**: 세 변경이 서로 간섭 없이 적용됨 (파일 면 분리: prompts, interactive.ts, input.ts)
+- [ ] **SC-2**: 커밋 3개가 이슈 단위로 분리됨, 각 타이틀이 해당 이슈를 정확히 기술
+- [ ] **SC-3**: #11 TTL 1000ms이 주석으로 의도 명시 (pre-emptive window)
+- [ ] **SC-4**: 수동 smoke (optional) — 실제 escalation 프롬프트에서 pre-emptive `S`/`C`/`Q` 입력이 첫 키에 반응
+
+---
+
+## Notes for Implementer
+
+- Task 1은 TDD 불필요(정적 텍스트). Task 2/3만 TDD.
+- Task 2의 assertion 반전은 상대 순서 비교(`toBeGreaterThan`). invocationCallOrder는 전역 카운터라 여러 테스트에서 값이 누적되지만, 각 테스트에서 `mockClear()`로 리셋 후 `mock.invocationCallOrder` 배열은 해당 테스트 호출만 포함.
+- Task 3 테스트에서 `(im as any).handler?.('s')`로 handler를 직접 invoke하는 이유: TTY 없는 환경에서 `onData`를 호출해도 handler가 set되기 전에 state 전이가 완료되어 의도한 경로를 재현하기 위함. handler는 `waitForKey`가 set하므로 Promise 생성 직후 `.then(resolve)` 이전에 호출 가능.
+- 커밋 메시지는 `fix(<scope>): <imperative>` 형식 유지.
+- resume 작업 코드 면(`src/runners/codex.ts`, `src/phases/gate.ts`, `src/phases/runner.ts`, `src/commands/inner.ts`, `src/signal.ts`, `src/state.ts`, `src/types.ts`, `src/context/assembler.ts`)은 건드리지 말 것.

--- a/docs/specs/2026-04-18-dogfood-ux-quickwins-2-design.md
+++ b/docs/specs/2026-04-18-dogfood-ux-quickwins-2-design.md
@@ -1,0 +1,342 @@
+# Dog-Fooding UX Quick-Wins 2 — Design Spec
+
+- 상태: draft
+- 작성일: 2026-04-18
+- 담당: Claude Code (engineer)
+- 관련 문서:
+  - 근거 QA 관찰: `qa-observations.md` (#4, #10, #11)
+  - 이전 번들: `docs/specs/2026-04-18-dogfood-ux-quickwins-design.md`
+  - Impl plan: `docs/plans/2026-04-18-dogfood-ux-quickwins-2.md` (작성 예정)
+  - Eval report: `docs/process/evals/2026-04-18-dogfood-ux-quickwins-2-eval.md` (작성 예정)
+
+## 1. 배경과 목표
+
+1차 quickwins 번들(pane ratio, sentinel contract, slug cap)이 main에 머지된 이후, resume 작업과 무관한 다음 독립 후보 3건을 한 번에 묶어 처리한다.
+
+**범위에 포함**:
+
+- **#4**: Phase 3 plan이 venv 밖 `pytest -q` 같은 env-naive checklist를 생성해 Phase 6 verify가 전체 fail.
+- **#10**: Advisor reminder가 `printAdvisorReminder`를 Claude dispatch **전**에 호출 → 워크스페이스 pane 활동(Ctrl+C, 래퍼 명령 타이핑)에 주의가 먼저 쏠려 리마인더가 "이미 작업 시작 후 등장한 것처럼" 인지됨.
+- **#11**: Escalation 단일키(`S`/`C`/`Q`)가 때때로 첫 입력에서 반응 안 함. 원인: `InputManager.onData`가 `state === 'idle'` 시 키를 드롭 → 사용자가 프롬프트 표시 직후/직전 키를 누르면 첫 키 유실.
+
+**비목표**:
+
+- Resume 작업 코드 면(`src/runners/codex.ts`, `src/phases/gate.ts`, `src/phases/runner.ts`, `src/commands/inner.ts`, `src/signal.ts`, `src/state.ts`, `src/types.ts`, `src/context/assembler.ts`) 수정 전면 금지.
+- Verify 스크립트(`scripts/harness-verify.sh`) 확장(#4 B안, checklist schema `setup` 필드). 본 작업은 프롬프트 제약만.
+- Advisor 워크플로 근본 재설계(prompt-before-submit 지원 등). Reminder 배치만.
+- 입력 시스템 전면 재작성(readline 전환 등). pending-key 버퍼링만.
+
+**성공 기준**:
+
+- Python 프로젝트 dog-fooding run에서 Phase 6 초기 실행이 venv 경유해 pytest를 실행.
+- Claude dispatch 직후 (PID 확보 완료 시점) 컨트롤 pane에 advisor reminder가 출력되어, 사용자 행동 가능 시점과 시각적 alignment.
+- Escalation 프롬프트에서 첫 키스트로크가 유효 키이면 즉시 반응. Idle 상태 pre-emptive 입력(1초 이내)이 유실되지 않음.
+- 기존 테스트 전부 green, 회귀 0.
+
+## 2. Context & Decisions
+
+### 핵심 결정사항
+
+- **#4 plan prompt env constraint**: `src/context/prompts/phase-3.md`의 checklist 스키마 블록 바로 아래에 환경 격리 제약 한 문장 추가. 예:
+  > 각 check command는 격리된 셸 환경에서 실행된다. venv/node_modules 등 의존성을 요구하는 검증은 절대경로 바이너리(`.venv/bin/python -m pytest`, `./node_modules/.bin/eslint`)나 env-aware 래퍼(`make test`, `pnpm test`)를 사용하라.
+- **#10 advisor reminder 이동**: `src/phases/interactive.ts:198` (Claude dispatch 전 호출 + 300ms sleep)을 **제거**. 대신 Claude 경로의 `runClaudeInteractive` 반환 직후(`waitForPhaseCompletion` 호출 **전**) 같은 reminder 호출. Codex 경로는 변경 없음(`printAdvisorReminder`는 runner==='codex'에서 no-op).
+- **#11 pendingKey 버퍼**: `InputManager`에 `pendingKey: { key: string; timestamp: number } | null` 필드 추가. `onData`에서 `state === 'idle' || 'configuring'`이면서 printable 키일 때 이 슬롯에 저장(최근 1개). `waitForKey(validKeys)` 진입 시 슬롯 확인 → 유효키 + 1초 이내면 즉시 resolve, 아니면 슬롯 clear 후 기존 대기 로직.
+
+### 제약 조건
+
+- **Resume 작업 코드 면 회피**: `git diff main origin/codex-optimization -- src/` 기준 수정 파일(`src/types.ts`, `src/state.ts`, `src/context/assembler.ts` 등)은 건드리지 않음. 본 작업은 `src/context/prompts/phase-3.md`, `src/phases/interactive.ts`, `src/input.ts`만 수정 → 겹침 0.
+- **InputManager 하위 호환**: `pendingKey` 추가는 기존 `waitForKey`/`waitForLine` 동작을 idle 상태 드롭 이외에는 바꾸지 않는다. 기존 `tests/input.test.ts` 회귀 없음을 검증.
+- **Reminder 텍스트 의미론**: "Claude 세션이 시작된 뒤 /advisor 입력" 문구가 이미 "Claude 시작 후" 시점을 가리킨다 → 호출 위치를 시작 후로 옮기는 것이 문구 의도와 일치.
+
+### 해소된 모호성
+
+- **#10이 정말 "reminder가 뒤에 나온다"는 것이냐, "reminder가 미리 나오는데 놓친다"는 것이냐?**: 현 코드는 dispatch 전에 호출한다. 즉 "미리 나오지만 놓친다"가 정확. 원인은 Claude dispatch 과정에서 워크스페이스 pane에 연쇄 활동(prev PID kill → Ctrl+C → wrapper typing) 발생 → 사용자 주의가 워크스페이스로 이동. 본 결정의 이동은 **시각 주의 시점과 reminder 출력 시점을 정렬**하기 위함. Reminder 텍스트 의미론도 이 이동과 일치.
+- **`pendingKey` 타임스탬프 이유**: 타임스탬프 없이 슬롯만 두면, 몇 분 전 user가 눌러둔 유령 키가 새 프롬프트에서 consume될 위험. 1초 제한으로 "프롬프트 표시 직전 pre-emptive 입력"만 consume하고 이전 잔여는 무시.
+- **1초 기준 근거**: tmux pane render lag + stderr write + 사용자 반응 시간의 합. 보수적으로 500ms도 가능하나 1초가 안전. 향후 조정 가능한 상수.
+- **`promptChoice` API 불변**: `promptChoice` 호출부는 변경 없음. `waitForKey` 내부 슬롯 확인만 추가 → caller 영향 0.
+
+### 구현 시 주의사항
+
+- **#4**: phase-3.md에 추가하는 문구는 JSON 스키마 블록 바로 아래, `checks` 배열 검증 규칙 문장 **뒤**에 배치. 기존 CRITICAL sentinel 라인과 분리.
+- **#10**: interactive.ts의 호출 위치 이동 시, Codex 경로에서 호출하지 않는 기존 semantics 유지. 이동 지점이 여러 개면 (Claude 경로 내부로 이동) runClaudeInteractive 반환 직후가 가장 자연스러움. 300ms sleep 삭제(dispatch 관련 race 방지 목적이었으나 새 위치에선 불필요).
+- **#11**: `onData`에서 arrow keys/F-keys(`\x1b` 시작)는 기존처럼 건너뛰기. `\x7f`(backspace), `\x03`/`\x04`(Ctrl+C/D)는 기존 처리 유지. 슬롯에 저장할 키 조건: 상태가 idle/configuring이면서 printable ASCII(문자/숫자)인 단일 바이트.
+- **#11 타임스탬프 소스**: `Date.now()` — monotonic 아님에도 수 초 단위 비교엔 충분.
+
+## 3. 현 구조 분석
+
+### 관련 파일과 역할
+
+| 파일 | 현 역할 | 본 작업에서의 변경 |
+|------|---------|--------------------|
+| `src/context/prompts/phase-3.md` | Phase 3(plan 작성) 프롬프트 템플릿 | checks 스키마 직후 env 격리 제약 한 문장 추가 |
+| `src/phases/interactive.ts` | Phase 1/3/5 interactive 디스패치, advisor reminder 호출 | 리마인더 호출을 runClaudeInteractive 반환 직후로 이동, 기존 300ms sleep 제거 |
+| `src/input.ts` | InputManager: raw-mode stdin, waitForKey/waitForLine | `pendingKey` 슬롯 추가, `onData`에서 idle/configuring 키 버퍼링, `waitForKey`에서 슬롯 확인 후 즉시 resolve 경로 추가 |
+| `tests/input.test.ts` | InputManager 단위 테스트 | pendingKey 신규 case 추가 (pre-emptive key 유효 vs stale 유령 키) |
+| `tests/phases/interactive.test.ts` | Interactive phase 테스트 (advisor reminder 관련 2 케이스 포함) | reminder 호출 순서 테스트 갱신 (sendKeysToPane **후** 호출) |
+
+### 현 호출 흐름 (변경 전)
+
+```
+runInteractivePhase(claude)
+  printAdvisorReminder(phase, 'claude')   ← 현재 위치
+  await setTimeout(300)
+  runClaudeInteractive(...)
+    killPrev? → sendKeysToPane(C-c) → sleep500 → sendKeysToPane(wrappedCmd)
+    pollForPidFile
+  waitForPhaseCompletion(...)
+```
+
+### 변경 후
+
+```
+runInteractivePhase(claude)
+  runClaudeInteractive(...)
+    killPrev? → sendKeysToPane(C-c) → sleep500 → sendKeysToPane(wrappedCmd)
+    pollForPidFile
+  printAdvisorReminder(phase, 'claude')   ← 새 위치
+  waitForPhaseCompletion(...)
+```
+
+Codex 경로는 `runCodexInteractive` 내부에서 동작이 다르고 reminder가 no-op이므로 변경 없음.
+
+## 4. 설계 상세
+
+### 4.1 #4 Plan prompt env 격리 제약
+
+**변경 위치**: `src/context/prompts/phase-3.md:17` 뒤(검증 규칙 문장 다음).
+
+**추가 문장**:
+
+```
+각 check command는 격리된 셸 환경에서 실행된다. venv/node_modules 등 의존성을 요구하는 검증은 절대경로 바이너리(`.venv/bin/python -m pytest`, `./node_modules/.bin/eslint`)나 env-aware 래퍼(`make test`, `pnpm test`)를 사용하라.
+```
+
+배치 예 (변경 후 전체):
+
+```markdown
+...
+`checks` 배열은 비어있지 않아야 하며 각 항목에 `name`(string)과 `command`(string)이 필수다.
+
+각 check command는 격리된 셸 환경에서 실행된다. venv/node_modules 등 의존성을 요구하는 검증은 절대경로 바이너리(`.venv/bin/python -m pytest`, `./node_modules/.bin/eslint`)나 env-aware 래퍼(`make test`, `pnpm test`)를 사용하라.
+
+`.harness/{{runId}}/phase-3.done` 파일을 생성하되 내용으로 '{{phaseAttemptId}}' 한 줄만 기록하라.
+...
+```
+
+**테스트**: 프롬프트는 정적 텍스트 → 현 테스트가 문자열을 assert하지 않음(기존 확인). 회귀 없음. 실제 동작 검증은 다음 dog-fooding run으로 확인.
+
+### 4.2 #10 Advisor reminder 위치 이동
+
+**변경 위치**: `src/phases/interactive.ts`의 `runInteractivePhase` Claude 분기.
+
+**변경 전** (라인 197-211 근방):
+
+```ts
+  printAdvisorReminder(phase, preset.runner);
+  await new Promise<void>((resolve) => setTimeout(resolve, 300));
+
+  // Dispatch to runner
+  if (preset.runner === 'claude') {
+    const { pid: claudePid } = await runClaudeInteractive(
+      phase, updatedState, preset, harnessDir, runDir, promptFile,
+    );
+    const sentinelPath = path.join(runDir, `phase-${phase}.done`);
+    const resolvedAttemptId = updatedState.phaseAttemptId[String(phase)] ?? attemptId;
+    const result = await waitForPhaseCompletion(
+      sentinelPath, resolvedAttemptId, claudePid, phase, updatedState, cwd, runDir
+    );
+    return { ...result, attemptId };
+  } else {
+    // Codex runner
+    ...
+  }
+```
+
+**변경 후**:
+
+```ts
+  // Dispatch to runner
+  if (preset.runner === 'claude') {
+    const { pid: claudePid } = await runClaudeInteractive(
+      phase, updatedState, preset, harnessDir, runDir, promptFile,
+    );
+    printAdvisorReminder(phase, preset.runner);  // 이동된 호출
+    const sentinelPath = path.join(runDir, `phase-${phase}.done`);
+    const resolvedAttemptId = updatedState.phaseAttemptId[String(phase)] ?? attemptId;
+    const result = await waitForPhaseCompletion(
+      sentinelPath, resolvedAttemptId, claudePid, phase, updatedState, cwd, runDir
+    );
+    return { ...result, attemptId };
+  } else {
+    // Codex runner — reminder no-op for codex, call omitted
+    ...
+  }
+```
+
+기존 `printAdvisorReminder(phase, preset.runner);` + `await setTimeout(300);` 두 줄을 Claude 분기 안으로 옮김. Codex 경로는 reminder 호출 자체가 없어졌지만 기존에도 no-op이었으므로 동작 동일.
+
+**테스트 영향**: `tests/phases/interactive.test.ts`의 "printAdvisorReminder is called before sendKeysToPane" 테스트가 **반대 기대**로 바뀜. 신규 기대: `sendKeysToPane` **후** `printAdvisorReminder` 호출 순서 + "sendKeysToPane command includes --dangerously-skip-permissions and --effort" 테스트는 그대로 유효.
+
+### 4.3 #11 pendingKey 슬롯
+
+**변경 위치**: `src/input.ts` InputManager 클래스 전체.
+
+**타입 정의**:
+
+```ts
+interface PendingKey {
+  key: string;
+  timestamp: number;
+}
+```
+
+**새 필드**:
+
+```ts
+private pendingKey: PendingKey | null = null;
+private static readonly PENDING_KEY_TTL_MS = 1000;
+```
+
+**`onData` 변경**:
+
+```ts
+private onData(buf: Buffer): void {
+  const str = buf.toString();
+
+  if (str === '\x03' || str === '\x04') {
+    if (this.isPreLoop) {
+      this.onConfigCancel?.();
+    } else {
+      process.kill(process.pid, 'SIGINT');
+    }
+    return;
+  }
+
+  if (str.startsWith('\x1b')) return;
+
+  // NEW: idle/configuring 상태 pre-emptive 키 버퍼링
+  if (this.state === 'idle' || this.state === 'configuring') {
+    // 단일 printable ASCII 문자만 (multibyte/연타 버퍼는 제외)
+    if (str.length === 1 && str.charCodeAt(0) >= 0x20 && str.charCodeAt(0) < 0x7f) {
+      this.pendingKey = { key: str, timestamp: Date.now() };
+    }
+    return;
+  }
+
+  this.handler?.(str);
+}
+```
+
+**`waitForKey` 변경**:
+
+```ts
+waitForKey(validKeys: Set<string>): Promise<string> {
+  return new Promise((resolve) => {
+    this.state = 'prompt-single';
+
+    // NEW: pending key 확인
+    if (this.pendingKey !== null) {
+      const { key, timestamp } = this.pendingKey;
+      this.pendingKey = null;
+      if (
+        Date.now() - timestamp <= InputManager.PENDING_KEY_TTL_MS &&
+        validKeys.has(key.toLowerCase())
+      ) {
+        this.state = this.isPreLoop ? 'configuring' : 'idle';
+        resolve(key.toLowerCase().toUpperCase());
+        return;
+      }
+    }
+
+    this.handler = (key: string) => {
+      const lower = key.toLowerCase();
+      if (validKeys.has(lower)) {
+        this.handler = null;
+        this.state = this.isPreLoop ? 'configuring' : 'idle';
+        resolve(lower.toUpperCase());
+      }
+    };
+  });
+}
+```
+
+**`waitForLine` 변경 없음**: line-based 입력은 이 이슈와 무관.
+
+**`stop()` 변경**:
+
+```ts
+stop(): void {
+  // ...기존...
+  this.pendingKey = null;  // NEW: cleanup
+  this.started = false;
+}
+```
+
+### 4.4 테스트 설계
+
+**#11 단위 테스트 신규** (`tests/input.test.ts`):
+
+- `waitForKey resolves immediately with pending key pressed during idle`
+  - InputManager start, state=idle 상태에서 onData('s') 주입, 이후 waitForKey({'s','c','q'}) → 즉시 'S' resolve.
+- `waitForKey ignores stale pending key older than TTL`
+  - onData('s') 주입, 1.1초 대기(fake timer로 Date.now() 시뮬), waitForKey → pending 무시, 새 키 대기.
+- `waitForKey ignores pending key outside validKeys`
+  - onData('x') 주입, waitForKey({'s','c','q'}) → pending 폐기, 새 키 대기.
+- `onData does not buffer control chars/ESC in pending`
+  - onData('\x1b') → pendingKey null 유지.
+- `waitForKey normal path unchanged when no pending`
+  - waitForKey 진입 후 onData('s') → 'S' resolve (기존 동작 회귀 없음).
+
+**#10 기존 테스트 갱신** (`tests/phases/interactive.test.ts`):
+
+- describe 블록 이름 `runInteractivePhase — advisor reminder fires before sendKeysToPane` → `... fires after runClaudeInteractive`로 갱신.
+- 내부 it 이름 `printAdvisorReminder is called before sendKeysToPane` → `printAdvisorReminder is called after all sendKeysToPane calls`.
+- assertion 갱신: `sendKeysToPane`이 여러 번 호출되므로(C-c pre-clear, wrapped cmd) **마지막** invocationCallOrder와 reminder의 invocationCallOrder 비교. 구체:
+  ```ts
+  const reminderOrder = vi.mocked(printAdvisorReminder).mock.invocationCallOrder[0];
+  const sendKeysCalls = vi.mocked(sendKeysToPane).mock.invocationCallOrder;
+  const lastSendKeysOrder = sendKeysCalls[sendKeysCalls.length - 1];
+  expect(reminderOrder).toBeGreaterThan(lastSendKeysOrder);
+  ```
+- 기존 "sendKeysToPane command includes --dangerously-skip-permissions and --effort" 변경 없음.
+
+**#4 테스트**: 정적 프롬프트 텍스트 변경. 추가 단위 테스트 불필요. 원하면 `tests/context/`에 phase-3.md가 env 제약 문구를 포함하는지 grep 스타일 assertion 1개 추가(선택).
+
+## 5. 테스트 전략
+
+### 5.1 단위 테스트
+
+- **#4**: (선택) `tests/context/` 계열에 phase-3.md 로드 후 env 제약 문구 포함 검증 1건. 없어도 회귀 없음.
+- **#10**: `tests/phases/interactive.test.ts` — sendKeysToPane 후 printAdvisorReminder 순서 검증.
+- **#11**: `tests/input.test.ts` — 5 신규 케이스.
+
+### 5.2 회귀
+
+- `pnpm -s vitest run` 전체 green.
+- `pnpm -s tsc --noEmit` 에러 0.
+- `pnpm -s lint` 에러 0.
+
+### 5.3 수동 smoke
+
+- Python 태스크 dog-fooding run에서 Phase 3 생성한 checklist가 `.venv/bin/` 접두어 또는 `make test` 쓰는지 확인(선택).
+- 실제 escalation 프롬프트에서 pre-emptive 키 입력 테스트(선택).
+
+## 6. 마이그레이션 및 호환성
+
+- Phase 3 프롬프트 텍스트 변경은 기존 외부 코드 영향 없음.
+- InputManager 변경은 내부 동작만, 공개 API 불변(`waitForKey`, `waitForLine` 시그니처 동일).
+- Interactive phase 호출 흐름은 interactive.ts 내부 구조만 변경, 외부 caller(`runPhaseLoop` 등)에 영향 없음.
+
+## 7. YAGNI / 범위 밖
+
+본 작업 **포함하지 않음**:
+
+- Checklist 스키마에 `setup` 필드 도입(#4 B안). harness-verify.sh 변경 필요.
+- Advisor 워크플로 근본 재설계 (pre-submit interactive phase 등).
+- InputManager의 readline 기반 재작성.
+- ESC sequence / arrow key 처리 확장.
+- 1차 quickwins에서 다룬 영역 추가 수정(pane ratio, sentinel contract, slug cap).
+
+## 8. Open Questions
+
+- 없음. 세 변경 모두 mechanism이 명확하고 원인 분석으로 결정 확정.

--- a/src/context/prompts/phase-3.md
+++ b/src/context/prompts/phase-3.md
@@ -16,6 +16,8 @@ eval checklist를 {{checklist_path}}에 아래 JSON 스키마로 저장하라:
 ```
 `checks` 배열은 비어있지 않아야 하며 각 항목에 `name`(string)과 `command`(string)이 필수다.
 
+각 check command는 격리된 셸 환경에서 실행된다. venv/node_modules 등 의존성을 요구하는 검증은 절대경로 바이너리(`.venv/bin/python -m pytest`, `./node_modules/.bin/eslint`)나 env-aware 래퍼(`make test`, `pnpm test`)를 사용하라.
+
 `.harness/{{runId}}/phase-3.done` 파일을 생성하되 내용으로 '{{phaseAttemptId}}' 한 줄만 기록하라.
 
 **CRITICAL: sentinel 파일(phase-3.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 이후 하네스는 다음 단계(리뷰/피드백)로 넘어가므로 추가 작업을 하지 말 것.**

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,11 +1,18 @@
 type InputState = 'idle' | 'configuring' | 'prompt-single' | 'prompt-line';
 
+interface PendingKey {
+  key: string;
+  timestamp: number;
+}
+
 export class InputManager {
   private state: InputState = 'idle';
   private isPreLoop: boolean = true;
   private handler: ((key: string) => void) | null = null;
   private onDataBound: ((buf: Buffer) => void) | null = null;
   private started = false;
+  private pendingKey: PendingKey | null = null;
+  private static readonly PENDING_KEY_TTL_MS = 1000;
 
   public onConfigCancel: (() => void) | null = null;
 
@@ -32,6 +39,7 @@ export class InputManager {
       process.stdin.setRawMode(false);
     }
     process.stdin.pause();
+    this.pendingKey = null;
     this.started = false;
   }
 
@@ -47,6 +55,21 @@ export class InputManager {
   waitForKey(validKeys: Set<string>): Promise<string> {
     return new Promise((resolve) => {
       this.state = 'prompt-single';
+
+      // Consume pending key from idle-state buffer if still fresh and valid.
+      if (this.pendingKey !== null) {
+        const { key, timestamp } = this.pendingKey;
+        this.pendingKey = null;
+        if (
+          Date.now() - timestamp <= InputManager.PENDING_KEY_TTL_MS &&
+          validKeys.has(key.toLowerCase())
+        ) {
+          this.state = this.isPreLoop ? 'configuring' : 'idle';
+          resolve(key.toLowerCase().toUpperCase());
+          return;
+        }
+      }
+
       this.handler = (key: string) => {
         const lower = key.toLowerCase();
         if (validKeys.has(lower)) {
@@ -94,8 +117,15 @@ export class InputManager {
     // ESC sequences (arrow keys, F-keys, etc.)
     if (str.startsWith('\x1b')) return;
 
-    // Idle/configuring without active prompt
-    if (this.state === 'idle' || this.state === 'configuring') return;
+    // Idle/configuring without active prompt — buffer single printable ASCII
+    // so a pre-emptive keystroke (typed while escalation prompt was printing)
+    // is not lost on the next waitForKey.
+    if (this.state === 'idle' || this.state === 'configuring') {
+      if (str.length === 1 && str.charCodeAt(0) >= 0x20 && str.charCodeAt(0) < 0x7f) {
+        this.pendingKey = { key: str, timestamp: Date.now() };
+      }
+      return;
+    }
 
     // Forward to active handler
     this.handler?.(str);

--- a/src/phases/interactive.ts
+++ b/src/phases/interactive.ts
@@ -195,14 +195,12 @@ export async function runInteractivePhase(
   const promptFile = path.join(runDir, `phase-${phase}-init-prompt.md`);
   fs.writeFileSync(promptFile, prompt, 'utf-8');
 
-  printAdvisorReminder(phase, preset.runner);
-  await new Promise<void>((resolve) => setTimeout(resolve, 300));
-
   // Dispatch to runner
   if (preset.runner === 'claude') {
     const { pid: claudePid } = await runClaudeInteractive(
       phase, updatedState, preset, harnessDir, runDir, promptFile,
     );
+    printAdvisorReminder(phase, preset.runner);
     const sentinelPath = path.join(runDir, `phase-${phase}.done`);
     const resolvedAttemptId = updatedState.phaseAttemptId[String(phase)] ?? attemptId;
     const result = await waitForPhaseCompletion(
@@ -210,7 +208,7 @@ export async function runInteractivePhase(
     );
     return { ...result, attemptId };
   } else {
-    // Codex runner
+    // Codex runner — printAdvisorReminder is a no-op for codex, omit call
     const { runCodexInteractive } = await import('../runners/codex.js');
     const result = await runCodexInteractive(
       phase, updatedState, preset, harnessDir, runDir, promptFile, cwd,

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -51,3 +51,55 @@ describe('InputManager', () => {
     // Verified indirectly: method doesn't throw
   });
 });
+
+describe('InputManager — pendingKey buffer', () => {
+  it('waitForKey resolves immediately with pending key pressed during idle', async () => {
+    const im = new InputManager();
+    im.enterPhaseLoop(); // state -> idle
+    // Inject a key while idle (private onData via any-cast)
+    (im as any).onData(Buffer.from('s'));
+    const key = await im.waitForKey(new Set(['s', 'c', 'q']));
+    expect(key).toBe('S');
+  });
+
+  it('waitForKey ignores pending key outside validKeys', async () => {
+    const im = new InputManager();
+    im.enterPhaseLoop();
+    (im as any).onData(Buffer.from('x'));
+    // pending is 'x' which is not valid; waitForKey should clear it and wait.
+    const p = im.waitForKey(new Set(['s', 'c', 'q']));
+    (im as any).handler?.('s');
+    const key = await p;
+    expect(key).toBe('S');
+  });
+
+  it('waitForKey ignores stale pending key older than TTL', async () => {
+    const im = new InputManager();
+    im.enterPhaseLoop();
+    (im as any).onData(Buffer.from('s'));
+    // Manually age the pending entry beyond TTL (1000ms)
+    (im as any).pendingKey.timestamp = Date.now() - 2000;
+    const p = im.waitForKey(new Set(['s', 'c', 'q']));
+    (im as any).handler?.('c');
+    const key = await p;
+    expect(key).toBe('C');
+  });
+
+  it('onData does not buffer ESC sequences or control chars in pending', () => {
+    const im = new InputManager();
+    im.enterPhaseLoop();
+    (im as any).onData(Buffer.from('\x1b[A')); // arrow up
+    expect((im as any).pendingKey).toBeNull();
+    (im as any).onData(Buffer.from('\x7f')); // DEL
+    expect((im as any).pendingKey).toBeNull();
+  });
+
+  it('waitForKey normal path unchanged when no pending', async () => {
+    const im = new InputManager();
+    im.enterPhaseLoop();
+    const p = im.waitForKey(new Set(['s', 'c', 'q']));
+    (im as any).handler?.('q');
+    const key = await p;
+    expect(key).toBe('Q');
+  });
+});

--- a/tests/phases/interactive.test.ts
+++ b/tests/phases/interactive.test.ts
@@ -573,8 +573,8 @@ describe('validatePhaseArtifacts — Phase 5', () => {
 
 // ─── runInteractivePhase: advisor reminder ordering ──────────────────────────
 
-describe('runInteractivePhase — advisor reminder fires before sendKeysToPane', () => {
-  it('printAdvisorReminder is called before sendKeysToPane', async () => {
+describe('runInteractivePhase — advisor reminder fires after runClaudeInteractive', () => {
+  it('printAdvisorReminder is called after all sendKeysToPane calls', async () => {
     const { sendKeysToPane } = await import('../../src/tmux.js');
     const { printAdvisorReminder } = await import('../../src/ui.js');
     const { runInteractivePhase } = await import('../../src/phases/interactive.js');
@@ -593,12 +593,14 @@ describe('runInteractivePhase — advisor reminder fires before sendKeysToPane',
     await runInteractivePhase(1, state, harnessDir, runDir, repoDir, 'test-attempt-id');
 
     const reminderOrder = vi.mocked(printAdvisorReminder).mock.invocationCallOrder[0];
-    // sendKeysToPane is called twice: C-c pre-clear, then the actual command
-    const sendKeysToPaneOrder = vi.mocked(sendKeysToPane).mock.invocationCallOrder[0];
+    // sendKeysToPane is called multiple times (C-c pre-clear, wrapped cmd);
+    // reminder should fire after all of them (post-dispatch).
+    const sendKeysCalls = vi.mocked(sendKeysToPane).mock.invocationCallOrder;
+    const lastSendKeysOrder = sendKeysCalls[sendKeysCalls.length - 1];
 
     expect(reminderOrder).toBeDefined();
-    expect(sendKeysToPaneOrder).toBeDefined();
-    expect(reminderOrder).toBeLessThan(sendKeysToPaneOrder);
+    expect(lastSendKeysOrder).toBeDefined();
+    expect(reminderOrder).toBeGreaterThan(lastSendKeysOrder);
     expect(vi.mocked(printAdvisorReminder)).toHaveBeenCalledWith(1, 'claude');
   });
 


### PR DESCRIPTION
## Summary

Three resume-independent fixes identified in the 2026-04-18 todo-manager dog-fooding run (`qa-observations.md` #4, #10, #11):

- **`fix(prompts)`** — Phase 3 plan prompt gains env-isolation constraint (absolute-path binaries or env-aware wrappers) so generated checklists don't fail under `harness-verify.sh`'s isolated shell (prior Python run: `pytest -q` → exit 127, 24/24 fail).
- **`fix(interactive)`** — `printAdvisorReminder` moves from pre-dispatch to after `runClaudeInteractive` returns, aligning reminder visibility with the moment user can act. Matches the reminder text ("Claude 세션이 시작된 뒤 /advisor 입력").
- **`fix(input)`** — `InputManager` gains a 1s-TTL pending-key buffer so pre-emptive keystrokes pressed while escalation prompt is rendering are not dropped at state=idle.

Resume-work codepaths (`src/runners/codex.ts`, `src/phases/gate.ts`, `src/phases/runner.ts`, `src/commands/inner.ts`, `src/signal.ts`, `src/state.ts`, `src/types.ts`, `src/context/assembler.ts`) are intentionally untouched.

## Test Plan

- [x] `pnpm -s vitest run` → 432 passed, 1 skipped, 0 fail (prev baseline 427 + 5 new `pendingKey` cases)
- [x] `pnpm -s lint` → clean
- [x] `pnpm -s tsc --noEmit` → clean
- [x] EC checklist (plan §Eval Checklist) EC-1..EC-12 verified
- [ ] Manual smoke: dog-fooding a Python project → Phase 3 generates `.venv/bin/...` style check commands
- [ ] Manual smoke: escalation prompt pre-emptive `S` key lands on first stroke