### PR TITLE
fix(codex): extract metadata from stderr, unblocks PR #6 resume

### DIFF
--- a/src/phases/verdict.ts
+++ b/src/phases/verdict.ts
@@ -38,11 +38,25 @@ export function parseVerdict(
   return { verdict, comments };
 }
 
-export function extractCodexMetadata(stdout: string): { tokensTotal?: number; codexSessionId?: string } {
+/**
+ * Extract `tokens used` and `session id:` metadata from a Codex `exec` run.
+ *
+ * Codex writes these lines to STDERR (alongside its banner and `hook:` lines), not
+ * stdout — stdout contains only the model's final answer text. Earlier versions of
+ * this helper scanned stdout only, which silently failed for real subprocess runs
+ * (the regexes never matched) while unit tests passed because fixtures stuffed
+ * metadata into the stdout argument. Scan both streams so the helper is robust to
+ * either wiring.
+ */
+export function extractCodexMetadata(
+  stdout: string,
+  stderr: string = ''
+): { tokensTotal?: number; codexSessionId?: string } {
   const out: { tokensTotal?: number; codexSessionId?: string } = {};
-  const m = stdout.match(/^tokens used\s*\n([\d,]+)/m);
+  const combined = stderr.length > 0 ? `${stdout}\n${stderr}` : stdout;
+  const m = combined.match(/^tokens used\s*\n([\d,]+)/m);
   if (m) out.tokensTotal = parseInt(m[1].replace(/,/g, ''), 10);
-  const s = stdout.match(/session id:\s*([0-9a-f-]+)/i);
+  const s = combined.match(/session id:\s*([0-9a-f-]+)/i);
   if (s) out.codexSessionId = s[1];
   return out;
 }

--- a/src/runners/codex.ts
+++ b/src/runners/codex.ts
@@ -279,7 +279,8 @@ function rawToResult(
   resumedFrom: string | null,
   resumeFallback: boolean,
 ): GatePhaseResult {
-  const metadata = extractCodexMetadata(raw.stdout);
+  // Codex metadata (session id + tokens used) lands on STDERR, so pass both streams.
+  const metadata = extractCodexMetadata(raw.stdout, raw.stderr);
   const sourcePreset = { model: preset.model, effort: preset.effort };
 
   if (raw.category === 'success_verdict') {
@@ -337,7 +338,7 @@ export async function runCodexGate(
       // mistake it for a new fresh id and re-persist the dead lineage. We
       // preserve tokensTotal (useful for accounting) but drop codexSessionId
       // explicitly. resumedFrom still records the stale id for audit/logging.
-      const firstMeta = extractCodexMetadata(first.stdout);
+      const firstMeta = extractCodexMetadata(first.stdout, first.stderr);
       return {
         type: 'error',
         error: `Resume fallback failed: ${freshPrompt.error}`,

--- a/tests/phases/verdict.test.ts
+++ b/tests/phases/verdict.test.ts
@@ -26,4 +26,42 @@ more blah`;
     const stdout = `Session ID: 0123-4567-89ab`;
     expect(extractCodexMetadata(stdout).codexSessionId).toBe('0123-4567-89ab');
   });
+
+  // Real Codex `exec` wiring: the metadata lines (`session id:`, `tokens used`) land
+  // on STDERR while stdout carries only the model's final answer. These regressions
+  // cover the case the runner actually encounters.
+  it('parses metadata when it lives on stderr (matches real codex exec wiring)', () => {
+    const stdout = 'REJECT\n';
+    const stderr = [
+      'OpenAI Codex v0.121.0 (research preview)',
+      '--------',
+      'session id: 019d9f82-8d29-78d2-a06c-1225569879fe',
+      '--------',
+      'user',
+      'some prompt',
+      '',
+      'hook: Stop Completed',
+      'tokens used',
+      '18,443',
+    ].join('\n');
+    const result = extractCodexMetadata(stdout, stderr);
+    expect(result.tokensTotal).toBe(18443);
+    expect(result.codexSessionId).toBe('019d9f82-8d29-78d2-a06c-1225569879fe');
+  });
+
+  it('prefers stdout matches over stderr when both present', () => {
+    // Belt-and-suspenders: if a future Codex release moves metadata to stdout, do not
+    // silently drop the newer signal. Current regex matches the first occurrence; stdout
+    // comes first in the combined string so it wins.
+    const stdout = 'session id: aaaa-bbbb-cccc\ntokens used\n100';
+    const stderr = 'session id: zzzz-yyyy-xxxx\ntokens used\n999';
+    const result = extractCodexMetadata(stdout, stderr);
+    expect(result.codexSessionId).toBe('aaaa-bbbb-cccc');
+    expect(result.tokensTotal).toBe(100);
+  });
+
+  it('backwards-compatible: stderr argument is optional', () => {
+    // Existing callers (and the original single-arg signature) must keep working.
+    expect(extractCodexMetadata('session id: 1234-5678').codexSessionId).toBe('1234-5678');
+  });
 });


### PR DESCRIPTION
## Summary
- \`extractCodexMetadata\`가 **stdout만** 스캔하고 있었는데, 실제 Codex \`exec\`는 \`session id:\` 배너와 \`tokens used\\n<N>\` 라인을 **STDERR**에 쓴다. stdout에는 모델 최종 답변만 담김 → 정규식이 실제 subprocess run에서 한 번도 매치된 적 없음.
- 단위 테스트가 stdout 필드에 메타데이터를 집어넣어 테스트하는 구조여서 bug가 **조용히 통과**되고 있었음.

## 파급 범위 — bug 1개가 아니라 3개
| 증상 | 원인 |
|---|---|
| \`gate_verdict\` events에 \`tokensTotal\` 항상 absent (qa-observations #9) | regex가 stdout 스캔 |
| \`codexSessionId\` null in all gate events | 동일 |
| **PR #6 resume 기능 완전 미작동** — 모든 retry가 fresh spawn | sessionId가 null이니 \`phaseCodexSessions[phase]\` 저장 안 됨 → Variant A resume path 비활성 |

### 실측 증거 — 2026-04-18 live run (\`~/.harness/sessions/5e057c6c8459/.../events.jsonl\`)
\`\`\`
Gate 2 retry 0: resumedFrom: null   ← 정상 (첫 호출)
Gate 2 retry 1: resumedFrom: null   ← BUG (retry 0 session을 resume해야 함)
Gate 2 retry 2: resumedFrom: null   ← BUG
\`\`\`
모든 gate event에 \`tokensTotal\`·\`codexSessionId\` 필드 absent.

### 진단 방법 (재현 가능)
\`\`\`bash
echo "Say ok" | codex exec --model gpt-5.4 -c model_reasoning_effort="low" --skip-git-repo-check - 1>/tmp/out 2>/tmp/err
cat /tmp/out   # ← "ok" 한 줄
cat /tmp/err   # ← session id:, tokens used, hook: 전부 여기
\`\`\`

## Fix
- \`extractCodexMetadata(stdout, stderr = '')\` — signature에 stderr 추가 (기본값 유지하여 단일 인자 호환성 보존).
- stdout + stderr 결합 버퍼 스캔. stdout을 앞에 둬서 Codex가 미래에 메타를 stdout으로 되돌려도 먼저 매치.
- \`src/runners/codex.ts\` 두 call site(\`rawToResult\`, resume fallback 분기) 모두 \`raw.stderr\`·\`first.stderr\` 전달.
- 회귀 테스트 3건 추가: 실 codex 와이어링 fixture (stderr에 메타), stdout 우선순위, 단일 인자 호환.

## Test plan
- [x] 회귀 테스트 7건 모두 pass (4 기존 + 3 신규): \`pnpm exec vitest run tests/phases/verdict.test.ts\`
- [x] 전체 테스트 스위트 pass (483 passed / 1 skipped)
- [x] 빌드 clean: \`pnpm build\` → \`tsc\` + copy-assets
- [x] **런타임 검증**: \`node -e "require('./dist/src/phases/verdict.js')...\` 실제 captured codex stderr에서 \`tokensTotal=18443\` + \`codexSessionId=019d9f82-...\` 추출 확인

## 권장 후속
- 이 fix 머지 후 \`experimental-todo\` 같은 dog-fooding run을 **재실행**해야 #1 gate 수렴 실험 데이터가 유효해짐. 현재 run은 resume이 꺼진 상태로 측정된 것이라 qa-observations #1 scope 판단에 사용 불가.
- \`docs/specs/2026-04-18-codex-session-resume-design.md\` §11 "기존 테스트되어 있음, 변경 없음" 기술은 이 bug 때문에 잘못된 전제였음. 후속 PR에서 spec 각주 추가 고려 (별도 scope).