### PR TITLE
fix(ui): adaptive separator width + folder-trust README note (#10/#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ State is persisted in `.harness/<runId>/state.json` (atomically written). All ar
 
 ## Troubleshooting
 
+**First run in a new project looks hung** — On first use in a project directory, Claude Code prompts you to approve folder access (the "Do you trust the files in this folder?" dialog). The prompt appears in the Claude tmux window, not the control panel, so the control panel sits at *Phase 1 ▶* until you respond. Switch to the Claude window with `Ctrl-B 1` and pick the "trust / proceed" option in the dialog. Subsequent runs in the same directory skip this prompt.
+
 **`tmux is required. Install with: brew install tmux`** — The CLI requires tmux for its multi-window architecture. Install it and try again.
 
 **`harness requires a git repository`** — Run from inside a git repo with at least one commit.

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -9,7 +9,13 @@ const YELLOW = '\x1b[33m';
 const BLUE = '\x1b[34m';
 const RESET = '\x1b[0m';
 
-const SEPARATOR = '━'.repeat(64);
+export function separator(): string {
+  const cols = process.stdout.columns;
+  const width = typeof cols === 'number' && cols > 0
+    ? Math.max(16, Math.min(64, cols - 2))
+    : 62;
+  return '━'.repeat(width);
+}
 
 function phaseLabel(phase: number): string {
   const labels: Record<number, string> = {
@@ -26,9 +32,9 @@ function phaseLabel(phase: number): string {
 
 export function renderControlPanel(state: HarnessState): void {
   process.stdout.write('\x1b[2J\x1b[H'); // clear screen
-  console.error(SEPARATOR);
+  console.error(separator());
   console.error(`${GREEN}▶${RESET} Harness Control Panel`);
-  console.error(SEPARATOR);
+  console.error(separator());
   console.error(`  Run:   ${state.runId}`);
   console.error(`  Phase: ${state.currentPhase}/7 — ${phaseLabel(state.currentPhase)}`);
   const preset = getPresetById(state.phasePresets?.[String(state.currentPhase)] ?? '');
@@ -45,7 +51,7 @@ export function renderControlPanel(state: HarnessState): void {
     console.error(`  [${icon}] Phase ${p}: ${phaseLabel(p)} (${status})${current}`);
   }
   console.error('');
-  console.error(SEPARATOR);
+  console.error(separator());
 }
 
 /**
@@ -81,9 +87,9 @@ export function printPhaseTransition(
   toLabel: string,
 ): void {
   console.error(`${GREEN}✓${RESET} Phase ${fromPhase} 완료 (${fromStatus})`);
-  console.error(SEPARATOR);
+  console.error(separator());
   console.error(`${GREEN}▶${RESET} Phase ${toPhase} 시작: ${toLabel}`);
-  console.error(SEPARATOR);
+  console.error(separator());
 }
 
 /**
@@ -135,9 +141,9 @@ export function printAdvisorReminder(phase: number, runner?: string): void {
 
 export function renderWelcome(runId: string): void {
   process.stdout.write('\x1b[2J\x1b[H');
-  console.error(SEPARATOR);
+  console.error(separator());
   console.error(`${GREEN}▶${RESET} Harness`);
-  console.error(SEPARATOR);
+  console.error(separator());
   console.error(`  Run: ${runId}`);
   console.error('');
   console.error('  What would you like to build?');
@@ -148,9 +154,9 @@ export function renderModelSelection(
   editablePhases?: Set<string>,
 ): void {
   process.stdout.write('\x1b[2J\x1b[H');
-  console.error(SEPARATOR);
+  console.error(separator());
   console.error(`${GREEN}▶${RESET} Model Configuration`);
-  console.error(SEPARATOR);
+  console.error(separator());
 
   const phaseLabels: Record<string, string> = {
     '1': 'Spec 작성', '2': 'Spec Gate', '3': 'Plan 작성',
@@ -167,7 +173,7 @@ export function renderModelSelection(
   console.error(`      Phase 6 (검증):        harness-verify.sh (fixed)`);
   console.error('');
   console.error(`  Change? Phase 번호 입력 or Enter to confirm:`);
-  console.error(SEPARATOR);
+  console.error(separator());
 }
 
 export async function promptModelConfig(

--- a/tests/ui-separator.test.ts
+++ b/tests/ui-separator.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { separator } from '../src/ui.js';
+
+describe('separator()', () => {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(process.stdout, 'columns');
+
+  afterEach(() => {
+    if (originalDescriptor) {
+      Object.defineProperty(process.stdout, 'columns', originalDescriptor);
+    }
+  });
+
+  function setColumns(value: number | undefined): void {
+    Object.defineProperty(process.stdout, 'columns', {
+      configurable: true,
+      get: () => value,
+    });
+  }
+
+  it('caps width at 64 on wide terminals', () => {
+    setColumns(200);
+    expect(separator()).toBe('━'.repeat(64));
+  });
+
+  it('fits within a 40-column terminal (narrow tmux split)', () => {
+    setColumns(40);
+    const s = separator();
+    expect(s.length).toBeLessThanOrEqual(40);
+    expect(s).toBe('━'.repeat(38));
+  });
+
+  it('respects minimum width of 16 when terminal is very narrow', () => {
+    setColumns(8);
+    expect(separator()).toBe('━'.repeat(16));
+  });
+
+  it('falls back to a default width when columns is unavailable', () => {
+    setColumns(undefined);
+    expect(separator()).toBe('━'.repeat(62));
+  });
+
+  it('recomputes on each call so terminal resize takes effect', () => {
+    setColumns(40);
+    const narrow = separator();
+    setColumns(200);
+    const wide = separator();
+    expect(narrow.length).toBeLessThan(wide.length);
+  });
+});


### PR DESCRIPTION
## Summary

Small UX polish bundling two independent P2 fixes from 2026-04-18 dog-fooding (CLAUDE.md open issues).

- **#10 — Separator wraps on narrow control pane.** `src/ui.ts` hardcoded `'━'.repeat(64)`, which wraps on the 40%-wide control pane when Claude takes 60% of a tmux split. Replaced with `separator()` computed at render time: `max(16, min(64, process.stdout.columns - 2))`, with a 62-char fallback when `columns` is unavailable. Called fresh on each render so terminal resize is reflected.
- **#11 — Folder-trust dialog looks like a hang.** Added a Troubleshooting entry: the Claude Code folder-trust prompt on first run appears in the Claude tmux window, not the control panel, so the control panel sits at *Phase 1 ▶* until the user responds. Wording is intentionally neutral (pick the "trust / proceed" option) rather than prescribing an exact keypress, since the prompt shape may vary across Claude Code versions.

## Decisions

- **Tmux split ratio left at `splitPane(..., 'h', 60)`** — the adaptive separator fixes the root wrap issue, so the ratio isn't clearly the problem. Keeping the change surface small.
- **`printAdvisorReminder` kept as-is** — it doesn't use `SEPARATOR`, nothing to migrate. Full removal (Issue #9) is a separate decision.
- **Folder-trust runtime hint (option B from the spec) deferred** — depends on Claude Code internals (trust state file layout), so README tip ships first.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm vitest run` — 502 passed / 1 skipped (baseline was 497 / 1; +5 from new `tests/ui-separator.test.ts`)
- [x] Manual smoke: `node -e "..."` over `dist/src/ui.js` across cols=30/40/64/120/200/undefined → widths 28/38/62/64/64/62, all ≤ terminal width
- [ ] Manual tmux verification (control pane no longer wraps) — recommend on review

Base: `main` (`2147fcf`)