### PR TITLE
fix: gate prompt hardening + phase-start logging

### DIFF
--- a/docs/plans/2026-04-18-gate-prompt-hardening.md
+++ b/docs/plans/2026-04-18-gate-prompt-hardening.md
@@ -1,0 +1,749 @@
+# Gate Prompt Hardening + phase-start Logging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/specs/2026-04-18-gate-prompt-hardening-design.md`
+
+**Goal:** Close three repeatable gate/phase defects (BUG-A lifecycle blind-spot, BUG-B auto-advisor, BUG-C external-convention bleed-through) and record preset identity on every phase boundary event so post-hoc token/wall-time attribution is possible.
+
+**Architecture:** Prompt-level fixes in `src/context/assembler.ts` and `src/context/prompts/phase-{1,3,5}.md`; typed-log extensions in `src/types.ts` wired through `src/phases/runner.ts`. No schema migration (event log v:1 is additive), no runtime behaviour change beyond what the reviewer/Claude see in prompts.
+
+**Tech Stack:** TypeScript (strict), vitest test suite, pnpm workspace, existing `assembleGatePrompt` / `assembleInteractivePrompt` entrypoints already covered by `tests/context/assembler.test.ts` and `tests/phases/runner.test.ts`.
+
+**Scope note:** Each task ends with `pnpm vitest run <path>` and a commit. Final task runs the full suite + `pnpm tsc --noEmit` + `pnpm build` before the PR.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/context/assembler.ts` | Modify | Extend `REVIEWER_CONTRACT` with scope rules; add `buildLifecycleContext(phase)` helper; wire it into `buildGatePromptPhase{2,4,7}`. |
+| `src/context/prompts/phase-1.md` | Modify | Append `HARNESS FLOW CONSTRAINT` stanza (no advisor). |
+| `src/context/prompts/phase-3.md` | Modify | Append `HARNESS FLOW CONSTRAINT` stanza (no advisor). |
+| `src/context/prompts/phase-5.md` | Modify | Append `HARNESS FLOW CONSTRAINT` stanza (no advisor). |
+| `src/types.ts` | Modify | Add optional `preset` field to `phase_start`, `gate_verdict`, `gate_error` log event variants. |
+| `src/phases/runner.ts` | Modify | Resolve preset via `getPresetById` and include it in `handleInteractivePhase`'s `phase_start` and `handleGatePhase`'s `gate_verdict` + `gate_error` logEvent calls. |
+| `tests/context/assembler.test.ts` | Modify | New cases: Gate-2/4/7 lifecycle stanza, REVIEWER_CONTRACT scope block, phase-1/3/5 prompts contain the `HARNESS FLOW CONSTRAINT` wording, including the `advisor()` prohibition. |
+| `tests/phases/runner.test.ts` | Modify | Extend existing `phase_start` + `gate_verdict` tests to assert `preset` presence. |
+| `dist/**` | Regenerate | Built via `pnpm build` at end of plan (harness CLI is consumed as a pnpm link — dist must be fresh). |
+
+---
+
+## Task 0: Verify working tree & baseline tests
+
+**Files:** none (pre-flight only).
+
+- [ ] **Step 1: Confirm clean working tree and rebased onto latest main**
+
+Run:
+
+```bash
+cd /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/new-experiment
+git status -s
+git log --oneline main..HEAD | cat
+```
+
+Expected:
+- `git status -s` prints nothing (clean tree).
+- `git log main..HEAD` shows only the two spec commits:
+  - `docs(spec): gate prompt hardening + phase-start logging`
+  - `docs(spec): clarify preset field lives on gate_verdict/gate_error for gates`
+
+If the tree is dirty or HEAD is behind `main`, stop and investigate before touching code.
+
+- [ ] **Step 2: Run the existing test suites we'll touch, green baseline**
+
+Run:
+
+```bash
+pnpm vitest run tests/context/assembler.test.ts tests/phases/runner.test.ts 2>&1 | tail -40
+```
+
+Expected: both files pass. Record any pre-existing failures (there should be none on a clean `main` + spec commits).
+
+---
+
+## Task 1: Add scope-rules block to REVIEWER_CONTRACT (BUG-C)
+
+**Files:**
+- Modify: `src/context/assembler.ts` (around line 19 — the `REVIEWER_CONTRACT` constant).
+- Modify: `tests/context/assembler.test.ts` (extend the existing Gate 2 describe block around line 119).
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/context/assembler.test.ts`, inside the existing `describe('Gate 2 prompt', …)` block, add:
+
+```ts
+  it('includes scope rules that forbid external conventions and not-yet-produced artifacts', () => {
+    const state = makeState();
+    const result = assembleGatePrompt(2, state, '/tmp/harness', makeTmpDir());
+    if (typeof result !== 'string') throw new Error('expected string');
+    expect(result).toContain('Scope rules:');
+    expect(result).toContain('personal or workspace-level conventions');
+    expect(result).toContain('later harness phases produce plan/impl/eval artifacts');
+  });
+```
+
+Note: the existing Gate 2 tests pass a spec fixture — check the top of the file to see how `assembleGatePrompt` is called. Reuse the same fixture-setup pattern (check lines 119-155 for current invocation shape before writing the new test).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+pnpm vitest run tests/context/assembler.test.ts -t 'includes scope rules' 2>&1 | tail -20
+```
+
+Expected: FAIL. The assertions on `'Scope rules:'` etc. do not yet match anything in the prompt.
+
+- [ ] **Step 3: Extend `REVIEWER_CONTRACT`**
+
+In `src/context/assembler.ts`, replace the existing constant (roughly lines 19-35) with:
+
+```ts
+const REVIEWER_CONTRACT = `You are an independent technical reviewer. Review the provided documents and return a structured verdict.
+Output format — must include exactly these sections in order:
+
+## Verdict
+APPROVE or REJECT
+
+## Comments
+- **[P0|P1|P2|P3]** — Location: ...
+  Issue: ...
+  Suggestion: ...
+  Evidence: ...
+
+## Summary
+One to two sentences.
+
+Rules: APPROVE only if zero P0/P1 findings. Every comment must cite a specific location.
+
+Scope rules:
+- Review ONLY the artifacts provided in this prompt (e.g. <spec>, <plan>, <eval_report>, <diff>).
+- Do NOT apply personal or workspace-level conventions (commit-message formats, naming rules, protocols) unless they are explicitly cited in the provided artifacts.
+- Do NOT flag artifacts that are outside this phase's scope as "missing" — later harness phases produce plan/impl/eval artifacts.
+`;
+```
+
+- [ ] **Step 4: Run the new test to verify it passes**
+
+Run:
+
+```bash
+pnpm vitest run tests/context/assembler.test.ts -t 'includes scope rules' 2>&1 | tail -20
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full assembler suite to confirm no regressions**
+
+Run:
+
+```bash
+pnpm vitest run tests/context/assembler.test.ts 2>&1 | tail -20
+```
+
+Expected: All assembler tests pass (including the unchanged "includes full reviewer contract with location-citation rule" at line 139 — we added to the contract, did not remove).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/context/assembler.ts tests/context/assembler.test.ts
+git commit -m "$(cat <<'EOF'
+fix(assembler): add scope rules to REVIEWER_CONTRACT (BUG-C)
+
+Gate reviewers were importing the user's ~/.codex/AGENTS.md personal
+conventions (e.g. Lore Commit Protocol) and flagging them against
+unrelated projects. The scope-rules block makes explicit that the
+reviewer reviews only the artifacts provided and must not apply external
+workspace conventions.
+
+Also forbids flagging not-yet-produced artifacts as missing — second half
+of the lifecycle-awareness fix (see Task 2 for the per-phase stanza).
+
+Observed: Gate 4 round-1 on the 2026-04-18 dog-fooding run raised a P1
+"Lore Commit Protocol violation" against a plan with no such protocol
+cited. One full Phase-3 re-run (Sonnet-high) per bogus P1.
+EOF
+)"
+```
+
+---
+
+## Task 2: Add phase-specific lifecycle context to each gate builder (BUG-A)
+
+**Files:**
+- Modify: `src/context/assembler.ts` (add helper after line ~105, wire into `buildGatePromptPhase2/4/7` around lines 108/120/134).
+- Modify: `tests/context/assembler.test.ts` (extend Gate 2 describe; add Gate 4 and Gate 7 describes if not present).
+
+- [ ] **Step 1: Write failing tests for each gate's lifecycle stanza**
+
+Add to `tests/context/assembler.test.ts`:
+
+```ts
+describe('Gate 2/4/7 lifecycle stanza', () => {
+  it('Gate 2 prompt includes phase-2 lifecycle stanza (plan/impl/eval not yet produced)', () => {
+    const state = makeState();
+    const result = assembleGatePrompt(2, state, '/tmp/harness', makeTmpDir());
+    if (typeof result !== 'string') throw new Error('expected string');
+    expect(result).toContain('<harness_lifecycle>');
+    expect(result).toContain('Gate 2');
+    expect(result).toContain('have not yet been produced');
+  });
+
+  it('Gate 4 prompt includes phase-4 lifecycle stanza (impl not yet produced)', () => {
+    const state = makeState();
+    const result = assembleGatePrompt(4, state, '/tmp/harness', makeTmpDir());
+    if (typeof result !== 'string') throw new Error('expected string');
+    expect(result).toContain('<harness_lifecycle>');
+    expect(result).toContain('Gate 4');
+    expect(result).toContain('implementation (Phase 5) has not yet been produced');
+  });
+
+  it('Gate 7 prompt includes terminal lifecycle stanza without "not yet produced" wording', () => {
+    const state = makeState();
+    const result = assembleGatePrompt(7, state, '/tmp/harness', makeTmpDir());
+    if (typeof result !== 'string') throw new Error('expected string');
+    expect(result).toContain('<harness_lifecycle>');
+    expect(result).toContain('Gate 7');
+    expect(result).toContain('terminal review');
+    expect(result).not.toContain('has not yet been produced');
+  });
+});
+```
+
+Note: `makeState()`, `makeTmpDir()`, and the fixture setup for `assembleGatePrompt` are already defined at the top of `tests/context/assembler.test.ts` — reuse them. If `assembleGatePrompt(4, …)` or `assembleGatePrompt(7, …)` requires additional state fields (plan, evalReport, etc.), look at the existing Gate-2 test fixtures (line 119-155) and the fixtures directory (`tests/context/fixtures/`) — the assembler signature and the minimal state shape are already established.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pnpm vitest run tests/context/assembler.test.ts -t 'lifecycle stanza' 2>&1 | tail -30
+```
+
+Expected: 3 FAIL.
+
+- [ ] **Step 3: Add `buildLifecycleContext` helper and wire it into each gate builder**
+
+In `src/context/assembler.ts`, insert after the `runGit` helper (around line 104), before the `// ─── Gate 2: Spec review ───` comment:
+
+```ts
+function buildLifecycleContext(phase: 2 | 4 | 7): string {
+  if (phase === 2) {
+    return `<harness_lifecycle>\nThis is Gate 2 of a 7-phase harness lifecycle. You are reviewing ONLY the <spec> artifact. The implementation plan (Phase 3), the implementation itself (Phase 5), and the eval report (Phase 7) have not yet been produced; their absence must NOT appear as a finding.\n</harness_lifecycle>\n\n`;
+  }
+  if (phase === 4) {
+    return `<harness_lifecycle>\nThis is Gate 4 of a 7-phase harness lifecycle. You are reviewing the <spec> and <plan>. The implementation (Phase 5) has not yet been produced; its absence must NOT appear as a finding.\n</harness_lifecycle>\n\n`;
+  }
+  return `<harness_lifecycle>\nThis is Gate 7 of a 7-phase harness lifecycle. Spec, plan, implementation diff, and eval report are all provided. This is the terminal review — if APPROVE, the run is complete.\n</harness_lifecycle>\n\n`;
+}
+```
+
+Then modify each builder to prepend the lifecycle stanza **after** `REVIEWER_CONTRACT` and **before** `<spec>…`:
+
+```ts
+// buildGatePromptPhase2 — replace the current return:
+return (
+  REVIEWER_CONTRACT +
+  buildLifecycleContext(2) +
+  `<spec>\n${specResult.content}\n</spec>\n`
+);
+```
+
+```ts
+// buildGatePromptPhase4 — similarly:
+return (
+  REVIEWER_CONTRACT +
+  buildLifecycleContext(4) +
+  `<spec>\n${specResult.content}\n</spec>\n\n` +
+  `<plan>\n${planResult.content}\n</plan>\n`
+);
+```
+
+```ts
+// buildGatePromptPhase7 — inject right after REVIEWER_CONTRACT.
+// Locate the existing `return REVIEWER_CONTRACT + …` string concatenation and
+// insert `buildLifecycleContext(7) +` before the `<spec>` block. If the
+// function uses template literals, put `${buildLifecycleContext(7)}` in the
+// corresponding spot. Do NOT change any downstream diff/metadata/externalSummary
+// block ordering.
+```
+
+(Phase-7 builder uses a larger body with diff + externalSummary + metadata sections; lifecycle stanza goes immediately after `REVIEWER_CONTRACT` and before the first `<spec>` block.)
+
+- [ ] **Step 4: Run the lifecycle tests**
+
+Run:
+
+```bash
+pnpm vitest run tests/context/assembler.test.ts -t 'lifecycle stanza' 2>&1 | tail -30
+```
+
+Expected: 3 PASS.
+
+- [ ] **Step 5: Run the full assembler suite + size-limit tests**
+
+Run:
+
+```bash
+pnpm vitest run tests/context/assembler.test.ts tests/context/assembler-resume.test.ts 2>&1 | tail -30
+```
+
+Expected: all green. The resume-prompt builder (`buildResumeSections`) did not change; its tests must still pass. Resume prompts intentionally skip `REVIEWER_CONTRACT` and lifecycle stanza per spec §4.3 — the change in Task 1+2 does not touch that path.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/context/assembler.ts tests/context/assembler.test.ts
+git commit -m "$(cat <<'EOF'
+fix(assembler): add per-gate lifecycle context to review prompt (BUG-A)
+
+The reviewer previously had no signal that later-phase artifacts (plan,
+impl, eval report) are produced in subsequent harness phases. It kept
+flagging them as "missing" P1 findings and triggering full reject loops.
+
+This change injects a phase-specific <harness_lifecycle> stanza into each
+of buildGatePromptPhase2/4/7 via a new buildLifecycleContext helper.
+
+- Gate 2: plan/impl/eval not yet produced.
+- Gate 4: impl not yet produced.
+- Gate 7: terminal review — all artifacts present.
+
+Observed: Gate 2 round-1 on the 2026-04-18 dog-fooding run raised a P1
+"plan file missing" against a spec that explicitly noted the plan is a
+future-phase artifact. One full Phase-1 re-run (Opus 4.7 xHigh) +
+another Gate 2 Codex call per bogus P1.
+
+Resume prompts (buildResumeSections) intentionally skip the lifecycle
+stanza per spec §4.3 — the context is already in the resumed session.
+EOF
+)"
+```
+
+---
+
+## Task 3: Add `HARNESS FLOW CONSTRAINT` stanza to interactive phase prompts (BUG-B)
+
+**Files:**
+- Modify: `src/context/prompts/phase-1.md`
+- Modify: `src/context/prompts/phase-3.md`
+- Modify: `src/context/prompts/phase-5.md`
+- Modify: `tests/context/assembler.test.ts`
+
+- [ ] **Step 1: Write failing tests for each interactive phase**
+
+Add to `tests/context/assembler.test.ts` (insert as a new describe block near the end of the interactive-prompt section, around line 100):
+
+```ts
+describe('Phase 1/3/5 HARNESS FLOW CONSTRAINT stanza', () => {
+  it.each([1, 3, 5] as const)('Phase %i prompt forbids advisor() and explains the gate reviewer', (phase) => {
+    const state = makeState({
+      phaseAttemptId: { '1': 'aid', '3': 'aid', '5': 'aid' },
+    });
+    const prompt = assembleInteractivePrompt(phase, state, '/tmp/harness');
+    expect(prompt).toContain('HARNESS FLOW CONSTRAINT');
+    expect(prompt).toContain('advisor()');
+    expect(prompt).toContain('독립 reviewer');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pnpm vitest run tests/context/assembler.test.ts -t 'HARNESS FLOW CONSTRAINT' 2>&1 | tail -20
+```
+
+Expected: 3 FAIL (none of the phase prompts yet include the stanza).
+
+- [ ] **Step 3: Append the stanza to each prompt template**
+
+The stanza content (keep wording identical across all three files to let the test `it.each` assert one block):
+
+```markdown
+
+**HARNESS FLOW CONSTRAINT**: 이 세션은 orchestrated harness 라이프사이클 내부에서 실행된다. 다음 phase에서 Codex 기반 독립 reviewer가 산출물을 검토한다(gate). 따라서:
+- `advisor()` 툴을 호출하지 말 것. 외부 리뷰가 이미 예약되어 있다.
+- 작업 범위는 이 프롬프트가 지시한 산출물 + 커밋 + sentinel 생성으로 제한한다.
+- skill 자동 로드는 허용. 그러나 의사결정을 advisor에 위임하지 말고 자체적으로 결론을 낸다.
+```
+
+Append this block to each of:
+- `src/context/prompts/phase-1.md` (after the existing CRITICAL sentinel line and the final "decisions.md는 …에 작성하라." line)
+- `src/context/prompts/phase-3.md` (after the existing CRITICAL sentinel line)
+- `src/context/prompts/phase-5.md` (after the existing CRITICAL sentinel line)
+
+Ensure there is exactly one blank line between the CRITICAL sentinel paragraph and the new stanza so the resulting markdown renders cleanly.
+
+- [ ] **Step 4: Run the new tests**
+
+Run:
+
+```bash
+pnpm vitest run tests/context/assembler.test.ts -t 'HARNESS FLOW CONSTRAINT' 2>&1 | tail -20
+```
+
+Expected: 3 PASS.
+
+- [ ] **Step 5: Run the full assembler suite**
+
+Run:
+
+```bash
+pnpm vitest run tests/context/assembler.test.ts 2>&1 | tail -20
+```
+
+Expected: all green. Existing "includes task.md path" / "includes feedback path" / "instructs writing '## Context & Decisions' section" tests still pass (we appended, did not remove).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/context/prompts/phase-1.md src/context/prompts/phase-3.md src/context/prompts/phase-5.md tests/context/assembler.test.ts
+git commit -m "$(cat <<'EOF'
+fix(prompts): forbid advisor() in harness interactive phases (BUG-B)
+
+The inner Claude session auto-invoked advisor() mid-phase (driven by
+Claude Code's using-superpowers skill). Inside a harness lifecycle, a
+gate reviewer at phase+1 already provides an independent second-look,
+so advisor calls are redundant — each one cost ~2 min Opus 4.7 wall
+time and thousands of tokens.
+
+Append a HARNESS FLOW CONSTRAINT block to phase-{1,3,5}.md that:
+- forbids advisor() invocations,
+- scopes the work to prompt-specified artifact + commit + sentinel,
+- keeps skill auto-loading intact (brainstorming / writing-plans help),
+  but requires decisions to be made by the phase owner rather than
+  delegated.
+
+Observed: Phase 1 retry and Phase 3 first-run on the 2026-04-18
+dog-fooding run each called advisor() at Opus 4.7, stretching Sonnet
+phases to wall time equal to xHigh Opus phases.
+EOF
+)"
+```
+
+---
+
+## Task 4: Add `preset` field to `phase_start`, `gate_verdict`, `gate_error` (logging)
+
+**Files:**
+- Modify: `src/types.ts` (extend the `LogEvent` union at ~line 175 and the `gate_verdict`/`gate_error` variants at ~lines 176-203).
+- Modify: `src/phases/runner.ts` (two logEvent call sites at line 219 and inside `handleGatePhase`).
+- Modify: `tests/phases/runner.test.ts` (extend existing `phase_start` and `gate_verdict` assertion tests).
+
+- [ ] **Step 1: Write failing tests for each event**
+
+In `tests/phases/runner.test.ts`, inside `describe('handleInteractivePhase — event emission', …)` (around line 731), add a new case:
+
+```ts
+  it('emits phase_start with preset { id, runner, model, effort } for phase 1', async () => {
+    const runDir = makeTmpDir();
+    const state = makeState({ currentPhase: 1 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    vi.mocked(runInteractivePhase).mockImplementationOnce(async (phase, st, _h, _r, _c, attemptId) => {
+      st.phases[String(phase)] = 'completed';
+      return { status: 'completed', attemptId } as any;
+    });
+
+    try {
+      await handleInteractivePhase(1, state, HDIR, runDir, CWD, logger);
+      const events = readEvents(eventsPath);
+      const phaseStart = events.find(e => e.event === 'phase_start');
+      expect(phaseStart.preset).toMatchObject({
+        id: expect.any(String),
+        runner: expect.stringMatching(/^(claude|codex)$/),
+        model: expect.any(String),
+        effort: expect.any(String),
+      });
+    } finally {
+      cleanup();
+    }
+  });
+```
+
+Inside `describe('handleGatePhase — gate_verdict emission (APPROVE)', …)` (around line 862), add:
+
+```ts
+  it('emits gate_verdict with preset for phase 2', async () => {
+    const runDir = makeTmpDir();
+    const state = makeState({ currentPhase: 2 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    vi.mocked(runGatePhase).mockResolvedValueOnce({
+      type: 'verdict',
+      verdict: 'APPROVE',
+      comments: '',
+      runner: 'codex',
+      durationMs: 100,
+      tokensTotal: 1000,
+      promptBytes: 500,
+      codexSessionId: 'test-session',
+      recoveredFromSidecar: false,
+      resumedFrom: null,
+      resumeFallback: false,
+      sourcePreset: { model: 'gpt-5.4', effort: 'high' },
+    } as any);
+
+    try {
+      await handleGatePhase(2, state, HDIR, runDir, CWD, createNoOpInputManager(), logger, { value: false });
+      const events = readEvents(eventsPath);
+      const verdict = events.find(e => e.event === 'gate_verdict');
+      expect(verdict.preset).toMatchObject({
+        id: expect.any(String),
+        runner: 'codex',
+        model: expect.any(String),
+        effort: expect.any(String),
+      });
+    } finally {
+      cleanup();
+    }
+  });
+```
+
+And one gate_error variant inside `describe('handleGatePhase — gate_error emission', …)` (around line 1123):
+
+```ts
+  it('emits gate_error with preset for phase 2', async () => {
+    const runDir = makeTmpDir();
+    const state = makeState({ currentPhase: 2 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    vi.mocked(runGatePhase).mockResolvedValueOnce({
+      type: 'error',
+      error: 'timeout',
+      runner: 'codex',
+      exitCode: null,
+      durationMs: 360_000,
+      tokensTotal: 0,
+      codexSessionId: undefined,
+      recoveredFromSidecar: false,
+      resumedFrom: null,
+      resumeFallback: false,
+      sourcePreset: { model: 'gpt-5.4', effort: 'high' },
+    } as any);
+
+    try {
+      await handleGatePhase(2, state, HDIR, runDir, CWD, createNoOpInputManager(), logger, { value: false });
+      const events = readEvents(eventsPath);
+      const err = events.find(e => e.event === 'gate_error');
+      expect(err.preset).toMatchObject({
+        id: expect.any(String),
+        runner: 'codex',
+        model: expect.any(String),
+        effort: expect.any(String),
+      });
+    } finally {
+      cleanup();
+    }
+  });
+```
+
+Note: before writing, skim the existing gate_verdict tests (lines 862-1030) to copy the exact fixture shape (`makeState`, `mockResolvedValueOnce`, etc.) — the mocked return value must satisfy the type, which I gave a best-effort snapshot of above. If `GatePhaseResult` fields have drifted, line up with the currently-passing tests rather than this plan's snapshot.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pnpm vitest run tests/phases/runner.test.ts -t 'preset' 2>&1 | tail -30
+```
+
+Expected: 3 FAIL (preset field not yet attached to any event).
+
+- [ ] **Step 3: Extend the LogEvent union**
+
+In `src/types.ts`, at the `phase_start` variant (around line 175), add the optional `preset` field. Replace:
+
+```ts
+  | (LogEventBase & { event: 'phase_start'; phase: number; attemptId?: string | null; reopenFromGate?: number | null; retryIndex?: number })
+```
+
+with:
+
+```ts
+  | (LogEventBase & {
+      event: 'phase_start';
+      phase: number;
+      attemptId?: string | null;
+      reopenFromGate?: number | null;
+      retryIndex?: number;
+      preset?: { id: string; runner: 'claude' | 'codex'; model: string; effort: string };
+    })
+```
+
+At the `gate_verdict` variant (around line 176-189), add the same `preset?` field at the end of the shape. At `gate_error` (around line 190-203), do the same.
+
+- [ ] **Step 4: Attach preset to phase_start in `handleInteractivePhase`**
+
+In `src/phases/runner.ts`, find the `logger.logEvent({ event: 'phase_start', phase, attemptId, reopenFromGate });` call (line 219 before this edit) and resolve the preset just above it. Use the existing `getPresetById` import (already used elsewhere in the file).
+
+```ts
+  const preset = (() => {
+    const id = state.phasePresets[String(phase)];
+    const p = getPresetById(id);
+    return p ? { id: p.id, runner: p.runner, model: p.model, effort: p.effort } : undefined;
+  })();
+  logger.logEvent({ event: 'phase_start', phase, attemptId, reopenFromGate, preset });
+```
+
+(If `getPresetById` is not yet imported in `runner.ts`, add it to the existing `from '../config.js'` import at the top of the file. Check the imports block before assuming.)
+
+- [ ] **Step 5: Attach preset to gate_verdict and gate_error in `handleGatePhase`**
+
+In `src/phases/runner.ts`, locate `handleGatePhase` (around line 340). There are three `logger.logEvent(...)` calls inside that function:
+1. `event: 'gate_verdict'` on APPROVE (around line 365).
+2. `event: 'gate_verdict'` on REJECT (around line 411).
+3. `event: 'gate_error'` on error (around line 431).
+
+Resolve the preset once near the top of `handleGatePhase` (after `state.phases[String(phase)] = 'in_progress'; writeState(...);`):
+
+```ts
+  const gatePresetMeta = (() => {
+    const id = state.phasePresets[String(phase)];
+    const p = getPresetById(id);
+    return p ? { id: p.id, runner: p.runner, model: p.model, effort: p.effort } : undefined;
+  })();
+```
+
+Then add `preset: gatePresetMeta,` to each of the three `logger.logEvent({ … })` objects (inside the existing shape, immediately after the existing `resumeFallback: …,` line — keep the order readable).
+
+- [ ] **Step 6: Run the preset tests**
+
+Run:
+
+```bash
+pnpm vitest run tests/phases/runner.test.ts -t 'preset' 2>&1 | tail -30
+```
+
+Expected: 3 PASS.
+
+- [ ] **Step 7: Run the full runner + gate suites**
+
+Run:
+
+```bash
+pnpm vitest run tests/phases/runner.test.ts tests/phases/gate.test.ts tests/phases/gate-resume.test.ts 2>&1 | tail -30
+```
+
+Expected: all green. The existing `phase_start` / `gate_verdict` / `gate_error` tests continue to pass — we only added a new optional field, did not change existing field values.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/types.ts src/phases/runner.ts tests/phases/runner.test.ts
+git commit -m "$(cat <<'EOF'
+feat(logging): attach preset to phase_start + gate_verdict/gate_error
+
+Post-hoc analysis of a harness run previously couldn't attribute
+wall-time or tokens to a specific preset on interactive phases — the
+event log only carried `runner` on gate verdicts and nothing at all on
+phase_start. This change adds an optional `preset: { id, runner, model,
+effort }` object to:
+
+- phase_start (phases 1/3/5) — resolved via getPresetById from the
+  caller's state.phasePresets.
+- gate_verdict / gate_error (phases 2/4/7) — same resolution inside
+  handleGatePhase.
+
+Verify phase 6 is unchanged (harness-verify.sh has no preset).
+
+Backwards-compatible: optional field, existing parsers ignore it.
+Observed need: the 2026-04-18 dog-fooding run showed that we cannot
+cleanly measure Phase-1 Opus-xHigh cost vs Phase-3 Sonnet-high cost
+from events.jsonl alone — this closes that gap.
+EOF
+)"
+```
+
+---
+
+## Task 5: Final verification + build + rebase check
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full test suite**
+
+Run:
+
+```bash
+pnpm vitest run 2>&1 | tail -30
+```
+
+Expected: all tests pass. No snapshot drift, no newly-skipped tests. If anything outside the files we touched fails, stop and investigate — it means one of our prompt/type changes had an unexpected ripple.
+
+- [ ] **Step 2: Typecheck**
+
+Run:
+
+```bash
+pnpm tsc --noEmit 2>&1 | tail -20
+```
+
+Expected: no errors. `pnpm lint` is an alias for this per `CLAUDE.md` — do not run both.
+
+- [ ] **Step 3: Rebuild dist/**
+
+Run:
+
+```bash
+pnpm build 2>&1 | tail -10
+```
+
+Expected: `tsc` + `scripts/copy-assets.mjs` complete. `dist/src/context/prompts/phase-{1,3,5}.md` should contain the new `HARNESS FLOW CONSTRAINT` stanza.
+
+Verify:
+
+```bash
+grep -c "HARNESS FLOW CONSTRAINT" dist/src/context/prompts/phase-*.md
+```
+
+Expected: each of the three prompt files reports `1`.
+
+- [ ] **Step 4: Rebase check**
+
+Run:
+
+```bash
+git fetch origin main
+git log --oneline HEAD..origin/main | cat
+```
+
+Expected: empty output (no new commits on main since Task 0). If there are new commits, `git rebase origin/main` and re-run Task 5 Step 1-3 before opening the PR.
+
+- [ ] **Step 5: Commit the rebuilt dist (if tracked)**
+
+`dist/` is listed in `.gitignore` per `CLAUDE.md`. Verify:
+
+```bash
+git status -s dist/ 2>&1 | head
+```
+
+Expected: no output. If `dist/` is tracked, include it in the final commit; otherwise skip.
+
+- [ ] **Step 6: Open the PR**
+
+```bash
+git push -u origin new-experiment
+```
+
+Then create a PR via `gh pr create` with the title `fix: gate prompt hardening + phase-start logging` and a body that lists:
+- the three bugs (BUG-A, B, C) with their observed locations,
+- the logging enhancement,
+- a link to the spec and plan docs,
+- the test plan (check each task's commit).
+
+---
+
+## Deferred / out-of-scope (explicitly not in this PR)
+
+- Phase 1 default preset tuning (`opus-max` → `opus-high`).
+- Skill-load-time reduction (separate investigation).
+- Isolating `HOME` when spawning Codex to skip `~/.codex/AGENTS.md` globally.
+- Per-phase Claude token accounting (not just Codex).
+- Pane-width readability at narrow terminals.
+- `harness-verify.sh` repeated `pip install` per check — a plan-prompt improvement, not a gate-prompt issue.

--- a/docs/specs/2026-04-18-gate-prompt-hardening-design.md
+++ b/docs/specs/2026-04-18-gate-prompt-hardening-design.md
@@ -48,7 +48,7 @@ Key decisions:
 | `src/context/prompts/phase-1.md` | Append a "harness flow constraints" stanza: no advisor() call. |
 | `src/context/prompts/phase-3.md` | Same stanza as phase-1. |
 | `src/context/prompts/phase-5.md` | Same stanza as phase-{1,3}, adapted. |
-| `src/phases/runner.ts` | `handleInteractivePhase` and `handleGatePhase` emit `preset` on `phase_start`. Verify phase 6 uses `harness-verify.sh` and has no preset — no change there. |
+| `src/phases/runner.ts` | `handleInteractivePhase` emits `preset` on `phase_start` (phases 1/3/5). `handleGatePhase` emits `preset` on `gate_verdict` and `gate_error` (phases 2/4/7). Verify phase 6 uses `harness-verify.sh` and has no preset — no change there. |
 | `src/types.ts` | Extend `LogEvent` union: optional `preset` field on `phase_start`. |
 | `tests/context/assembler.test.ts` | New cases: Gate 2/4 prompt contains lifecycle stanza; REVIEWER_CONTRACT contains scope stanza. |
 | `tests/context/` | Snapshot or substring assertions for each builder. |
@@ -113,12 +113,9 @@ Appended to each of `src/context/prompts/phase-{1,3,5}.md` (after the existing C
 
 ### 3.4 `phase_start` preset field (logging)
 
-Extend the `phase_start` variant of the `LogEvent` union in `src/types.ts:175` with an optional `preset` field:
+For **interactive phases (1/3/5)**, extend the `phase_start` variant of the `LogEvent` union in `src/types.ts:175` with an optional `preset` field:
 
 ```ts
-// before
-| (LogEventBase & { event: 'phase_start'; phase: number; attemptId?: string | null; reopenFromGate?: number | null; retryIndex?: number })
-
 // after
 | (LogEventBase & {
     event: 'phase_start';
@@ -129,6 +126,15 @@ Extend the `phase_start` variant of the `LogEvent` union in `src/types.ts:175` w
     preset?: { id: string; runner: 'claude' | 'codex'; model: string; effort: string };
   })
 ```
+
+For **gate phases (2/4/7)**, the runner only emits `gate_verdict` / `gate_error` (no `phase_start`). Extend both variants with the same `preset?` field. Gate phases already include `runner`, but the `model`/`effort` pair is currently absent from the event log.
+
+```ts
+// gate_verdict / gate_error: add
+preset?: { id: string; runner: 'claude' | 'codex'; model: string; effort: string };
+```
+
+Verify phase 6 has no preset and emits `phase_start` / `verify_result` / `phase_end` without this field — no change.
 
 `handleInteractivePhase` (src/phases/runner.ts:219) already resolves the preset via `getPresetById`; include it in `logger.logEvent({ event: 'phase_start', ... })`.
 
@@ -147,7 +153,8 @@ Unit tests (vitest, existing fixtures in `tests/context/`):
 - **Gate 7 prompt** contains scope rules AND a lifecycle stanza that does NOT say "has not yet been produced" (terminal review).
 - **REVIEWER_CONTRACT**'s approval rule (zero P0/P1) is still present verbatim — guards against accidental regression.
 - **Phase 1/3/5 interactive prompts** contain the `HARNESS FLOW CONSTRAINT` block and the `advisor()` prohibition.
-- **`phase_start` event** emits `preset: { id, runner, model, effort }` for phases 1/3/5 and 2/4/7. Test via existing logger integration tests or add a minimal new one.
+- **Interactive `phase_start` event** emits `preset: { id, runner, model, effort }` for phases 1/3/5 — extend existing `handleInteractivePhase` tests in `tests/phases/runner.test.ts:731`.
+- **Gate `gate_verdict` / `gate_error` events** emit `preset` for phases 2/4/7 — extend existing `handleGatePhase` tests (around line 862).
 
 No manual end-to-end retest required for this PR; dog-fooding will re-run the full lifecycle in a follow-up session to measure reject-loop reduction.
 

--- a/docs/specs/2026-04-18-gate-prompt-hardening-design.md
+++ b/docs/specs/2026-04-18-gate-prompt-hardening-design.md
@@ -1,0 +1,172 @@
+# Gate Prompt Hardening & Phase-Start Logging — Design Spec
+
+- Related QA notes: `~/Desktop/projects/harness/experimental-todo/observations.md`
+- Scope of run these fixes target: full `harness run` lifecycle, especially gate phases 2/4/7 and interactive phases 1/3/5.
+
+## Context & Decisions
+
+Dog-fooding a fresh `harness run` on a vague todo-CLI prompt (2026-04-18) surfaced three recurring, high-leverage defects and one missing observability field:
+
+- **BUG-A — Gate reviewers lack harness-lifecycle context.** The reviewer (Codex) reads `REVIEWER_CONTRACT + <spec>` without any signal that more artifacts (plan, impl) will be produced by later phases. Observed Gate 2 round-1: reviewer emitted a P1 ("plan file missing") blocking APPROVE even though Phase 3 had not yet run. Each such bogus P1 costs a full Phase-1 re-run (Opus 4.7 xHigh) plus another Gate 2 Codex review.
+- **BUG-C — Reviewer imports external personal conventions.** Codex autoloads `~/.codex/AGENTS.md` on every session. Observed Gate 4 round-1: a P1 ("Lore Commit Protocol violation") was raised against a plan that had no reason to know about the user's personal commit-message protocol. Same reject-loop cost as BUG-A.
+- **BUG-B — Inner Claude auto-invokes `advisor()` mid-phase.** The Claude Code `using-superpowers` skill instructs Claude to escalate non-trivial tasks to the advisor. Inside a harness interactive phase, the gate review at phase + 1 is already an independent reviewer; a per-phase advisor call duplicates it and adds ~2 min Opus 4.7 wall time per phase. Observed on Phase 1 retry and Phase 3 first-run.
+- **Observability gap — `phase_start` log event omits runner/model/effort.** Post-hoc analysis of multi-phase runs cannot attribute tokens/wall time to a specific preset because `events.jsonl` only has preset data on `gate_verdict` / `gate_error`, not on interactive phase boundaries.
+
+Key decisions:
+
+| # | Decision | Summary |
+|---|----------|---------|
+| D1 | Edit gate prompts, not the Codex invocation | Scope-bleed via `~/.codex/AGENTS.md` could also be fixed by isolating HOME when spawning codex, but that's broad and risky. Prompt-level scope guidance is precise and easy to iterate. |
+| D2 | Split lifecycle from scope guidance | Lifecycle ("plan will come later") is phase-specific; scope guidance ("review only what's given, ignore personal workspace conventions") applies to every gate. Keep scope in the shared `REVIEWER_CONTRACT`, inject lifecycle per-builder. |
+| D3 | Ban `advisor()` in interactive prompts, keep skill loading | Advisor calls duplicate the gate reviewer. Skills (brainstorming, writing-plans) do produce higher-quality artifacts. Ban the former, allow the latter. |
+| D4 | Add `preset` object to `phase_start` event | One extra field (`preset: { id, runner, model, effort }`) on interactive phase_start events. Gate `phase_start` already implicitly reconstructs preset via later gate_verdict, but capturing on start is cheaper and crash-safe. |
+| D5 | Keep existing `REVIEWER_CONTRACT` approval rule unchanged | Approval rule ("APPROVE only if zero P0/P1 findings") stays. The fix narrows what qualifies as a finding, not the threshold. |
+
+---
+
+## 1. Goals & Non-Goals
+
+### Goals
+- Gate reviewers no longer flag artifacts that do not yet exist in the lifecycle.
+- Gate reviewers no longer flag violations of conventions not present in the reviewed artifacts.
+- Inner Claude interactive sessions do not call `advisor()` during harness phases.
+- `phase_start` events carry the preset used, for all phases where a runner preset is applicable (interactive phases 1/3/5 and gate phases 2/4/7).
+
+### Non-Goals (this PR)
+- Changing the Phase 1 default preset (opus-max → opus-high) — defer; `quality > speed > tokens` preference concern.
+- Discouraging skill auto-loading or otherwise tuning overengineering — not reproduced as a hard failure yet; needs more data.
+- Isolating Codex's HOME / disabling `~/.codex/AGENTS.md` globally — broader change, defer until prompt-level fix proves insufficient.
+- Reducing Phase 3 advisor cost *inside* the gate itself (gate reviewer uses no advisor).
+
+---
+
+## 2. Changes overview
+
+| File | Change |
+|------|--------|
+| `src/context/assembler.ts` | 1. Extend `REVIEWER_CONTRACT` with a scope guidance block. 2. Add a `buildLifecycleContext(phase)` helper. 3. Wire lifecycle context into `buildGatePromptPhase2/4/7`. |
+| `src/context/prompts/phase-1.md` | Append a "harness flow constraints" stanza: no advisor() call. |
+| `src/context/prompts/phase-3.md` | Same stanza as phase-1. |
+| `src/context/prompts/phase-5.md` | Same stanza as phase-{1,3}, adapted. |
+| `src/phases/runner.ts` | `handleInteractivePhase` and `handleGatePhase` emit `preset` on `phase_start`. Verify phase 6 uses `harness-verify.sh` and has no preset — no change there. |
+| `src/types.ts` | Extend `LogEvent` union: optional `preset` field on `phase_start`. |
+| `tests/context/assembler.test.ts` | New cases: Gate 2/4 prompt contains lifecycle stanza; REVIEWER_CONTRACT contains scope stanza. |
+| `tests/context/` | Snapshot or substring assertions for each builder. |
+| `tests/phases/*.test.ts` (add or extend) | Assert `phase_start` event includes `preset` for phases 1/3/5 and 2/4/7. |
+
+No schema migration (logger event v:1 is already append-only; adding a field is backward-compatible).
+
+---
+
+## 3. Change detail
+
+### 3.1 `REVIEWER_CONTRACT` scope guidance (BUG-C)
+
+Current (src/context/assembler.ts:19-35):
+
+```
+You are an independent technical reviewer. …
+Rules: APPROVE only if zero P0/P1 findings. Every comment must cite a specific location.
+```
+
+New trailing paragraph (inserted after the existing "Rules" line):
+
+```
+Scope rules:
+- Review ONLY the artifacts provided in this prompt (e.g. <spec>, <plan>, <eval_report>, <diff>).
+- Do NOT apply personal or workspace-level conventions (commit-message formats, naming rules, protocols) unless they are explicitly cited in the provided artifacts.
+- Do NOT flag artifacts that are outside this phase's scope as "missing" — later harness phases produce plan/impl/eval artifacts.
+```
+
+(Bullet 3 is a complement to the phase-specific stanza; kept in the shared contract so every reviewer sees the rule even if we later add a gate that forgets to include a per-phase stanza.)
+
+### 3.2 Phase-specific lifecycle stanza (BUG-A)
+
+New helper in assembler:
+
+```ts
+function buildLifecycleContext(phase: 2 | 4 | 7): string {
+  if (phase === 2) {
+    return `<harness_lifecycle>\nThis is Gate 2 of a 7-phase harness lifecycle. You are reviewing ONLY the <spec> artifact. The implementation plan (Phase 3) and the implementation itself (Phase 5) have not yet been produced; their absence must NOT appear as a finding.\n</harness_lifecycle>\n\n`;
+  }
+  if (phase === 4) {
+    return `<harness_lifecycle>\nThis is Gate 4 of a 7-phase harness lifecycle. You are reviewing the <spec> and <plan>. The implementation (Phase 5) has not yet been produced; its absence must NOT appear as a finding.\n</harness_lifecycle>\n\n`;
+  }
+  return `<harness_lifecycle>\nThis is Gate 7 of a 7-phase harness lifecycle. Spec, plan, implementation diff, and eval report are all provided. This is the terminal review — if APPROVE, the run is complete.\n</harness_lifecycle>\n\n`;
+}
+```
+
+Each `buildGatePromptPhaseN` calls `REVIEWER_CONTRACT + buildLifecycleContext(N) + <artifacts>`.
+
+Resume prompts (`buildResumeSections`) do NOT need re-injection (Strategy C: context is already in the resumed session) — no change there.
+
+### 3.3 Interactive phase stanza (BUG-B)
+
+Appended to each of `src/context/prompts/phase-{1,3,5}.md` (after the existing CRITICAL sentinel warning):
+
+```
+**HARNESS FLOW CONSTRAINT**: 이 세션은 orchestrated harness 라이프사이클 내부에서 실행된다. 다음 phase에서 Codex 기반 독립 reviewer가 산출물을 검토한다(gate). 따라서:
+- `advisor()` 툴을 호출하지 말 것. 외부 리뷰가 이미 예약되어 있다.
+- 작업 범위는 이 프롬프트가 지시한 산출물 + 커밋 + sentinel 생성으로 제한한다.
+- skill 자동 로드는 허용. 그러나 의사결정을 advisor에 위임하지 말고 자체적으로 결론을 낸다.
+```
+
+### 3.4 `phase_start` preset field (logging)
+
+Extend the `phase_start` variant of the `LogEvent` union in `src/types.ts:175` with an optional `preset` field:
+
+```ts
+// before
+| (LogEventBase & { event: 'phase_start'; phase: number; attemptId?: string | null; reopenFromGate?: number | null; retryIndex?: number })
+
+// after
+| (LogEventBase & {
+    event: 'phase_start';
+    phase: number;
+    attemptId?: string | null;
+    reopenFromGate?: number | null;
+    retryIndex?: number;
+    preset?: { id: string; runner: 'claude' | 'codex'; model: string; effort: string };
+  })
+```
+
+`handleInteractivePhase` (src/phases/runner.ts:219) already resolves the preset via `getPresetById`; include it in `logger.logEvent({ event: 'phase_start', ... })`.
+
+`handleGatePhase` similarly has the preset available; include on its `phase_start` event.
+
+Verify phase 6 uses `harness-verify.sh` and has no preset — emit `phase_start` without the `preset` field (no change).
+
+---
+
+## 4. Testing
+
+Unit tests (vitest, existing fixtures in `tests/context/`):
+
+- **Gate 2 prompt** contains both the scope-rules block AND the phase-2 lifecycle stanza ("has not yet been produced").
+- **Gate 4 prompt** contains scope rules AND phase-4 lifecycle stanza mentioning "implementation … has not yet been produced".
+- **Gate 7 prompt** contains scope rules AND a lifecycle stanza that does NOT say "has not yet been produced" (terminal review).
+- **REVIEWER_CONTRACT**'s approval rule (zero P0/P1) is still present verbatim — guards against accidental regression.
+- **Phase 1/3/5 interactive prompts** contain the `HARNESS FLOW CONSTRAINT` block and the `advisor()` prohibition.
+- **`phase_start` event** emits `preset: { id, runner, model, effort }` for phases 1/3/5 and 2/4/7. Test via existing logger integration tests or add a minimal new one.
+
+No manual end-to-end retest required for this PR; dog-fooding will re-run the full lifecycle in a follow-up session to measure reject-loop reduction.
+
+---
+
+## 5. Out of Scope / Deferred
+
+- Phase 1 default preset tuning (opus-max → opus-high) — user-preference-sensitive.
+- Skill-load-time reduction in interactive phases — low-confidence fix, needs more data.
+- Per-phase token accounting for Claude (not just Codex gates).
+- Pane layout auto-width / readability at narrow terminals.
+- `harness-verify.sh` repeated setup-per-check pattern (plan-phase prompt guidance issue, not gate-prompt issue).
+
+---
+
+## 6. Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Scope stanza weakens reviewer rigor (reviewer stops flagging legitimate contract violations). | Stanza is scoped to "personal/workspace conventions not cited in artifacts" — spec-defined contracts are still in bounds. |
+| Advisor ban harms quality for genuinely ambiguous design choices. | Gate reviewer catches those; if the gate misses the gap, the reject loop forces a re-try. |
+| Preset field breaks older event-log parsers. | New field is optional. Existing readers ignore unknown fields (`logger.ts` serializes as JSON; downstream tooling must be additive-tolerant). |

--- a/src/context/assembler.ts
+++ b/src/context/assembler.ts
@@ -32,6 +32,11 @@ APPROVE or REJECT
 One to two sentences.
 
 Rules: APPROVE only if zero P0/P1 findings. Every comment must cite a specific location.
+
+Scope rules:
+- Review ONLY the artifacts provided in this prompt (e.g. <spec>, <plan>, <eval_report>, <diff>).
+- Do NOT apply personal or workspace-level conventions (commit-message formats, naming rules, protocols) unless they are explicitly cited in the provided artifacts.
+- Do NOT flag artifacts that are outside this phase's scope as "missing" — later harness phases produce plan/impl/eval artifacts.
 `;
 
 function readTemplateFile(filename: string): string {

--- a/src/context/assembler.ts
+++ b/src/context/assembler.ts
@@ -108,6 +108,38 @@ function runGit(cmd: string, cwd: string): string {
   }
 }
 
+// ─── Lifecycle context ──────────────────────────────────────────────────────
+//
+// Each gate sees a phase-specific stanza so the reviewer understands which
+// later-phase artifacts do not yet exist. Keeps BUG-A from recurring: gates
+// used to flag "plan file missing" at Gate 2 even though plan = Phase 3.
+
+function buildLifecycleContext(phase: 2 | 4 | 7): string {
+  if (phase === 2) {
+    return (
+      '<harness_lifecycle>\n' +
+      'This is Gate 2 of a 7-phase harness lifecycle. You are reviewing ONLY the <spec> artifact. ' +
+      'The implementation plan (Phase 3), the implementation itself (Phase 5), and the eval report (Phase 7) ' +
+      'have not yet been produced; their absence must NOT appear as a finding.\n' +
+      '</harness_lifecycle>\n\n'
+    );
+  }
+  if (phase === 4) {
+    return (
+      '<harness_lifecycle>\n' +
+      'This is Gate 4 of a 7-phase harness lifecycle. You are reviewing the <spec> and <plan>. ' +
+      'The implementation (Phase 5) has not yet been produced; its absence must NOT appear as a finding.\n' +
+      '</harness_lifecycle>\n\n'
+    );
+  }
+  return (
+    '<harness_lifecycle>\n' +
+    'This is Gate 7 of a 7-phase harness lifecycle. Spec, plan, implementation diff, and eval report are all provided. ' +
+    'This is the terminal review — if APPROVE, the run is complete.\n' +
+    '</harness_lifecycle>\n\n'
+  );
+}
+
 // ─── Gate 2: Spec review ─────────────────────────────────────────────────────
 
 function buildGatePromptPhase2(state: HarnessState, cwd: string): string | { error: string } {
@@ -116,7 +148,8 @@ function buildGatePromptPhase2(state: HarnessState, cwd: string): string | { err
 
   return (
     REVIEWER_CONTRACT +
-    `\n<spec>\n${specResult.content}\n</spec>\n`
+    buildLifecycleContext(2) +
+    `<spec>\n${specResult.content}\n</spec>\n`
   );
 }
 
@@ -131,7 +164,8 @@ function buildGatePromptPhase4(state: HarnessState, cwd: string): string | { err
 
   return (
     REVIEWER_CONTRACT +
-    `\n<spec>\n${specResult.content}\n</spec>\n\n` +
+    buildLifecycleContext(4) +
+    `<spec>\n${specResult.content}\n</spec>\n\n` +
     `<plan>\n${planResult.content}\n</plan>\n`
   );
 }
@@ -215,7 +249,8 @@ function buildGatePromptPhase7(state: HarnessState, cwd: string): string | { err
 
   return (
     REVIEWER_CONTRACT +
-    `\n<spec>\n${specResult.content}\n</spec>\n\n` +
+    buildLifecycleContext(7) +
+    `<spec>\n${specResult.content}\n</spec>\n\n` +
     `<plan>\n${planResult.content}\n</plan>\n\n` +
     `<eval_report>\n${evalResult.content}\n</eval_report>\n\n` +
     diffSection +

--- a/src/context/prompts/phase-1.md
+++ b/src/context/prompts/phase-1.md
@@ -11,3 +11,8 @@ spec을 {{spec_path}}에, decision log를 {{decisions_path}}에 저장하고,
 
 spec 문서는 "{{spec_path}}" 경로에 작성하고, 상단에 "## Context & Decisions" 섹션을 포함하라.
 decisions.md는 "{{decisions_path}}" 경로에 작성하라.
+
+**HARNESS FLOW CONSTRAINT**: 이 세션은 orchestrated harness 라이프사이클 내부에서 실행된다. 다음 phase에서 Codex 기반 독립 reviewer가 산출물을 검토한다(gate). 따라서:
+- `advisor()` 툴을 호출하지 말 것. 외부 리뷰가 이미 예약되어 있다.
+- 작업 범위는 이 프롬프트가 지시한 산출물 + 커밋 + sentinel 생성으로 제한한다.
+- skill 자동 로드는 허용. 그러나 의사결정을 advisor에 위임하지 말고 자체적으로 결론을 낸다.

--- a/src/context/prompts/phase-3.md
+++ b/src/context/prompts/phase-3.md
@@ -21,3 +21,8 @@ eval checklist를 {{checklist_path}}에 아래 JSON 스키마로 저장하라:
 `.harness/{{runId}}/phase-3.done` 파일을 생성하되 내용으로 '{{phaseAttemptId}}' 한 줄만 기록하라.
 
 **CRITICAL: sentinel 파일(phase-3.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 이후 하네스는 다음 단계(리뷰/피드백)로 넘어가므로 추가 작업을 하지 말 것.**
+
+**HARNESS FLOW CONSTRAINT**: 이 세션은 orchestrated harness 라이프사이클 내부에서 실행된다. 다음 phase에서 Codex 기반 독립 reviewer가 산출물을 검토한다(gate). 따라서:
+- `advisor()` 툴을 호출하지 말 것. 외부 리뷰가 이미 예약되어 있다.
+- 작업 범위는 이 프롬프트가 지시한 산출물 + 커밋 + sentinel 생성으로 제한한다.
+- skill 자동 로드는 허용. 그러나 의사결정을 advisor에 위임하지 말고 자체적으로 결론을 낸다.

--- a/src/context/prompts/phase-5.md
+++ b/src/context/prompts/phase-5.md
@@ -12,3 +12,8 @@
 구현 완료 후 `.harness/{{runId}}/phase-5.done` 파일을 생성하되 내용으로 '{{phaseAttemptId}}' 한 줄만 기록하라.
 
 **CRITICAL: sentinel 파일(phase-5.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 이후 하네스는 다음 단계(리뷰/피드백)로 넘어가므로 추가 작업을 하지 말 것.**
+
+**HARNESS FLOW CONSTRAINT**: 이 세션은 orchestrated harness 라이프사이클 내부에서 실행된다. 다음 phase에서 Codex 기반 독립 reviewer가 산출물을 검토한다(gate). 따라서:
+- `advisor()` 툴을 호출하지 말 것. 외부 리뷰가 이미 예약되어 있다.
+- 작업 범위는 이 프롬프트가 지시한 산출물 + 커밋 + sentinel 생성으로 제한한다.
+- skill 자동 로드는 허용. 그러나 의사결정을 advisor에 위임하지 말고 자체적으로 결론을 낸다.

--- a/src/phases/runner.ts
+++ b/src/phases/runner.ts
@@ -9,6 +9,7 @@ import {
   VERIFY_RETRY_LIMIT,
   TERMINAL_PHASE,
   PHASE_ARTIFACT_FILES,
+  getPresetById,
 } from '../config.js';
 import { writeState } from '../state.js';
 import { getHead } from '../git.js';
@@ -27,6 +28,21 @@ import {
 } from '../ui.js';
 
 // ─── Phase type dispatch helpers ──────────────────────────────────────────────
+
+/**
+ * Resolve the preset assigned to a phase into a log-event payload shape.
+ * Returns undefined when no preset is configured (e.g. verify phase 6) — callers
+ * should omit the `preset` field rather than emit a partial object.
+ */
+function getPhasePresetMeta(state: HarnessState, phase: number):
+  | { id: string; runner: 'claude' | 'codex'; model: string; effort: string }
+  | undefined {
+  const id = state.phasePresets?.[String(phase)];
+  if (!id) return undefined;
+  const p = getPresetById(id);
+  if (!p) return undefined;
+  return { id: p.id, runner: p.runner, model: p.model, effort: p.effort };
+}
 
 function isInteractivePhase(phase: number): phase is InteractivePhase {
   return phase === 1 || phase === 3 || phase === 5;
@@ -215,8 +231,9 @@ export async function handleInteractivePhase(
 
   const isReopen = state.phaseReopenFlags[String(phase)] ?? false;
   const reopenFromGate = isReopen ? (state.phaseReopenSource[String(phase)] ?? undefined) : undefined;
+  const preset = getPhasePresetMeta(state, phase);
 
-  logger.logEvent({ event: 'phase_start', phase, attemptId, reopenFromGate });
+  logger.logEvent({ event: 'phase_start', phase, attemptId, reopenFromGate, preset });
 
   // Clear the logging-only reopen source (keep phaseReopenFlags for runInteractivePhase)
   if (state.phaseReopenSource[String(phase)] !== null) {
@@ -345,6 +362,7 @@ export async function handleGatePhase(
 
   // Capture retryIndex BEFORE any mutation (spec §5.3)
   const retryIndex = state.gateRetries[String(phase)] ?? 0;
+  const gatePresetMeta = getPhasePresetMeta(state, phase);
 
   printInfo(`Codex 리뷰 진행 중... (최대 ${Math.round(GATE_TIMEOUT_MS / 1000)}초 소요)`);
   const result = await runGatePhase(phase, state, harnessDir, runDir, cwd, sidecarReplayAllowed);
@@ -375,6 +393,7 @@ export async function handleGatePhase(
           recoveredFromSidecar: result.recoveredFromSidecar ?? false,
           resumedFrom: result.resumedFrom,
           resumeFallback: result.resumeFallback,
+          preset: gatePresetMeta,
         });
       }
 
@@ -420,6 +439,7 @@ export async function handleGatePhase(
           recoveredFromSidecar: result.recoveredFromSidecar ?? false,
           resumedFrom: result.resumedFrom,
           resumeFallback: result.resumeFallback,
+          preset: gatePresetMeta,
         });
       }
       await handleGateReject(phase, result.comments, retryIndex, state, harnessDir, runDir, cwd, inputManager, logger);
@@ -441,6 +461,7 @@ export async function handleGatePhase(
         recoveredFromSidecar: result.recoveredFromSidecar ?? false,
         resumedFrom: result.resumedFrom,
         resumeFallback: result.resumeFallback,
+        preset: gatePresetMeta,
       });
     }
     await handleGateError(phase, result.error, state, runDir, cwd, inputManager, logger);

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,7 +172,14 @@ export interface LogEventBase {
 export type LogEvent =
   | (LogEventBase & { event: 'session_start'; task: string; autoMode: boolean; baseCommit: string; harnessVersion: string })
   | (LogEventBase & { event: 'session_resumed'; fromPhase: number; stateStatus: RunStatus })
-  | (LogEventBase & { event: 'phase_start'; phase: number; attemptId?: string | null; reopenFromGate?: number | null; retryIndex?: number })
+  | (LogEventBase & {
+      event: 'phase_start';
+      phase: number;
+      attemptId?: string | null;
+      reopenFromGate?: number | null;
+      retryIndex?: number;
+      preset?: { id: string; runner: 'claude' | 'codex'; model: string; effort: string };
+    })
   | (LogEventBase & {
       event: 'gate_verdict';
       phase: number;
@@ -186,6 +193,7 @@ export type LogEvent =
       recoveredFromSidecar?: boolean;
       resumedFrom?: string | null;
       resumeFallback?: boolean;
+      preset?: { id: string; runner: 'claude' | 'codex'; model: string; effort: string };
     })
   | (LogEventBase & {
       event: 'gate_error';
@@ -200,6 +208,7 @@ export type LogEvent =
       recoveredFromSidecar?: boolean;
       resumedFrom?: string | null;
       resumeFallback?: boolean;
+      preset?: { id: string; runner: 'claude' | 'codex'; model: string; effort: string };
     })
   | (LogEventBase & { event: 'gate_retry'; phase: number; retryIndex: number; retryCount: number; retryLimit: number; feedbackPath: string; feedbackBytes: number; feedbackPreview: string })
   | (LogEventBase & { event: 'escalation'; phase: number; reason: 'gate-retry-limit' | 'gate-error' | 'verify-limit' | 'verify-error'; userChoice?: 'C' | 'S' | 'Q' | 'R' })

--- a/tests/context/assembler.test.ts
+++ b/tests/context/assembler.test.ts
@@ -150,6 +150,22 @@ describe('Gate 2 prompt', () => {
     const prompt = result as string;
     expect(prompt).toContain('Every comment must cite a specific location');
   });
+
+  it('includes scope rules that forbid external conventions and not-yet-produced artifacts', () => {
+    const cwd = makeTmpDir();
+    const state = makeState();
+
+    const specAbsPath = path.join(cwd, state.artifacts.spec);
+    fs.mkdirSync(path.dirname(specAbsPath), { recursive: true });
+    fs.writeFileSync(specAbsPath, '# Spec');
+
+    const result = assembleGatePrompt(2, state, '/tmp/harness', cwd);
+    expect(typeof result).toBe('string');
+    const prompt = result as string;
+    expect(prompt).toContain('Scope rules:');
+    expect(prompt).toContain('personal or workspace-level conventions');
+    expect(prompt).toContain('later harness phases produce plan/impl/eval artifacts');
+  });
 });
 
 describe('Gate size limits', () => {

--- a/tests/context/assembler.test.ts
+++ b/tests/context/assembler.test.ts
@@ -114,6 +114,18 @@ describe('Phase 5 interactive prompt', () => {
   });
 });
 
+describe('Phase 1/3/5 HARNESS FLOW CONSTRAINT stanza', () => {
+  it.each([1, 3, 5] as const)('Phase %i prompt forbids advisor() and explains the gate reviewer', (phase) => {
+    const state = makeState({
+      phaseAttemptId: { '1': 'aid', '3': 'aid', '5': 'aid' },
+    });
+    const prompt = assembleInteractivePrompt(phase, state, '/tmp/harness');
+    expect(prompt).toContain('HARNESS FLOW CONSTRAINT');
+    expect(prompt).toContain('advisor()');
+    expect(prompt).toContain('독립 reviewer');
+  });
+});
+
 // ─── Gate Prompt Tests ────────────────────────────────────────────────────
 
 describe('Gate 2 prompt', () => {

--- a/tests/context/assembler.test.ts
+++ b/tests/context/assembler.test.ts
@@ -168,6 +168,58 @@ describe('Gate 2 prompt', () => {
   });
 });
 
+describe('Gate 2/4/7 lifecycle stanza', () => {
+  function writeSpecPlanEval(cwd: string, state: HarnessState, { plan = false, evalReport = false } = {}): void {
+    const specAbsPath = path.join(cwd, state.artifacts.spec);
+    fs.mkdirSync(path.dirname(specAbsPath), { recursive: true });
+    fs.writeFileSync(specAbsPath, '# Spec');
+    if (plan) {
+      const planAbsPath = path.join(cwd, state.artifacts.plan);
+      fs.mkdirSync(path.dirname(planAbsPath), { recursive: true });
+      fs.writeFileSync(planAbsPath, '# Plan');
+    }
+    if (evalReport) {
+      const evalAbsPath = path.join(cwd, state.artifacts.evalReport);
+      fs.mkdirSync(path.dirname(evalAbsPath), { recursive: true });
+      fs.writeFileSync(evalAbsPath, '# Eval');
+    }
+  }
+
+  it('Gate 2 prompt includes phase-2 lifecycle stanza (plan/impl/eval not yet produced)', () => {
+    const cwd = makeTmpDir();
+    const state = makeState();
+    writeSpecPlanEval(cwd, state);
+    const result = assembleGatePrompt(2, state, '/tmp/harness', cwd);
+    if (typeof result !== 'string') throw new Error('expected string');
+    expect(result).toContain('<harness_lifecycle>');
+    expect(result).toContain('Gate 2');
+    expect(result).toContain('have not yet been produced');
+  });
+
+  it('Gate 4 prompt includes phase-4 lifecycle stanza (impl not yet produced)', () => {
+    const cwd = makeTmpDir();
+    const state = makeState();
+    writeSpecPlanEval(cwd, state, { plan: true });
+    const result = assembleGatePrompt(4, state, '/tmp/harness', cwd);
+    if (typeof result !== 'string') throw new Error('expected string');
+    expect(result).toContain('<harness_lifecycle>');
+    expect(result).toContain('Gate 4');
+    expect(result).toContain('implementation (Phase 5) has not yet been produced');
+  });
+
+  it('Gate 7 prompt includes terminal lifecycle stanza without "not yet produced" wording', () => {
+    const cwd = makeTmpDir();
+    const state = makeState();
+    writeSpecPlanEval(cwd, state, { plan: true, evalReport: true });
+    const result = assembleGatePrompt(7, state, '/tmp/harness', cwd);
+    if (typeof result !== 'string') throw new Error('expected string');
+    expect(result).toContain('<harness_lifecycle>');
+    expect(result).toContain('Gate 7');
+    expect(result).toContain('terminal review');
+    expect(result).not.toContain('has not yet been produced');
+  });
+});
+
 describe('Gate size limits', () => {
   it('returns error object when file exceeds 200KB limit', () => {
     const cwd = makeTmpDir();

--- a/tests/phases/runner.test.ts
+++ b/tests/phases/runner.test.ts
@@ -855,6 +855,31 @@ describe('handleInteractivePhase — event emission', () => {
       cleanup();
     }
   });
+
+  it('emits phase_start with preset { id, runner, model, effort } for phase 1', async () => {
+    const runDir = makeTmpDir();
+    const state = makeState({ currentPhase: 1 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    vi.mocked(runInteractivePhase).mockImplementationOnce(async (phase, st, _h, _r, _c, attemptId) => {
+      st.phases[String(phase)] = 'completed';
+      return { status: 'completed', attemptId } as any;
+    });
+
+    try {
+      await handleInteractivePhase(1, state, HDIR, runDir, CWD, logger);
+      const events = readEvents(eventsPath);
+      const phaseStart = events.find((e: any) => e.event === 'phase_start');
+      expect(phaseStart.preset).toMatchObject({
+        id: expect.any(String),
+        runner: expect.stringMatching(/^(claude|codex)$/),
+        model: expect.any(String),
+        effort: expect.any(String),
+      });
+    } finally {
+      cleanup();
+    }
+  });
 });
 
 // ─── handleGatePhase — event emission ─────────────────────────────────────────
@@ -886,6 +911,37 @@ describe('handleGatePhase — gate_verdict emission (APPROVE)', () => {
       expect(verdict.runner).toBe('codex');
       expect(verdict.tokensTotal).toBe(45000);
       expect(verdict.retryIndex).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('emits gate_verdict with preset { id, runner, model, effort } for phase 2', async () => {
+    const runDir = makeTmpDir();
+    const state = makeState({ currentPhase: 2 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    vi.mocked(runGatePhase).mockResolvedValueOnce({
+      type: 'verdict',
+      verdict: 'APPROVE',
+      comments: '',
+      rawOutput: '',
+      runner: 'codex',
+      promptBytes: 1000,
+      durationMs: 5000,
+      tokensTotal: 45000,
+    } as any);
+
+    try {
+      await handleGatePhase(2, state, HDIR, runDir, CWD, createNoOpInputManager(), logger, { value: false });
+      const events = readEvents(eventsPath);
+      const verdict = events.find((e: any) => e.event === 'gate_verdict');
+      expect(verdict.preset).toMatchObject({
+        id: expect.any(String),
+        runner: 'codex',
+        model: expect.any(String),
+        effort: expect.any(String),
+      });
     } finally {
       cleanup();
     }
@@ -1145,6 +1201,35 @@ describe('handleGatePhase — gate_error emission', () => {
       expect(errEvent.runner).toBe('codex');
       expect(errEvent.error).toBe('subprocess timeout');
       expect(errEvent.exitCode).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('emits gate_error with preset { id, runner, model, effort } for phase 2', async () => {
+    const runDir = makeTmpDir();
+    const state = makeState({ currentPhase: 2 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    vi.mocked(runGatePhase).mockResolvedValueOnce({
+      type: 'error',
+      error: 'subprocess timeout',
+      runner: 'codex',
+      durationMs: 60000,
+      exitCode: 1,
+    } as any);
+    vi.mocked(promptChoice).mockResolvedValueOnce('Q');
+
+    try {
+      await handleGatePhase(2, state, HDIR, runDir, CWD, createNoOpInputManager(), logger, { value: false });
+      const events = readEvents(eventsPath);
+      const errEvent = events.find((e: any) => e.event === 'gate_error');
+      expect(errEvent.preset).toMatchObject({
+        id: expect.any(String),
+        runner: 'codex',
+        model: expect.any(String),
+        effort: expect.any(String),
+      });
     } finally {
       cleanup();
     }


### PR DESCRIPTION
## Summary

Closes three repeatable defects surfaced by 2026-04-18 dog-fooding of a fresh `harness run` on a vague todo-CLI prompt, plus one observability gap. Triage + measurements in `~/Desktop/projects/harness/experimental-todo/observations.md`.

- **BUG-A** — Gate reviewer lacked lifecycle awareness, flagging not-yet-produced artifacts (plan at Gate 2, impl at Gate 4) as P1 "missing" → forced reject loops. Fixed with per-phase `<harness_lifecycle>` stanza injected by each gate builder.
- **BUG-B** — Inner Claude auto-invoked `advisor()` mid-phase (driven by Claude Code's `using-superpowers` skill); Gate N+1 already provides independent review, so `advisor()` was ~2 min Opus 4.7 redundant cost per interactive phase. Fixed by appending a `HARNESS FLOW CONSTRAINT` block to `phase-{1,3,5}.md` that explicitly forbids `advisor()` while leaving skill auto-loading intact.
- **BUG-C** — Codex auto-loads `~/.codex/AGENTS.md`, so reviewer imported personal workspace conventions (e.g. Lore Commit Protocol) and flagged them against unrelated projects. Fixed by adding a "Scope rules" block to the shared `REVIEWER_CONTRACT` that forbids applying external conventions not cited in the artifacts.
- **Logging gap** — `phase_start`, `gate_verdict`, `gate_error` events now carry an optional `preset: { id, runner, model, effort }` so post-hoc token/wall-time attribution per phase is possible. Verify phase 6 unchanged (no preset).

Design doc: `docs/specs/2026-04-18-gate-prompt-hardening-design.md`
Implementation plan: `docs/plans/2026-04-18-gate-prompt-hardening.md`

## Test plan

- [x] `pnpm exec vitest run` — 493 passed / 1 skipped / 0 failed (36 files).
- [x] `pnpm tsc --noEmit` — clean.
- [x] `pnpm build` — `dist/src/context/prompts/phase-{1,3,5}.md` each contain the new stanza (verified via grep).
- [x] New unit cases:
  - `tests/context/assembler.test.ts` — Gate 2/4/7 lifecycle stanza (3 tests), Gate 2 scope-rules block (1), Phase 1/3/5 HARNESS FLOW CONSTRAINT (3 via `it.each`).
  - `tests/phases/runner.test.ts` — `phase_start.preset` for phase 1, `gate_verdict.preset` + `gate_error.preset` for phase 2.
- [ ] Dog-fooding re-run on the same vague todo-CLI prompt to measure reject-loop reduction and per-phase preset coverage — to run in a follow-up session.

## Scope / deferred

Not in this PR (explicitly listed in the design doc §5):

- Phase 1 default preset tuning (`opus-max` → `opus-high`).
- Skill-load-time reduction inside interactive phases.
- `HOME` isolation for Codex gate invocations.
- Per-phase Claude token accounting.