### PR TITLE
feat(logging): capture Claude token usage on interactive phase_end events (gap #12)

### DIFF
--- a/docs/specs/2026-04-18-claude-token-capture-design.md
+++ b/docs/specs/2026-04-18-claude-token-capture-design.md
@@ -234,6 +234,7 @@ Tests (cover all three observable states of D3 / §2.5, plus every real-work `ph
 3. **Codex preset** (any outcome) → assert `claudeTokens` field absent from the `phase_end` event (field-level undefined).
 4. **Redirected-by-signal branch** (existing repo test path in `tests/phases/runner.test.ts` already exercises this; extend or add a sibling case) → assert the `phase_end` event with `details: { reason: 'redirected' }` has NO `claudeTokens` field. Rationale: the runner didn't actually perform its own work; meter read is meaningless.
 5. **Claude preset + throw path** — drive `runInteractivePhase` to reject with an error; assert the catch-block `phase_end` event carries `claudeTokens` (object or null, not undefined). Establishes parity with §2.6 "four real-work emission sites".
+6. **Claude preset + artifact-commit failure path** (phase 1 or 3) — stub `normalizeInteractiveArtifacts` (or the underlying `normalizeArtifactCommit`) to throw after `runInteractivePhase` returns `completed`; assert the resulting `phase_end` event has `status: 'failed'` and `claudeTokens` is present (object or null, not undefined). Closes the last of the four real-work emission sites.
 
 **Exit criterion:** new tests green; existing `pnpm vitest run` baseline (497 passed / 1 skipped) still holds (count increases with new tests).
 
@@ -303,7 +304,7 @@ Manual smoke (not automatable — requires an interactive Claude session):
 | `--session-id` causes Claude to attempt to resume a non-existent session and error out | low | attemptId is freshly random; Claude's docs say the flag "uses a specific session ID for the conversation". If observed, gate behind a boolean constant and fall back to time-window scan only. |
 | fs.readFileSync of a multi-MB jsonl blows up memory | low | typical phase jsonl is <2 MB per observation; we scan line-by-line via `split('\n')`. If needed, switch to streaming later. |
 | Race: phase_end fires before Claude flushes last turn | low | accepted; see Q2. |
-| Project dir encoding drift (Claude Code changes the hash scheme) | medium | Both pinned and fallback paths route through `encodeProjectDir(cwd)`, so drift breaks both at once. Detection relies on (a) a lightweight smoke check during CI — pinned file's parent dir is probed post-phase — and (b) the manual smoke in §4 failing to find `claudeTokens` in events.jsonl. On drift, update the one regex in `encodeProjectDir`; no other code needs to change. |
+| Project dir encoding drift (Claude Code changes the hash scheme) | medium | Both pinned and fallback paths route through `encodeProjectDir(cwd)`, so drift breaks both at once. Detection mechanism = the §4 manual smoke: if `events.jsonl` ships with no `claudeTokens` on Claude interactive phases, drift has occurred. No in-process automated probe is planned (kept out of scope to avoid coupling lifecycle health to an external-schema assumption). On drift, update the one regex in `encodeProjectDir`; no other code needs to change. |
 
 ---
 

--- a/docs/specs/2026-04-18-claude-token-capture-design.md
+++ b/docs/specs/2026-04-18-claude-token-capture-design.md
@@ -60,7 +60,7 @@ The scan is bounded to the phase's own encoded project dir. It does **not** shor
 
 "Empty" or "no assistant entries" in the pinned file is **not** a fallback trigger — that's a legitimate zero-sum outcome (Claude session existed but no billable turns occurred).
 
-Scan is opt-in per call, bounded to the phase's own project dir, and short-circuits on the first match. On any error the reader still returns `null`.
+On any hard I/O error during the scan (directory unreadable, file open fails with non-ENOENT), the reader returns `null` per §2.7.
 
 ### 2.3 JSONL line format
 
@@ -127,7 +127,7 @@ Emission rules:
 | `src/types.ts` | Add `ClaudeTokens` interface; add optional `claudeTokens` on the `phase_end` variant. |
 | `src/runners/claude.ts` | `runClaudeInteractive`: prepend `--session-id ${attemptId}` to `claudeArgs`. |
 | `src/runners/claude-usage.ts` **(new)** | Pure module exposing `encodeProjectDir(cwd)` and `readClaudeSessionUsage({ sessionId, cwd, phaseStartTs, homeDir? })`. |
-| `src/phases/runner.ts` | `handleInteractivePhase`: after `runInteractivePhase` returns, call the reader when `preset.runner === 'claude'` and attach `claudeTokens` to every `phase_end` emission in that function. |
+| `src/phases/runner.ts` | `handleInteractivePhase`: call the reader when `preset.runner === 'claude'` and attach `claudeTokens` to every `phase_end` emission in that function — the success path (completed), the normal failed path, **and** the catch-block (`throw`) path. The only `phase_end` emission that does NOT receive `claudeTokens` is the `control signal redirect` branch (`state.currentPhase !== phase`), since the phase didn't actually perform its own work. |
 | `tests/runners/claude-usage.test.ts` **(new)** | Unit tests for the parser, driven by fixtures under `tests/fixtures/claude-sessions/`. |
 | `tests/phases/runner-token-capture.test.ts` **(new)** | Integration-ish test: fake a jsonl, run `handleInteractivePhase`, assert the emitted `phase_end` event carries `claudeTokens`. |
 
@@ -157,8 +157,9 @@ Fixtures under `tests/fixtures/claude-sessions/`:
 - `no-assistant-entries.jsonl` — only `queue-operation` / `user` entries; returns `{0,0,0,0,0}`.
 - `cache-only.jsonl` — all entries miss `input_tokens` but have `cache_creation_input_tokens`; correct sum.
 - `fallback-before.jsonl` — first assistant timestamp < `phaseStartTs` (must be excluded by the scanner).
-- `fallback-early.jsonl` — first assistant timestamp `== phaseStartTs + 1s` (the one the scanner should pick).
+- `fallback-early.jsonl` — first assistant timestamp `== phaseStartTs + 1s` (the one the scanner should pick on distinct-timestamp test).
 - `fallback-late.jsonl` — first assistant timestamp `== phaseStartTs + 60s` (must NOT be picked when `fallback-early` is also present).
+- `fallback-tie-a.jsonl` and `fallback-tie-b.jsonl` — both have identical first-assistant timestamp `== phaseStartTs + 2s`; lexical rule dictates `fallback-tie-a` wins.
 
 Cases:
 1. happy path, pinned UUID, correct totals.
@@ -168,6 +169,7 @@ Cases:
 5. no assistant entries → zero sum (not null).
 6. cache-only entries sum correctly.
 7. project dir missing entirely → `null` + single stderr warn.
+8. **tie-break**: pinned file missing + `fallback-tie-a` + `fallback-tie-b` both present with identical first-assistant timestamp → scanner returns `fallback-tie-a` aggregates (lexical filename rule).
 
 **Integration (`tests/phases/runner-token-capture.test.ts`):**
 - Set up a temp `$HOME` via env; drop a fixture jsonl at `<HOME>/.claude/projects/<encoded>/<attemptId>.jsonl`.
@@ -194,7 +196,7 @@ Cases:
 2. Implement `encodeProjectDir(cwd)` — single-regex replace `/[^a-zA-Z0-9]/g → '-'`.
 3. Implement `readClaudeSessionUsage({ sessionId, cwd, phaseStartTs, homeDir = os.homedir() })`:
    - Compute pinned path. **If pinned file exists:** read and parse line-by-line (per-line `JSON.parse` errors are skipped silently; one trailing stderr warn at end if ≥1 line was skipped). Aggregate per §2.4. Return the aggregate (zero-sum is valid).
-   - **If pinned file is ENOENT:** fall back to §2.2 scan — list project dir, for each `*.jsonl` find the earliest `type: assistant` entry, keep those with `timestamp >= phaseStartTs`, pick the one with the smallest first-assistant timestamp, parse it.
+   - **If pinned file is ENOENT:** fall back to §2.2 scan — list project dir, for each `*.jsonl` find the earliest `type: assistant` entry, keep those with `timestamp >= phaseStartTs`, pick the one with the smallest first-assistant timestamp (break ties by lexical filename order), parse it.
    - **Hard I/O error at any point** (project dir unreadable, pinned file `readFileSync` throws with non-ENOENT, or the fallback scan itself fails): stderr warn once, return `null`.
    - **Empty pinned file / zero assistant entries**: NOT a fallback trigger — return `{0,0,0,0,0}`.
 4. Re-run tests; all pass.
@@ -218,15 +220,20 @@ Cases:
 In `handleInteractivePhase`:
 - Determine runner: `const runnerName = preset?.runner` (from `getPhasePresetMeta`).
 - Helper inside the function: `const collectTokens = () => runnerName === 'claude' ? readClaudeSessionUsage({ sessionId: attemptId, cwd, phaseStartTs }) : undefined;`.
-- Call it once **after** `runInteractivePhase` resolves and attach to every `phase_end` emission in the function (completed path, failed path, redirected-by-signal path **skip** — redirect means the phase didn't really run its own work).
-- Don't add tokens to the early `throw` catch path's phase_end — unreachable in practice (integration tests to confirm).
+- Call it lazily (at each emission site, OR cache after first call) and attach `claudeTokens` to **all four** `phase_end` emissions that represent real work by this phase:
+  - success/completed path (after `normalizeInteractiveArtifacts` + state advance),
+  - artifact-commit failure path (state set to `'error'`),
+  - normal failed path,
+  - `catch (err)` path (`phase_end` emitted with `status: 'failed'`).
+- **Skip** the `control signal redirect` branch (`state.currentPhase !== phase`) — the phase didn't actually run its own work; token attribution would be misleading.
 
-Tests (cover all three observable states of D3 / §2.5):
+Tests (cover all three observable states of D3 / §2.5, plus every real-work `phase_end` emission site per §2.6):
 
-1. **Claude preset + fixture jsonl present** → assert `claudeTokens` present, correct aggregated object matching the fixture.
-2. **Claude preset + no jsonl fixture** (neither pinned nor in project dir) → assert `claudeTokens: null` (not absent — explicit failure marker).
-3. **Codex preset** → assert `claudeTokens` field absent from the `phase_end` event (field-level undefined).
+1. **Claude preset + completed path + fixture jsonl present** → assert `claudeTokens` present, correct aggregated object matching the fixture.
+2. **Claude preset + failed path + no jsonl fixture** (neither pinned nor in project dir) → assert `claudeTokens: null` (not absent — explicit failure marker). Also validates the "real work failed" emission site.
+3. **Codex preset** (any outcome) → assert `claudeTokens` field absent from the `phase_end` event (field-level undefined).
 4. **Redirected-by-signal branch** (existing repo test path in `tests/phases/runner.test.ts` already exercises this; extend or add a sibling case) → assert the `phase_end` event with `details: { reason: 'redirected' }` has NO `claudeTokens` field. Rationale: the runner didn't actually perform its own work; meter read is meaningless.
+5. **Claude preset + throw path** — drive `runInteractivePhase` to reject with an error; assert the catch-block `phase_end` event carries `claudeTokens` (object or null, not undefined). Establishes parity with §2.6 "four real-work emission sites".
 
 **Exit criterion:** new tests green; existing `pnpm vitest run` baseline (497 passed / 1 skipped) still holds (count increases with new tests).
 
@@ -296,7 +303,7 @@ Manual smoke (not automatable — requires an interactive Claude session):
 | `--session-id` causes Claude to attempt to resume a non-existent session and error out | low | attemptId is freshly random; Claude's docs say the flag "uses a specific session ID for the conversation". If observed, gate behind a boolean constant and fall back to time-window scan only. |
 | fs.readFileSync of a multi-MB jsonl blows up memory | low | typical phase jsonl is <2 MB per observation; we scan line-by-line via `split('\n')`. If needed, switch to streaming later. |
 | Race: phase_end fires before Claude flushes last turn | low | accepted; see Q2. |
-| Project dir encoding drift (Claude Code changes the hash scheme) | medium | pinned lookup still works (filename == attemptId regardless of parent dir). Fallback scan relies on encoding — if Claude changes it, unit-test fails fast and we patch `encodeProjectDir`. |
+| Project dir encoding drift (Claude Code changes the hash scheme) | medium | Both pinned and fallback paths route through `encodeProjectDir(cwd)`, so drift breaks both at once. Detection relies on (a) a lightweight smoke check during CI — pinned file's parent dir is probed post-phase — and (b) the manual smoke in §4 failing to find `claudeTokens` in events.jsonl. On drift, update the one regex in `encodeProjectDir`; no other code needs to change. |
 
 ---
 

--- a/docs/specs/2026-04-18-claude-token-capture-design.md
+++ b/docs/specs/2026-04-18-claude-token-capture-design.md
@@ -48,7 +48,9 @@ where `encodedCwd = cwd.replace(/[^a-zA-Z0-9]/g, '-')`. Confirmed empirically: `
 
 ### 2.2 Fallback — time-window scan
 
-If the pinned file is missing or empty when we read it (e.g., a future Claude version silently ignores `--session-id`), fall back to scanning `~/.claude/projects/<encodedCwd>/*.jsonl` for files whose **first assistant entry's timestamp** is `>= phaseStartTs`. Among matches, pick the one with the **smallest** first-assistant timestamp (i.e., the session that began closest to — but not before — phase open). Parse the same way.
+If the pinned file is **completely missing** (ENOENT) when we read it — typically because a future Claude version silently ignored `--session-id` and wrote its auto-generated UUID file instead — fall back to scanning `~/.claude/projects/<encodedCwd>/*.jsonl` for files whose **first assistant entry's timestamp** is `>= phaseStartTs`. Among matches, pick the one with the **smallest** first-assistant timestamp (i.e., the session that began closest to — but not before — phase open). Parse the same way.
+
+"Empty" or "no assistant entries" is **not** a fallback trigger — that's a legitimate zero-sum outcome (Claude session existed but no billable turns occurred).
 
 Scan is opt-in per call, bounded to the phase's own project dir, and short-circuits on the first match. On any error the reader still returns `null`.
 
@@ -125,7 +127,17 @@ No state.json schema change. No migration. `events.jsonl` v:1 is append-only wit
 
 ### 2.7 Error handling
 
-`readClaudeSessionUsage` never throws. On any error (missing dir, ENOENT, malformed JSON line, fs permission, invalid shape) it logs **one** `warnOnce`-style stderr line per failure and returns `null`. Callers in `handleInteractivePhase` do not wrap in extra try/catch beyond this contract.
+`readClaudeSessionUsage` never throws. Failure semantics (single source of truth — §2.8 tests and T2 behavior MUST align with this table):
+
+| Failure class | Outcome | Logging |
+|---|---|---|
+| Pinned file `ENOENT` | trigger §2.2 fallback scan | none (normal path) |
+| Hard I/O error: project dir unreadable, fs permission/EIO on the jsonl file | **return `null`** | one stderr line per phase |
+| Per-line `JSON.parse` throws (truncated / invalid JSON) | **skip that line**, keep summing the rest | module-level "skipped lines" warn once per phase, at the end |
+| Per-line shape mismatch (JSON parse ok, `type !== 'assistant'` or `message.usage` missing or field not a number) | **skip silently**, keep summing | none (expected for non-assistant rows) |
+| Zero assistant entries after full parse | return `{ 0, 0, 0, 0, 0 }` | none |
+
+Callers in `handleInteractivePhase` do not wrap in extra try/catch beyond this contract.
 
 ### 2.8 Testing strategy
 
@@ -168,12 +180,13 @@ Cases:
 ### T2 — parser module + unit tests (TDD)
 **Files:** `src/runners/claude-usage.ts` (new), `tests/runners/claude-usage.test.ts` (new), `tests/fixtures/claude-sessions/*.jsonl` (new).
 
-1. Write failing tests first for the 7 cases in §2.8.
-2. Implement `encodeProjectDir(cwd)` — single-regex replace.
+1. Write failing tests first for the cases in §2.8 (which aligns 1:1 with the failure-semantics table in §2.7).
+2. Implement `encodeProjectDir(cwd)` — single-regex replace `/[^a-zA-Z0-9]/g → '-'`.
 3. Implement `readClaudeSessionUsage({ sessionId, cwd, phaseStartTs, homeDir = os.homedir() })`:
-   - Compute pinned path. If exists: parse line-by-line, sum.
-   - Else: list project dir, find earliest jsonl whose first assistant entry timestamp ≥ phaseStartTs; parse it.
-   - On any caught error: stderr warn once, return `null`.
+   - Compute pinned path. **If pinned file exists:** read and parse line-by-line (per-line `JSON.parse` errors are skipped silently; one trailing stderr warn at end if ≥1 line was skipped). Aggregate per §2.4. Return the aggregate (zero-sum is valid).
+   - **If pinned file is ENOENT:** fall back to §2.2 scan — list project dir, for each `*.jsonl` find the earliest `type: assistant` entry, keep those with `timestamp >= phaseStartTs`, pick the one with the smallest first-assistant timestamp, parse it.
+   - **Hard I/O error at any point** (project dir unreadable, pinned file `readFileSync` throws with non-ENOENT, or the fallback scan itself fails): stderr warn once, return `null`.
+   - **Empty pinned file / zero assistant entries**: NOT a fallback trigger — return `{0,0,0,0,0}`.
 4. Re-run tests; all pass.
 
 **Exit criterion:** `pnpm vitest run tests/runners/claude-usage.test.ts` green.
@@ -198,14 +211,14 @@ In `handleInteractivePhase`:
 - Call it once **after** `runInteractivePhase` resolves and attach to every `phase_end` emission in the function (completed path, failed path, redirected-by-signal path **skip** — redirect means the phase didn't really run its own work).
 - Don't add tokens to the early `throw` catch path's phase_end — unreachable in practice (integration tests to confirm).
 
-Tests:
-- Drop fixture jsonl at the expected path.
-- Mock/stub `runInteractivePhase` to return completed.
-- Drive `handleInteractivePhase` with a minimal state; capture the logged event.
-- Assert `claudeTokens` present and correct.
-- Repeat with codex preset; assert field absent.
+Tests (cover all three observable states of D3 / §2.5):
 
-**Exit criterion:** new test green; existing `pnpm vitest run` baseline (497 passed / 1 skipped) still holds (count may increase with new tests).
+1. **Claude preset + fixture jsonl present** → assert `claudeTokens` present, correct aggregated object matching the fixture.
+2. **Claude preset + no jsonl fixture** (neither pinned nor in project dir) → assert `claudeTokens: null` (not absent — explicit failure marker).
+3. **Codex preset** → assert `claudeTokens` field absent from the `phase_end` event (field-level undefined).
+4. **Redirected-by-signal branch** (existing repo test path in `tests/phases/runner.test.ts` already exercises this; extend or add a sibling case) → assert the `phase_end` event with `details: { reason: 'redirected' }` has NO `claudeTokens` field. Rationale: the runner didn't actually perform its own work; meter read is meaningless.
+
+**Exit criterion:** new tests green; existing `pnpm vitest run` baseline (497 passed / 1 skipped) still holds (count increases with new tests).
 
 ### T5 — smoke & PR
 **Files:** none (runtime verification).
@@ -235,7 +248,11 @@ Tests:
 Manual smoke (not automatable — requires an interactive Claude session):
 - `pnpm build` in this worktree.
 - Run a trivial `harness run --enable-logging "<task>"` from a scratch worktree (or Desktop experimental dir).
-- Verify `events.jsonl` phases 1/3/5 `phase_end` events have `claudeTokens` with `total > 0` and the four subfields.
+- Verify `events.jsonl` phases 1/3/5 `phase_end` events have `claudeTokens` with:
+  - all four subfields present (`input`, `output`, `cacheRead`, `cacheCreate`) + `total`;
+  - each subfield is a finite non-negative number;
+  - arithmetic identity: `total === input + output + cacheRead + cacheCreate`;
+  - at least one phase with `total > 0` (sanity that a real session was captured).
 - Sample (last 5 lines or redacted) → PR body.
 
 ---
@@ -270,6 +287,13 @@ Manual smoke (not automatable — requires an interactive Claude session):
 | fs.readFileSync of a multi-MB jsonl blows up memory | low | typical phase jsonl is <2 MB per observation; we scan line-by-line via `split('\n')`. If needed, switch to streaming later. |
 | Race: phase_end fires before Claude flushes last turn | low | accepted; see Q2. |
 | Project dir encoding drift (Claude Code changes the hash scheme) | medium | pinned lookup still works (filename == attemptId regardless of parent dir). Fallback scan relies on encoding — if Claude changes it, unit-test fails fast and we patch `encodeProjectDir`. |
+
+---
+
+## 6.1 Deferred from plan gate review (recorded, not blocking)
+
+- **P2 (gate round 1): No automated test for `--session-id` flag in `runClaudeInteractive`.**
+  Current `tests/runners/claude.test.ts` only asserts exports; adding a command-string assertion requires mocking `sendKeysToPane` / `pollForPidFile` / fs write (non-trivial scaffolding not present yet in that test file). Acceptance is covered implicitly by T4 integration test (fixture jsonl at the pinned path → event carries tokens → implies the flag worked end-to-end) + manual smoke result attached to PR. Defer a dedicated unit test for T3 to a follow-up if the integration coverage proves insufficient.
 
 ---
 

--- a/docs/specs/2026-04-18-claude-token-capture-design.md
+++ b/docs/specs/2026-04-18-claude-token-capture-design.md
@@ -48,9 +48,17 @@ where `encodedCwd = cwd.replace(/[^a-zA-Z0-9]/g, '-')`. Confirmed empirically: `
 
 ### 2.2 Fallback — time-window scan
 
-If the pinned file is **completely missing** (ENOENT) when we read it — typically because a future Claude version silently ignored `--session-id` and wrote its auto-generated UUID file instead — fall back to scanning `~/.claude/projects/<encodedCwd>/*.jsonl` for files whose **first assistant entry's timestamp** is `>= phaseStartTs`. Among matches, pick the one with the **smallest** first-assistant timestamp (i.e., the session that began closest to — but not before — phase open). Parse the same way.
+If the pinned file is **completely missing** (ENOENT) when we read it — typically because a future Claude version silently ignored `--session-id` and wrote its auto-generated UUID file instead — fall back to scanning `~/.claude/projects/<encodedCwd>/*.jsonl`:
 
-"Empty" or "no assistant entries" is **not** a fallback trigger — that's a legitimate zero-sum outcome (Claude session existed but no billable turns occurred).
+1. Enumerate all `*.jsonl` files in the project dir.
+2. For each, read entries until the **first** `type: assistant` entry is found; record its `timestamp`.
+3. Keep only candidates whose first-assistant `timestamp >= phaseStartTs`. Files with no assistant entries, or with a first-assistant timestamp earlier than `phaseStartTs`, are dropped.
+4. Among remaining candidates, select the one with the **smallest** first-assistant timestamp (i.e., the session that began closest to — but not before — phase open). Ties are broken by lexical filename order (deterministic).
+5. Parse the selected file the same way as the pinned file.
+
+The scan is bounded to the phase's own encoded project dir. It does **not** short-circuit on the first match — it must enumerate all candidates to satisfy the selection rule.
+
+"Empty" or "no assistant entries" in the pinned file is **not** a fallback trigger — that's a legitimate zero-sum outcome (Claude session existed but no billable turns occurred).
 
 Scan is opt-in per call, bounded to the phase's own project dir, and short-circuits on the first match. On any error the reader still returns `null`.
 
@@ -148,13 +156,15 @@ Fixtures under `tests/fixtures/claude-sessions/`:
 - `malformed-line.jsonl` — one bad JSON line surrounded by valid entries; parser skips the bad line and sums the rest.
 - `no-assistant-entries.jsonl` — only `queue-operation` / `user` entries; returns `{0,0,0,0,0}`.
 - `cache-only.jsonl` — all entries miss `input_tokens` but have `cache_creation_input_tokens`; correct sum.
-- `fallback-candidate.jsonl` — used to exercise the time-window fallback (pinned UUID file missing, scan finds this one).
+- `fallback-before.jsonl` — first assistant timestamp < `phaseStartTs` (must be excluded by the scanner).
+- `fallback-early.jsonl` — first assistant timestamp `== phaseStartTs + 1s` (the one the scanner should pick).
+- `fallback-late.jsonl` — first assistant timestamp `== phaseStartTs + 60s` (must NOT be picked when `fallback-early` is also present).
 
 Cases:
 1. happy path, pinned UUID, correct totals.
-2. pinned file missing + fallback finds the right file.
-3. pinned file missing + fallback finds nothing → `null`.
-4. malformed line skipped.
+2. pinned file missing + fallback scan with `fallback-before` + `fallback-early` + `fallback-late` all present in the dir → scanner returns the `fallback-early` aggregates (verifies both the ≥ `phaseStartTs` filter and the smallest-timestamp selection rule).
+3. pinned file missing + fallback finds nothing (only `fallback-before` present) → `null`.
+4. malformed line skipped **AND** stderr is called exactly once (spy on `process.stderr.write` / `console.error`) to report the skipped line tally.
 5. no assistant entries → zero sum (not null).
 6. cache-only entries sum correctly.
 7. project dir missing entirely → `null` + single stderr warn.

--- a/docs/specs/2026-04-18-claude-token-capture-design.md
+++ b/docs/specs/2026-04-18-claude-token-capture-design.md
@@ -127,7 +127,7 @@ Emission rules:
 | `src/types.ts` | Add `ClaudeTokens` interface; add optional `claudeTokens` on the `phase_end` variant. |
 | `src/runners/claude.ts` | `runClaudeInteractive`: prepend `--session-id ${attemptId}` to `claudeArgs`. |
 | `src/runners/claude-usage.ts` **(new)** | Pure module exposing `encodeProjectDir(cwd)` and `readClaudeSessionUsage({ sessionId, cwd, phaseStartTs, homeDir? })`. |
-| `src/phases/runner.ts` | `handleInteractivePhase`: call the reader when `preset.runner === 'claude'` and attach `claudeTokens` to every `phase_end` emission in that function — the success path (completed), the normal failed path, **and** the catch-block (`throw`) path. The only `phase_end` emission that does NOT receive `claudeTokens` is the `control signal redirect` branch (`state.currentPhase !== phase`), since the phase didn't actually perform its own work. |
+| `src/phases/runner.ts` | `handleInteractivePhase`: call the reader when `preset.runner === 'claude'` and attach `claudeTokens` to every `phase_end` emission representing real work by this phase. Four such sites: (1) success/completed, (2) artifact-commit failure, (3) normal failed, (4) catch-block `throw`. The only `phase_end` emission that does NOT receive `claudeTokens` is the `control signal redirect` branch (`state.currentPhase !== phase`), since the phase didn't actually perform its own work. |
 | `tests/runners/claude-usage.test.ts` **(new)** | Unit tests for the parser, driven by fixtures under `tests/fixtures/claude-sessions/`. |
 | `tests/phases/runner-token-capture.test.ts` **(new)** | Integration-ish test: fake a jsonl, run `handleInteractivePhase`, assert the emitted `phase_end` event carries `claudeTokens`. |
 
@@ -170,6 +170,7 @@ Cases:
 6. cache-only entries sum correctly.
 7. project dir missing entirely → `null` + single stderr warn.
 8. **tie-break**: pinned file missing + `fallback-tie-a` + `fallback-tie-b` both present with identical first-assistant timestamp → scanner returns `fallback-tie-a` aggregates (lexical filename rule).
+9. **hard I/O on pinned file (non-ENOENT)**: stub `fs.readFileSync` (or the module-level file reader) to throw `EACCES` on the pinned path → reader returns `null` + single stderr warn. Separates the ENOENT→fallback branch from the hard-error→null branch per §2.7.
 
 **Integration (`tests/phases/runner-token-capture.test.ts`):**
 - Set up a temp `$HOME` via env; drop a fixture jsonl at `<HOME>/.claude/projects/<encoded>/<attemptId>.jsonl`.
@@ -266,7 +267,7 @@ Tests (cover all three observable states of D3 / §2.5, plus every real-work `ph
 Manual smoke (not automatable — requires an interactive Claude session):
 - `pnpm build` in this worktree.
 - Run a trivial `harness run --enable-logging "<task>"` from a scratch worktree (or Desktop experimental dir).
-- Verify `events.jsonl` phases 1/3/5 `phase_end` events have `claudeTokens` with:
+- Verify, for each interactive phase whose `preset.runner === 'claude'` (typically 1/3/5 under default presets), that the `phase_end` event has `claudeTokens` with:
   - all four subfields present (`input`, `output`, `cacheRead`, `cacheCreate`) + `total`;
   - each subfield is a finite non-negative number;
   - arithmetic identity: `total === input + output + cacheRead + cacheCreate`;

--- a/docs/specs/2026-04-18-claude-token-capture-design.md
+++ b/docs/specs/2026-04-18-claude-token-capture-design.md
@@ -1,0 +1,283 @@
+# Claude Token Capture on Interactive Phases — Design Spec + Plan
+
+- Related:
+  - `docs/specs/2026-04-18-gate-prompt-hardening-design.md` — prior PR that added `preset` to `phase_start` (observability gap #12 parent).
+  - CLAUDE.md "이벤트 로깅 스키마" — current event schema to be extended.
+  - `~/Desktop/projects/harness/experimental-todo/observations.md` — dog-fooding observation that surfaced the gap.
+- Process: light 4-phase flow (spec + plan in this single doc → codex plan gate → impl → verify).
+
+---
+
+## 1. Problem & Goals
+
+### Problem
+`events.jsonl` records `preset: { id, runner, model, effort }` on every interactive `phase_start` (PR #11), but no token count on the matching `phase_end`. Gate phases already capture `tokensTotal` (from Codex stderr). The asymmetry prevents answering "which phase burnt how many tokens?" in post-hoc analysis — blocking Issue #1 (gate reject convergence) diagnosis and making Issue #8 (Phase 1 preset over-provisioning) hard to quantify.
+
+### Goals
+- Interactive `phase_end` events (phases 1/3/5) gain an optional `claudeTokens` field when `preset.runner === 'claude'`.
+- Field carries per-phase aggregated input / output / cache-read / cache-create / total.
+- Best-effort: missing/unparseable logs yield `claudeTokens: null`, never throw, never block the lifecycle.
+
+### Non-Goals
+- Codex interactive token capture (Codex interactive runner doesn't expose per-session token counts the way gate runs do; separate issue).
+- Gate/verify phase re-capture (gate already has `tokensTotal`; verify has no preset).
+- Cost/$$$ calc. Numbers only.
+- Dashboard or summary.json schema change.
+- Changing existing preset defaults (Issue #8).
+- UI/docs refresh of CLAUDE.md event-schema table — deferred to next session index refresh, per repo convention.
+
+---
+
+## 2. Design
+
+### 2.1 Token source — pinned Claude session UUID
+
+**Primary:** pass `--session-id ${attemptId}` when launching `claude` in `runClaudeInteractive`. The harness already mints a fresh UUID (`attemptId` via `randomUUID()`) for each phase attempt in `handleInteractivePhase` and propagates it into `state.phaseAttemptId[String(phase)]`. Reusing the same UUID as the Claude session id makes the log filename deterministic:
+
+```
+~/.claude/projects/<encodedCwd>/<attemptId>.jsonl
+```
+
+where `encodedCwd = cwd.replace(/[^a-zA-Z0-9]/g, '-')`. Confirmed empirically: `/Users/daniel/.grove/github.com/...` → `-Users-daniel--grove-github-com-...` (slash and dot both collapse to `-`).
+
+**Rejected alternatives:**
+- stdout/stderr end-of-session summary — Claude Code does not emit one in interactive mode (verified via `claude --help`).
+- Stop hook — requires user-level `~/.claude/settings.json` mutation; brittle across Claude versions and pollutes user global config.
+- `claude /usage` subcommand — does not exist (verified via `claude --help`).
+- Time-window scan only — ambiguous if Claude's auto-generated session id shifts or overlaps with concurrent sessions.
+
+### 2.2 Fallback — time-window scan
+
+If the pinned file is missing or empty when we read it (e.g., a future Claude version silently ignores `--session-id`), fall back to scanning `~/.claude/projects/<encodedCwd>/*.jsonl` for files whose **first assistant entry's timestamp** is `>= phaseStartTs`. Among matches, pick the one with the **smallest** first-assistant timestamp (i.e., the session that began closest to — but not before — phase open). Parse the same way.
+
+Scan is opt-in per call, bounded to the phase's own project dir, and short-circuits on the first match. On any error the reader still returns `null`.
+
+### 2.3 JSONL line format
+
+Observed shape of the entries we care about (other line types — `queue-operation`, `user`, `system`, etc. — are ignored):
+
+```json
+{
+  "type": "assistant",
+  "timestamp": "2026-04-18T07:06:05.269Z",
+  "sessionId": "67e99f92-...",
+  "message": {
+    "usage": {
+      "input_tokens": 3,
+      "output_tokens": 595,
+      "cache_read_input_tokens": 0,
+      "cache_creation_input_tokens": 23100
+    }
+  }
+}
+```
+
+Only the four numeric fields inside `message.usage` are summed. Missing fields default to 0. Other fields (`service_tier`, `iterations`, etc.) are ignored.
+
+### 2.4 Aggregation
+
+```ts
+interface ClaudeTokens {
+  input: number;       // Σ input_tokens
+  output: number;      // Σ output_tokens
+  cacheRead: number;   // Σ cache_read_input_tokens
+  cacheCreate: number; // Σ cache_creation_input_tokens
+  total: number;       // input + output + cacheRead + cacheCreate
+}
+```
+
+Zero assistant turns → `{ input: 0, output: 0, cacheRead: 0, cacheCreate: 0, total: 0 }` (distinct from `null`; means "Claude ran but emitted nothing billable").
+
+### 2.5 Event schema
+
+`phase_end` LogEvent gains an optional field:
+
+```ts
+// src/types.ts — LogEvent union
+| (LogEventBase & {
+    event: 'phase_end';
+    phase: number;
+    attemptId?: string | null;
+    status: 'completed' | 'failed';
+    durationMs: number;
+    details?: { reason: string };
+    claudeTokens?: ClaudeTokens | null;  // NEW
+  })
+```
+
+Emission rules:
+- Emit `claudeTokens` only when the phase preset has `runner === 'claude'`.
+- `null` means the attempt ran on Claude but token extraction failed.
+- `undefined` (field omitted) means extraction wasn't attempted — runner is codex, or phase is not interactive (gate/verify), or the phase ended via the early "redirected by control signal" branch where token metering is meaningless.
+
+### 2.6 Integration points
+
+| File | Change |
+|------|--------|
+| `src/types.ts` | Add `ClaudeTokens` interface; add optional `claudeTokens` on the `phase_end` variant. |
+| `src/runners/claude.ts` | `runClaudeInteractive`: prepend `--session-id ${attemptId}` to `claudeArgs`. |
+| `src/runners/claude-usage.ts` **(new)** | Pure module exposing `encodeProjectDir(cwd)` and `readClaudeSessionUsage({ sessionId, cwd, phaseStartTs, homeDir? })`. |
+| `src/phases/runner.ts` | `handleInteractivePhase`: after `runInteractivePhase` returns, call the reader when `preset.runner === 'claude'` and attach `claudeTokens` to every `phase_end` emission in that function. |
+| `tests/runners/claude-usage.test.ts` **(new)** | Unit tests for the parser, driven by fixtures under `tests/fixtures/claude-sessions/`. |
+| `tests/phases/runner-token-capture.test.ts` **(new)** | Integration-ish test: fake a jsonl, run `handleInteractivePhase`, assert the emitted `phase_end` event carries `claudeTokens`. |
+
+No state.json schema change. No migration. `events.jsonl` v:1 is append-only with optional fields — backward-compatible.
+
+### 2.7 Error handling
+
+`readClaudeSessionUsage` never throws. On any error (missing dir, ENOENT, malformed JSON line, fs permission, invalid shape) it logs **one** `warnOnce`-style stderr line per failure and returns `null`. Callers in `handleInteractivePhase` do not wrap in extra try/catch beyond this contract.
+
+### 2.8 Testing strategy
+
+**Unit (`tests/runners/claude-usage.test.ts`):**
+
+Fixtures under `tests/fixtures/claude-sessions/`:
+- `happy-multi-turn.jsonl` — three assistant entries with mixed cache usage.
+- `malformed-line.jsonl` — one bad JSON line surrounded by valid entries; parser skips the bad line and sums the rest.
+- `no-assistant-entries.jsonl` — only `queue-operation` / `user` entries; returns `{0,0,0,0,0}`.
+- `cache-only.jsonl` — all entries miss `input_tokens` but have `cache_creation_input_tokens`; correct sum.
+- `fallback-candidate.jsonl` — used to exercise the time-window fallback (pinned UUID file missing, scan finds this one).
+
+Cases:
+1. happy path, pinned UUID, correct totals.
+2. pinned file missing + fallback finds the right file.
+3. pinned file missing + fallback finds nothing → `null`.
+4. malformed line skipped.
+5. no assistant entries → zero sum (not null).
+6. cache-only entries sum correctly.
+7. project dir missing entirely → `null` + single stderr warn.
+
+**Integration (`tests/phases/runner-token-capture.test.ts`):**
+- Set up a temp `$HOME` via env; drop a fixture jsonl at `<HOME>/.claude/projects/<encoded>/<attemptId>.jsonl`.
+- Stub `runInteractivePhase` to return `{ status: 'completed', attemptId }` without actually launching Claude.
+- Drive `handleInteractivePhase` and assert the `phase_end` log event carries `claudeTokens` matching the fixture.
+- Codex preset case: assert `claudeTokens` is absent (undefined, not null).
+
+**Run with existing harness**: `pnpm tsc --noEmit` + `pnpm vitest run`. New tests should not disturb the 497/1-skipped baseline.
+
+---
+
+## 3. Implementation Plan (TDD task order)
+
+### T1 — types & shared interface
+**Files:** `src/types.ts`
+- Define `ClaudeTokens`.
+- Extend `phase_end` variant with `claudeTokens?: ClaudeTokens | null`.
+- **Exit criterion:** `pnpm tsc --noEmit` clean; no downstream compile failures.
+
+### T2 — parser module + unit tests (TDD)
+**Files:** `src/runners/claude-usage.ts` (new), `tests/runners/claude-usage.test.ts` (new), `tests/fixtures/claude-sessions/*.jsonl` (new).
+
+1. Write failing tests first for the 7 cases in §2.8.
+2. Implement `encodeProjectDir(cwd)` — single-regex replace.
+3. Implement `readClaudeSessionUsage({ sessionId, cwd, phaseStartTs, homeDir = os.homedir() })`:
+   - Compute pinned path. If exists: parse line-by-line, sum.
+   - Else: list project dir, find earliest jsonl whose first assistant entry timestamp ≥ phaseStartTs; parse it.
+   - On any caught error: stderr warn once, return `null`.
+4. Re-run tests; all pass.
+
+**Exit criterion:** `pnpm vitest run tests/runners/claude-usage.test.ts` green.
+
+### T3 — pin session id in Claude runner
+**Files:** `src/runners/claude.ts`.
+- In `runClaudeInteractive`, insert `--session-id ${attemptId}` into `claudeArgs` BEFORE `@${promptFile}`:
+  ```ts
+  const claudeArgs = `--dangerously-skip-permissions --session-id ${attemptId} --model ${preset.model} --effort ${preset.effort} @${path.resolve(promptFile)}`;
+  ```
+- `attemptId` is already derived on line 55 from `state.phaseAttemptId[String(phase)]`.
+- Guard against empty attemptId (shouldn't happen given upstream contract): if `attemptId === ''`, skip the flag rather than emit an invalid CLI call.
+
+**Exit criterion:** manual read + `pnpm tsc --noEmit` clean. No existing test regresses.
+
+### T4 — wire reader into phase_end
+**Files:** `src/phases/runner.ts`, `tests/phases/runner-token-capture.test.ts` (new).
+
+In `handleInteractivePhase`:
+- Determine runner: `const runnerName = preset?.runner` (from `getPhasePresetMeta`).
+- Helper inside the function: `const collectTokens = () => runnerName === 'claude' ? readClaudeSessionUsage({ sessionId: attemptId, cwd, phaseStartTs }) : undefined;`.
+- Call it once **after** `runInteractivePhase` resolves and attach to every `phase_end` emission in the function (completed path, failed path, redirected-by-signal path **skip** — redirect means the phase didn't really run its own work).
+- Don't add tokens to the early `throw` catch path's phase_end — unreachable in practice (integration tests to confirm).
+
+Tests:
+- Drop fixture jsonl at the expected path.
+- Mock/stub `runInteractivePhase` to return completed.
+- Drive `handleInteractivePhase` with a minimal state; capture the logged event.
+- Assert `claudeTokens` present and correct.
+- Repeat with codex preset; assert field absent.
+
+**Exit criterion:** new test green; existing `pnpm vitest run` baseline (497 passed / 1 skipped) still holds (count may increase with new tests).
+
+### T5 — smoke & PR
+**Files:** none (runtime verification).
+- `pnpm build` → dist produced.
+- Copy / rebuild into `~/Desktop/projects/harness/harness-cli` (or keep separate dist) and run a simple `harness run --enable-logging` task.
+- Grep `~/.harness/sessions/<repoKey>/<runId>/events.jsonl` for `phase_end` entries; confirm phases 1/3/5 carry `claudeTokens` with plausible values (total > 0).
+- Attach a redacted sample to PR description.
+
+**Exit criterion:** PR body contains smoke result; checklist green; PR opened against `main`.
+
+---
+
+## 4. Eval Checklist (Phase 6 `harness-verify.sh` input)
+
+`.harness/checklist.json` equivalent (placed inside commit of the same PR per repo convention; actual file is written by plan phase in full harness but we're in light flow, so listed here for reviewer reference):
+
+```json
+{
+  "checks": [
+    { "name": "typecheck",  "command": "pnpm tsc --noEmit" },
+    { "name": "vitest",     "command": "pnpm vitest run" },
+    { "name": "build",      "command": "pnpm build" }
+  ]
+}
+```
+
+Manual smoke (not automatable — requires an interactive Claude session):
+- `pnpm build` in this worktree.
+- Run a trivial `harness run --enable-logging "<task>"` from a scratch worktree (or Desktop experimental dir).
+- Verify `events.jsonl` phases 1/3/5 `phase_end` events have `claudeTokens` with `total > 0` and the four subfields.
+- Sample (last 5 lines or redacted) → PR body.
+
+---
+
+## 5. Open Questions
+
+**Q1. Does `claude --session-id <uuid>` work in interactive (non `--print`) mode?**
+- `claude --help` does not scope `--session-id` to `--print`. Assume yes.
+- **If Claude silently ignores it in interactive mode:** §2.2 time-window fallback covers this case. The observable cost is a marginally slower path (one directory scan), which is well below the phase-level timing.
+- We also cover this in testing by explicitly exercising the fallback path with the pinned file absent.
+
+**Q2. Flush lag on the last assistant turn.**
+- Claude appears to append per-turn; no observed buffering in existing logs.
+- If the final turn's line is being flushed at exactly the moment we read, we may under-count it. Acceptable: tokens are a metric, not a billing record. No retry/sleep.
+
+**Q3. Should phase_end carry `claudeSessionId` too?**
+- Deferred. `attemptId` already equals the Claude session id by construction after T3. Duplicating is cost without new information.
+
+**Q4. What about phase 5 reopen (verify-failure retry) — multiple attempts, multiple jsonl files?**
+- Each retry gets a fresh `attemptId`, so each `phase_end` captures only that attempt's tokens. That's the desired semantic.
+
+**Q5. Safety of inserting `--session-id` as a shell-quoted command for tmux?**
+- `attemptId` is a v4 UUID (`randomUUID()`), so characters are `[0-9a-f-]` only — no shell-escaping concerns. The existing tmux command uses `sh -c '...'` single-quoted, and UUIDs interpolate safely.
+
+---
+
+## 6. Risks & Mitigations
+
+| Risk | Likelihood | Mitigation |
+|------|------------|-----------|
+| `--session-id` causes Claude to attempt to resume a non-existent session and error out | low | attemptId is freshly random; Claude's docs say the flag "uses a specific session ID for the conversation". If observed, gate behind a boolean constant and fall back to time-window scan only. |
+| fs.readFileSync of a multi-MB jsonl blows up memory | low | typical phase jsonl is <2 MB per observation; we scan line-by-line via `split('\n')`. If needed, switch to streaming later. |
+| Race: phase_end fires before Claude flushes last turn | low | accepted; see Q2. |
+| Project dir encoding drift (Claude Code changes the hash scheme) | medium | pinned lookup still works (filename == attemptId regardless of parent dir). Fallback scan relies on encoding — if Claude changes it, unit-test fails fast and we patch `encodeProjectDir`. |
+
+---
+
+## 7. Out of Scope (reminder)
+
+- Codex interactive token capture.
+- Gate / verify token re-capture.
+- Cost / pricing.
+- CLAUDE.md event-schema table refresh (follow-up doc-only PR).
+- Phase preset changes (Issue #8).
+- State.json, checklist.json, or other persistent schema changes.

--- a/src/phases/runner.ts
+++ b/src/phases/runner.ts
@@ -17,6 +17,7 @@ import { normalizeArtifactCommit } from '../artifact.js';
 import { runInteractivePhase } from './interactive.js';
 import { runGatePhase } from './gate.js';
 import { runVerifyPhase } from './verify.js';
+import { readClaudeSessionUsage } from '../runners/claude-usage.js';
 import {
   promptChoice,
   printPhaseTransition,
@@ -233,6 +234,13 @@ export async function handleInteractivePhase(
   const reopenFromGate = isReopen ? (state.phaseReopenSource[String(phase)] ?? undefined) : undefined;
   const preset = getPhasePresetMeta(state, phase);
 
+  // Token capture helper: runner=claude → read ~/.claude/projects/<cwd>/<attemptId>.jsonl;
+  // runner=codex → return undefined so the field is omitted from phase_end entirely (§2.5).
+  const collectClaudeTokens = () =>
+    preset?.runner === 'claude'
+      ? readClaudeSessionUsage({ sessionId: attemptId, cwd, phaseStartTs })
+      : undefined;
+
   logger.logEvent({ event: 'phase_start', phase, attemptId, reopenFromGate, preset });
 
   // Clear the logging-only reopen source (keep phaseReopenFlags for runInteractivePhase)
@@ -271,12 +279,14 @@ export async function handleInteractivePhase(
           state.phases[String(phase)] = 'error';
           savePausedAtHead(state, cwd);
           writeState(runDir, state);
+          const tokens = collectClaudeTokens();
           logger.logEvent({
             event: 'phase_end',
             phase,
             attemptId,
             status: 'failed',
             durationMs: Date.now() - phaseStartTs,
+            ...(tokens !== undefined ? { claudeTokens: tokens } : {}),
           });
           return;
         }
@@ -303,12 +313,14 @@ export async function handleInteractivePhase(
       renderControlPanel(state);
       writeState(runDir, state);
 
+      const completedTokens = collectClaudeTokens();
       logger.logEvent({
         event: 'phase_end',
         phase,
         attemptId,
         status: 'completed',
         durationMs: Date.now() - phaseStartTs,
+        ...(completedTokens !== undefined ? { claudeTokens: completedTokens } : {}),
       });
 
       // Anomaly: phase 5 completed but reopen flag still set
@@ -325,21 +337,25 @@ export async function handleInteractivePhase(
       savePausedAtHead(state, cwd);
       printError(`Phase ${phase} failed`);
       writeState(runDir, state);
+      const failedTokens = collectClaudeTokens();
       logger.logEvent({
         event: 'phase_end',
         phase,
         attemptId,
         status: 'failed',
         durationMs: Date.now() - phaseStartTs,
+        ...(failedTokens !== undefined ? { claudeTokens: failedTokens } : {}),
       });
     }
   } catch (err) {
+    const thrownTokens = collectClaudeTokens();
     logger.logEvent({
       event: 'phase_end',
       phase,
       attemptId,
       status: 'failed',
       durationMs: Date.now() - phaseStartTs,
+      ...(thrownTokens !== undefined ? { claudeTokens: thrownTokens } : {}),
     });
     throw err;
   }

--- a/src/runners/claude-usage.ts
+++ b/src/runners/claude-usage.ts
@@ -1,0 +1,137 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import type { ClaudeTokens } from '../types.js';
+
+const NON_ALNUM_RE = /[^a-zA-Z0-9]/g;
+
+export function encodeProjectDir(cwd: string): string {
+  return cwd.replace(NON_ALNUM_RE, '-');
+}
+
+export interface ReadClaudeSessionUsageInput {
+  sessionId: string;
+  cwd: string;
+  phaseStartTs: number;
+  homeDir?: string;
+}
+
+interface ParseOutcome {
+  tokens: ClaudeTokens;
+  skippedLines: number;
+}
+
+function zeroTokens(): ClaudeTokens {
+  return { input: 0, output: 0, cacheRead: 0, cacheCreate: 0, total: 0 };
+}
+
+function toNumber(v: unknown): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : 0;
+}
+
+function parseSessionFile(absPath: string): ParseOutcome {
+  const raw = fs.readFileSync(absPath, 'utf-8');
+  const tokens = zeroTokens();
+  let skipped = 0;
+  for (const line of raw.split('\n')) {
+    if (!line) continue;
+    let entry: any;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      skipped += 1;
+      continue;
+    }
+    if (!entry || entry.type !== 'assistant') continue;
+    const usage = entry?.message?.usage;
+    if (!usage || typeof usage !== 'object') continue;
+    tokens.input += toNumber(usage.input_tokens);
+    tokens.output += toNumber(usage.output_tokens);
+    tokens.cacheRead += toNumber(usage.cache_read_input_tokens);
+    tokens.cacheCreate += toNumber(usage.cache_creation_input_tokens);
+  }
+  tokens.total = tokens.input + tokens.output + tokens.cacheRead + tokens.cacheCreate;
+  return { tokens, skippedLines: skipped };
+}
+
+function firstAssistantTs(absPath: string): number | null {
+  const raw = fs.readFileSync(absPath, 'utf-8');
+  for (const line of raw.split('\n')) {
+    if (!line) continue;
+    let entry: any;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (entry?.type !== 'assistant') continue;
+    const ts = entry.timestamp;
+    if (typeof ts !== 'string') continue;
+    const ms = Date.parse(ts);
+    if (Number.isFinite(ms)) return ms;
+  }
+  return null;
+}
+
+function warn(msg: string): void {
+  process.stderr.write(`[harness.claudeUsage] ${msg}\n`);
+}
+
+export function readClaudeSessionUsage(input: ReadClaudeSessionUsageInput): ClaudeTokens | null {
+  const { sessionId, cwd, phaseStartTs } = input;
+  const homeDir = input.homeDir ?? os.homedir();
+  const projectDir = path.join(homeDir, '.claude', 'projects', encodeProjectDir(cwd));
+  const pinnedPath = path.join(projectDir, `${sessionId}.jsonl`);
+
+  if (fs.existsSync(pinnedPath)) {
+    try {
+      const { tokens, skippedLines } = parseSessionFile(pinnedPath);
+      if (skippedLines > 0) warn(`skipped ${skippedLines} malformed line(s) in ${pinnedPath}`);
+      return tokens;
+    } catch (err) {
+      warn(`failed to read pinned session ${pinnedPath}: ${(err as Error).message}`);
+      return null;
+    }
+  }
+
+  // Fallback: enumerate project dir, pick earliest-eligible (then lexical tiebreak)
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(projectDir);
+  } catch (err) {
+    warn(`project dir unreadable ${projectDir}: ${(err as Error).message}`);
+    return null;
+  }
+
+  const candidates: Array<{ file: string; ts: number }> = [];
+  for (const name of entries) {
+    if (!name.endsWith('.jsonl')) continue;
+    const absPath = path.join(projectDir, name);
+    let ts: number | null;
+    try {
+      ts = firstAssistantTs(absPath);
+    } catch {
+      // per-file hard read error inside scan: skip this file (best-effort)
+      continue;
+    }
+    if (ts === null) continue;
+    if (ts < phaseStartTs) continue;
+    candidates.push({ file: name, ts });
+  }
+
+  if (candidates.length === 0) return null;
+
+  candidates.sort((a, b) => {
+    if (a.ts !== b.ts) return a.ts - b.ts;
+    return a.file < b.file ? -1 : a.file > b.file ? 1 : 0;
+  });
+  const winner = candidates[0];
+  try {
+    const { tokens, skippedLines } = parseSessionFile(path.join(projectDir, winner.file));
+    if (skippedLines > 0) warn(`skipped ${skippedLines} malformed line(s) in ${winner.file}`);
+    return tokens;
+  } catch (err) {
+    warn(`fallback read failed ${winner.file}: ${(err as Error).message}`);
+    return null;
+  }
+}

--- a/src/runners/claude.ts
+++ b/src/runners/claude.ts
@@ -56,8 +56,13 @@ export async function runClaudeInteractive(
   const pidFile = path.join(runDir, `claude-${phase}-${attemptId}.pid`);
   if (fs.existsSync(pidFile)) fs.unlinkSync(pidFile);
 
-  // Launch Claude via exec wrapper
-  const claudeArgs = `--dangerously-skip-permissions --model ${preset.model} --effort ${preset.effort} @${path.resolve(promptFile)}`;
+  // Launch Claude via exec wrapper.
+  // Pin Claude's session UUID to our attemptId so the session JSONL lands at
+  // ~/.claude/projects/<encodedCwd>/<attemptId>.jsonl (§D5 of the token-capture design).
+  // Guard against empty attemptId (shouldn't happen given upstream contract) by
+  // omitting the flag rather than passing an invalid argument.
+  const sessionIdArg = attemptId ? `--session-id ${attemptId} ` : '';
+  const claudeArgs = `--dangerously-skip-permissions ${sessionIdArg}--model ${preset.model} --effort ${preset.effort} @${path.resolve(promptFile)}`;
   const wrappedCmd = `sh -c 'echo $$ > ${pidFile}; exec claude ${claudeArgs}'`;
   sendKeysToPane(sessionName, workspacePane, wrappedCmd);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,6 +155,16 @@ export type PreflightItem = 'git' | 'head' | 'node' | 'claude' | 'claudeAtFile' 
 
 export type PhaseType = 'interactive' | 'gate' | 'verify' | 'terminal' | 'ui_only';
 
+// --- Claude interactive token usage (phase_end.claudeTokens) ---
+
+export interface ClaudeTokens {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheCreate: number;
+  total: number;
+}
+
 // --- Session Logging Events ---
 
 // Distributive Omit: applies Omit to each member of a union separately,
@@ -214,7 +224,7 @@ export type LogEvent =
   | (LogEventBase & { event: 'escalation'; phase: number; reason: 'gate-retry-limit' | 'gate-error' | 'verify-limit' | 'verify-error'; userChoice?: 'C' | 'S' | 'Q' | 'R' })
   | (LogEventBase & { event: 'force_pass'; phase: number; by: 'auto' | 'user' })
   | (LogEventBase & { event: 'verify_result'; passed: boolean; retryIndex: number; durationMs: number; failedChecks?: string[] })
-  | (LogEventBase & { event: 'phase_end'; phase: number; attemptId?: string | null; status: 'completed' | 'failed'; durationMs: number; details?: { reason: string } })
+  | (LogEventBase & { event: 'phase_end'; phase: number; attemptId?: string | null; status: 'completed' | 'failed'; durationMs: number; details?: { reason: string }; claudeTokens?: ClaudeTokens | null })
   | (LogEventBase & { event: 'state_anomaly'; kind: string; details: Record<string, unknown> })
   | (LogEventBase & { event: 'session_end'; status: 'completed' | 'paused' | 'interrupted'; totalWallMs: number });
 

--- a/tests/fixtures/claude-sessions/README.md
+++ b/tests/fixtures/claude-sessions/README.md
@@ -1,0 +1,7 @@
+# Claude session JSONL fixtures
+
+Fixtures for `src/runners/claude-usage.ts` parser. Each `*.jsonl` mirrors the
+format written by `claude` at `~/.claude/projects/<encodedCwd>/<sessionId>.jsonl`.
+
+Only `type: assistant` entries with `message.usage.*_tokens` contribute to
+aggregation. Everything else (queue-operation, user, system) is ignored.

--- a/tests/phases/runner-token-capture.test.ts
+++ b/tests/phases/runner-token-capture.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { HarnessState, LogEvent, SessionMeta, ClaudeTokens, DistributiveOmit } from '../../src/types.js';
+import type { InteractiveResult } from '../../src/phases/interactive.js';
+import { createInitialState } from '../../src/state.js';
+
+vi.mock('../../src/phases/interactive.js', () => ({
+  runInteractivePhase: vi.fn(),
+  preparePhase: vi.fn(),
+  checkSentinelFreshness: vi.fn(),
+  validatePhaseArtifacts: vi.fn(),
+}));
+
+vi.mock('../../src/runners/claude-usage.js', () => ({
+  readClaudeSessionUsage: vi.fn(),
+  encodeProjectDir: vi.fn((cwd: string) => cwd.replace(/[^a-zA-Z0-9]/g, '-')),
+}));
+
+vi.mock('../../src/ui.js', () => ({
+  promptChoice: vi.fn(),
+  printPhaseTransition: vi.fn(),
+  renderControlPanel: vi.fn(),
+  printWarning: vi.fn(),
+  printError: vi.fn(),
+  printSuccess: vi.fn(),
+  printInfo: vi.fn(),
+  printAdvisorReminder: vi.fn(),
+}));
+
+vi.mock('../../src/artifact.js', () => ({
+  normalizeArtifactCommit: vi.fn().mockReturnValue(true),
+  runPhase6Preconditions: vi.fn(),
+}));
+
+vi.mock('../../src/git.js', () => ({
+  getHead: vi.fn().mockReturnValue('mock-head-sha'),
+  getGitRoot: vi.fn(),
+  isAncestor: vi.fn(),
+  isWorkingTreeClean: vi.fn(),
+  hasStagedChanges: vi.fn(),
+  getStagedFiles: vi.fn(),
+  getFileStatus: vi.fn(),
+  generateRunId: vi.fn(),
+  detectExternalCommits: vi.fn(),
+}));
+
+vi.mock('../../src/state.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/state.js')>();
+  return { ...actual, writeState: vi.fn() };
+});
+
+import { handleInteractivePhase } from '../../src/phases/runner.js';
+import { runInteractivePhase } from '../../src/phases/interactive.js';
+import { readClaudeSessionUsage } from '../../src/runners/claude-usage.js';
+import { normalizeArtifactCommit } from '../../src/artifact.js';
+
+// ─── Test-double logger ──────────────────────────────────────────────────────
+
+class CapturingLogger {
+  events: DistributiveOmit<LogEvent, 'v' | 'ts' | 'runId'>[] = [];
+  logEvent(e: DistributiveOmit<LogEvent, 'v' | 'ts' | 'runId'>): void { this.events.push(e); }
+  writeMeta(_: Partial<SessionMeta> & { task: string }): void { /* noop */ }
+  updateMeta(): void { /* noop */ }
+  finalizeSummary(): void { /* noop */ }
+  close(): void { /* noop */ }
+  hasBootstrapped(): boolean { return true; }
+  hasEmittedSessionOpen(): boolean { return true; }
+  getStartedAt(): number { return Date.now(); }
+
+  phaseEnds() {
+    return this.events.filter((e) => (e as any).event === 'phase_end') as any[];
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  vi.clearAllMocks();
+  for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+  tmpDirs.length = 0;
+});
+
+function makeTmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'runner-token-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function makeState(overrides: Partial<HarnessState> = {}): HarnessState {
+  const base = createInitialState('test-run', '/tasks/test.md', 'base-sha', false);
+  return { ...base, ...overrides };
+}
+
+const HDIR = '/tmp/harness-dir';
+const CWD = '/tmp/cwd';
+
+function setCodexPreset(state: HarnessState, phase: number): void {
+  state.phasePresets[String(phase)] = 'codex-high';
+}
+
+const HAPPY_TOKENS: ClaudeTokens = {
+  input: 10, output: 100, cacheRead: 1_000, cacheCreate: 10_000, total: 11_110,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('handleInteractivePhase claudeTokens capture', () => {
+  // Case 1 — Claude preset + completed path → claudeTokens present
+  it('attaches claudeTokens to phase_end on completed path when preset.runner === claude', async () => {
+    vi.mocked(runInteractivePhase).mockResolvedValueOnce({ status: 'completed', attemptId: 'a-1' });
+    vi.mocked(readClaudeSessionUsage).mockReturnValue(HAPPY_TOKENS);
+
+    const logger = new CapturingLogger();
+    const state = makeState({ currentPhase: 1 });
+    await handleInteractivePhase(1, state, HDIR, makeTmpDir(), CWD, logger as any);
+
+    const ends = logger.phaseEnds();
+    expect(ends).toHaveLength(1);
+    expect(ends[0].status).toBe('completed');
+    expect(ends[0].claudeTokens).toEqual(HAPPY_TOKENS);
+  });
+
+  // Case 2 — Claude preset + extraction fails → claudeTokens: null
+  it('attaches claudeTokens=null when preset is Claude but extraction returns null', async () => {
+    vi.mocked(runInteractivePhase).mockResolvedValueOnce({ status: 'failed', attemptId: 'a-2' });
+    vi.mocked(readClaudeSessionUsage).mockReturnValue(null);
+
+    const logger = new CapturingLogger();
+    const state = makeState({ currentPhase: 1 });
+    await handleInteractivePhase(1, state, HDIR, makeTmpDir(), CWD, logger as any);
+
+    const ends = logger.phaseEnds();
+    expect(ends).toHaveLength(1);
+    expect(ends[0].status).toBe('failed');
+    expect(ends[0].claudeTokens).toBeNull();
+  });
+
+  // Case 3 — Codex preset → field absent (undefined)
+  it('omits claudeTokens entirely when preset.runner === codex', async () => {
+    vi.mocked(runInteractivePhase).mockResolvedValueOnce({ status: 'completed', attemptId: 'a-3' });
+    vi.mocked(readClaudeSessionUsage).mockReturnValue(HAPPY_TOKENS);
+
+    const logger = new CapturingLogger();
+    const state = makeState({ currentPhase: 1 });
+    setCodexPreset(state, 1);
+    await handleInteractivePhase(1, state, HDIR, makeTmpDir(), CWD, logger as any);
+
+    const ends = logger.phaseEnds();
+    expect(ends).toHaveLength(1);
+    // Undefined — field absent from the event payload entirely.
+    expect('claudeTokens' in ends[0]).toBe(false);
+    // The reader must not have been called at all.
+    expect(vi.mocked(readClaudeSessionUsage)).not.toHaveBeenCalled();
+  });
+
+  // Case 4 — Redirected-by-signal branch skips token attachment
+  it('does NOT attach claudeTokens on the redirected-by-signal phase_end branch', async () => {
+    vi.mocked(runInteractivePhase).mockImplementationOnce(async (phase: any, s: any, _h, _r, _c, attemptId) => {
+      // Simulate SIGUSR1 redirect: mutate currentPhase while phase is running
+      s.currentPhase = 3;
+      return { status: 'completed', attemptId };
+    });
+    vi.mocked(readClaudeSessionUsage).mockReturnValue(HAPPY_TOKENS);
+
+    const logger = new CapturingLogger();
+    const state = makeState({ currentPhase: 1 });
+    await handleInteractivePhase(1, state, HDIR, makeTmpDir(), CWD, logger as any);
+
+    const ends = logger.phaseEnds();
+    expect(ends).toHaveLength(1);
+    expect(ends[0].details).toEqual({ reason: 'redirected' });
+    expect('claudeTokens' in ends[0]).toBe(false);
+  });
+
+  // Case 5 — throw path: phase_end in catch block carries claudeTokens
+  it('attaches claudeTokens on the catch-block phase_end when runInteractivePhase throws', async () => {
+    vi.mocked(runInteractivePhase).mockRejectedValueOnce(new Error('boom'));
+    vi.mocked(readClaudeSessionUsage).mockReturnValue(HAPPY_TOKENS);
+
+    const logger = new CapturingLogger();
+    const state = makeState({ currentPhase: 1 });
+    await expect(
+      handleInteractivePhase(1, state, HDIR, makeTmpDir(), CWD, logger as any)
+    ).rejects.toThrow('boom');
+
+    const ends = logger.phaseEnds();
+    expect(ends).toHaveLength(1);
+    expect(ends[0].status).toBe('failed');
+    expect(ends[0].claudeTokens).toEqual(HAPPY_TOKENS);
+  });
+
+  // Case 6 — artifact-commit failure path carries claudeTokens
+  it('attaches claudeTokens on the artifact-commit-failure phase_end', async () => {
+    vi.mocked(runInteractivePhase).mockResolvedValueOnce({ status: 'completed', attemptId: 'a-6' });
+    vi.mocked(readClaudeSessionUsage).mockReturnValue(HAPPY_TOKENS);
+    vi.mocked(normalizeArtifactCommit).mockImplementationOnce(() => {
+      throw new Error('git commit failed');
+    });
+
+    const logger = new CapturingLogger();
+    const state = makeState({ currentPhase: 1 });
+    await handleInteractivePhase(1, state, HDIR, makeTmpDir(), CWD, logger as any);
+
+    const ends = logger.phaseEnds();
+    expect(ends).toHaveLength(1);
+    expect(ends[0].status).toBe('failed');
+    expect(ends[0].claudeTokens).toEqual(HAPPY_TOKENS);
+  });
+});

--- a/tests/runners/claude-usage.test.ts
+++ b/tests/runners/claude-usage.test.ts
@@ -1,0 +1,289 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  encodeProjectDir,
+  readClaudeSessionUsage,
+} from '../../src/runners/claude-usage.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface AssistantTurnInput {
+  tsMs: number;
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheCreate?: number;
+}
+
+function assistantLine(t: AssistantTurnInput): string {
+  return JSON.stringify({
+    type: 'assistant',
+    timestamp: new Date(t.tsMs).toISOString(),
+    sessionId: 'fake',
+    message: {
+      usage: {
+        input_tokens: t.input ?? 0,
+        output_tokens: t.output ?? 0,
+        cache_read_input_tokens: t.cacheRead ?? 0,
+        cache_creation_input_tokens: t.cacheCreate ?? 0,
+      },
+    },
+  });
+}
+
+function nonAssistantLine(type: string, tsMs: number): string {
+  return JSON.stringify({ type, timestamp: new Date(tsMs).toISOString() });
+}
+
+function writeSession(absPath: string, lines: string[]): void {
+  fs.mkdirSync(path.dirname(absPath), { recursive: true });
+  fs.writeFileSync(absPath, lines.join('\n') + '\n');
+}
+
+function projectDirFor(tmpHome: string, cwd: string): string {
+  return path.join(tmpHome, '.claude', 'projects', encodeProjectDir(cwd));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('encodeProjectDir', () => {
+  it('encodes slashes and dots as hyphens', () => {
+    expect(
+      encodeProjectDir('/Users/daniel/.grove/github.com/DongGukMon/harness-cli')
+    ).toBe('-Users-daniel--grove-github-com-DongGukMon-harness-cli');
+  });
+
+  it('replaces all non-alphanumeric characters with hyphen', () => {
+    expect(encodeProjectDir('/a/b c/d_e')).toBe('-a-b-c-d-e');
+  });
+});
+
+describe('readClaudeSessionUsage', () => {
+  const PHASE_START = 1_750_000_000_000;
+  const CWD = '/tmp/fake-cwd';
+  const ATTEMPT_ID = '00000000-0000-4000-8000-000000000001';
+
+  let tmpHome: string;
+  let stderrSpy: any;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-usage-test-'));
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    stderrSpy.mockRestore();
+  });
+
+  // Case 1 — happy path (pinned)
+  it('sums usage across assistant turns in the pinned session file', () => {
+    const dir = projectDirFor(tmpHome, CWD);
+    writeSession(path.join(dir, `${ATTEMPT_ID}.jsonl`), [
+      nonAssistantLine('queue-operation', PHASE_START),
+      assistantLine({ tsMs: PHASE_START + 1_000, input: 1, output: 10, cacheRead: 100, cacheCreate: 1_000 }),
+      assistantLine({ tsMs: PHASE_START + 2_000, input: 2, output: 20, cacheRead: 200, cacheCreate: 2_000 }),
+      assistantLine({ tsMs: PHASE_START + 3_000, input: 3, output: 30, cacheRead: 300, cacheCreate: 3_000 }),
+    ]);
+    const result = readClaudeSessionUsage({
+      sessionId: ATTEMPT_ID,
+      cwd: CWD,
+      phaseStartTs: PHASE_START,
+      homeDir: tmpHome,
+    });
+    expect(result).toEqual({
+      input: 6,
+      output: 60,
+      cacheRead: 600,
+      cacheCreate: 6_000,
+      total: 6_666,
+    });
+  });
+
+  // Case 2 — fallback scan picks earliest-eligible (distinct timestamps)
+  it('falls back to scanning project dir when pinned file is missing and picks the smallest-eligible first-assistant timestamp', () => {
+    const dir = projectDirFor(tmpHome, CWD);
+    // fallback-before: first-assistant < phaseStartTs → must be excluded
+    writeSession(path.join(dir, 'fallback-before.jsonl'), [
+      assistantLine({ tsMs: PHASE_START - 5_000, input: 999, output: 999, cacheRead: 999, cacheCreate: 999 }),
+    ]);
+    // fallback-early: first-assistant == phaseStartTs + 1s → should be picked
+    writeSession(path.join(dir, 'fallback-early.jsonl'), [
+      assistantLine({ tsMs: PHASE_START + 1_000, input: 1, output: 2, cacheRead: 3, cacheCreate: 4 }),
+      assistantLine({ tsMs: PHASE_START + 2_000, input: 10, output: 20, cacheRead: 30, cacheCreate: 40 }),
+    ]);
+    // fallback-late: first-assistant == phaseStartTs + 60s → should NOT be picked
+    writeSession(path.join(dir, 'fallback-late.jsonl'), [
+      assistantLine({ tsMs: PHASE_START + 60_000, input: 500, output: 500, cacheRead: 500, cacheCreate: 500 }),
+    ]);
+
+    const result = readClaudeSessionUsage({
+      sessionId: ATTEMPT_ID,
+      cwd: CWD,
+      phaseStartTs: PHASE_START,
+      homeDir: tmpHome,
+    });
+    // Expected: early's two turns summed (1+10, 2+20, 3+30, 4+40, total)
+    expect(result).toEqual({
+      input: 11,
+      output: 22,
+      cacheRead: 33,
+      cacheCreate: 44,
+      total: 110,
+    });
+  });
+
+  // Case 3 — fallback has no eligible candidate
+  it('returns null when pinned file is missing and no fallback candidate is in the window', () => {
+    const dir = projectDirFor(tmpHome, CWD);
+    writeSession(path.join(dir, 'fallback-before.jsonl'), [
+      assistantLine({ tsMs: PHASE_START - 10_000, input: 1 }),
+    ]);
+    const result = readClaudeSessionUsage({
+      sessionId: ATTEMPT_ID,
+      cwd: CWD,
+      phaseStartTs: PHASE_START,
+      homeDir: tmpHome,
+    });
+    expect(result).toBeNull();
+  });
+
+  // Case 4 — malformed line skipped, stderr warn once
+  it('skips malformed JSON lines and warns exactly once per read', () => {
+    const dir = projectDirFor(tmpHome, CWD);
+    const lines = [
+      assistantLine({ tsMs: PHASE_START + 1, input: 1, output: 1, cacheRead: 1, cacheCreate: 1 }),
+      '{ this is not valid json ::::',
+      'also broken',
+      assistantLine({ tsMs: PHASE_START + 2, input: 2, output: 2, cacheRead: 2, cacheCreate: 2 }),
+    ];
+    writeSession(path.join(dir, `${ATTEMPT_ID}.jsonl`), lines);
+    const result = readClaudeSessionUsage({
+      sessionId: ATTEMPT_ID,
+      cwd: CWD,
+      phaseStartTs: PHASE_START,
+      homeDir: tmpHome,
+    });
+    expect(result).toEqual({ input: 3, output: 3, cacheRead: 3, cacheCreate: 3, total: 12 });
+
+    // Exactly one stderr write for the skipped-lines summary.
+    const writes = stderrSpy.mock.calls.map((c: any[]) => String(c[0]));
+    const skippedWrites = writes.filter((w: string) => /skip|malformed|parse/i.test(w));
+    expect(skippedWrites).toHaveLength(1);
+  });
+
+  // Case 5 — no assistant entries → zero-sum, not null
+  it('returns a zero-sum object when the session has no assistant entries', () => {
+    const dir = projectDirFor(tmpHome, CWD);
+    writeSession(path.join(dir, `${ATTEMPT_ID}.jsonl`), [
+      nonAssistantLine('queue-operation', PHASE_START),
+      nonAssistantLine('user', PHASE_START + 1_000),
+    ]);
+    const result = readClaudeSessionUsage({
+      sessionId: ATTEMPT_ID,
+      cwd: CWD,
+      phaseStartTs: PHASE_START,
+      homeDir: tmpHome,
+    });
+    expect(result).toEqual({ input: 0, output: 0, cacheRead: 0, cacheCreate: 0, total: 0 });
+  });
+
+  // Case 6 — cache-only entries sum correctly
+  it('aggregates cache-only entries (missing input_tokens) correctly', () => {
+    const dir = projectDirFor(tmpHome, CWD);
+    writeSession(path.join(dir, `${ATTEMPT_ID}.jsonl`), [
+      JSON.stringify({
+        type: 'assistant',
+        timestamp: new Date(PHASE_START + 100).toISOString(),
+        message: { usage: { cache_creation_input_tokens: 5_000 } },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        timestamp: new Date(PHASE_START + 200).toISOString(),
+        message: { usage: { cache_creation_input_tokens: 3_000, cache_read_input_tokens: 1_000 } },
+      }),
+    ]);
+    const result = readClaudeSessionUsage({
+      sessionId: ATTEMPT_ID,
+      cwd: CWD,
+      phaseStartTs: PHASE_START,
+      homeDir: tmpHome,
+    });
+    expect(result).toEqual({
+      input: 0,
+      output: 0,
+      cacheRead: 1_000,
+      cacheCreate: 8_000,
+      total: 9_000,
+    });
+  });
+
+  // Case 7 — project dir missing entirely → null + single warn
+  it('returns null with a single stderr warning when the project dir does not exist', () => {
+    const result = readClaudeSessionUsage({
+      sessionId: ATTEMPT_ID,
+      cwd: CWD,
+      phaseStartTs: PHASE_START,
+      homeDir: tmpHome, // this HOME has no ~/.claude/projects tree
+    });
+    expect(result).toBeNull();
+    const writes = stderrSpy.mock.calls.map((c: any[]) => String(c[0]));
+    expect(writes.length).toBe(1);
+  });
+
+  // Case 8 — tie-break by lexical filename when two candidates share a timestamp
+  it('breaks ties by lexical filename order when two fallback candidates share a first-assistant timestamp', () => {
+    const dir = projectDirFor(tmpHome, CWD);
+    const tieTs = PHASE_START + 2_000;
+    writeSession(path.join(dir, 'fallback-tie-a.jsonl'), [
+      assistantLine({ tsMs: tieTs, input: 1, output: 1, cacheRead: 1, cacheCreate: 1 }),
+    ]);
+    writeSession(path.join(dir, 'fallback-tie-b.jsonl'), [
+      assistantLine({ tsMs: tieTs, input: 9, output: 9, cacheRead: 9, cacheCreate: 9 }),
+    ]);
+
+    const result = readClaudeSessionUsage({
+      sessionId: ATTEMPT_ID,
+      cwd: CWD,
+      phaseStartTs: PHASE_START,
+      homeDir: tmpHome,
+    });
+    // tie-a wins lexically
+    expect(result).toEqual({ input: 1, output: 1, cacheRead: 1, cacheCreate: 1, total: 4 });
+  });
+
+  // Case 9 — hard I/O on pinned file (non-ENOENT) → null + single stderr warn
+  it('returns null with a single stderr warning when the pinned file exists but read fails hard (e.g. EACCES)', () => {
+    const dir = projectDirFor(tmpHome, CWD);
+    const pinnedPath = path.join(dir, `${ATTEMPT_ID}.jsonl`);
+    writeSession(pinnedPath, [assistantLine({ tsMs: PHASE_START + 1, input: 1 })]);
+
+    const orig = fs.readFileSync;
+    const readSpy = vi.spyOn(fs, 'readFileSync').mockImplementation(((p: any, ...rest: any[]) => {
+      if (typeof p === 'string' && p === pinnedPath) {
+        const err: NodeJS.ErrnoException = new Error('EACCES simulated');
+        err.code = 'EACCES';
+        throw err;
+      }
+      return (orig as any)(p, ...rest);
+    }) as any);
+
+    try {
+      const result = readClaudeSessionUsage({
+        sessionId: ATTEMPT_ID,
+        cwd: CWD,
+        phaseStartTs: PHASE_START,
+        homeDir: tmpHome,
+      });
+      expect(result).toBeNull();
+      const writes = stderrSpy.mock.calls.map((c: any[]) => String(c[0]));
+      expect(writes.length).toBe(1);
+    } finally {
+      readSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
Closes observability gap #12 (CLAUDE.md "현재 open issues" table).

## Summary
- `phase_end` events for interactive phases now carry an optional `claudeTokens: { input, output, cacheRead, cacheCreate, total }` field when the phase preset's runner is Claude. Gate phases (2/4/7) already had `tokensTotal`; this fills the symmetric gap for phases 1/3/5.
- Mechanism: pin Claude's session UUID via `claude --session-id ${attemptId}` → parse `~/.claude/projects/<encodedCwd>/<attemptId>.jsonl`. Fallback: project-dir scan for the session whose first-assistant timestamp is closest to (but not before) `phaseStartTs`.
- Three-state contract on `phase_end` (per spec §2.5):
  - `claudeTokens: { ... }` = success
  - `claudeTokens: null`    = extraction failed (runner was Claude)
  - field absent            = not attempted (codex runner, non-interactive phase, or redirected-by-signal)
- Attached to all four real-work emission sites: completed, artifact-commit failure, normal failed, catch-block throw. Redirect-by-signal intentionally skipped.
- No `state.json` migration, no schema changes beyond the one optional field, `events.jsonl` v:1 remains append-only backward-compatible.

## Rationale / token source selection
Evaluated four candidates (spec §2.1 + §2.2):
- (a) stdout/stderr end-of-session summary — Claude Code does not emit one in interactive mode.
- (b) JSONL parse with pinned `--session-id` — selected. Deterministic filename; reuses the UUID the harness already mints as `attemptId`.
- (c) Stop hook — would mutate `~/.claude/settings.json`; brittle across Claude versions.
- (d) `/usage` subcommand — does not exist.

## Fallback policy
Pinned file missing → scan project dir; pick smallest first-assistant timestamp `>= phaseStartTs`; tiebreak by lexical filename. Hard I/O errors on either path → `null` + single stderr warn. Per-line `JSON.parse` errors skipped silently with one trailing warn per phase. Zero assistant entries → zero-sum, not null.

## Design review
Codex plan gate: APPROVED after 5 rounds (spec-tightening loop). Full design at `docs/specs/2026-04-18-claude-token-capture-design.md`. §6.1 records one deferred P2 (dedicated unit test for the `--session-id` flag in `runClaudeInteractive`; integration coverage in `tests/phases/runner-token-capture.test.ts` plus the real-data smoke below prove the flag is wired correctly).

## Smoke result
A real-data smoke was run against a past dog-fooding session (`~/.claude/projects/-Users-daniel--grove-github-com-DongGukMon-harness-cli-worktrees-experimental-todo/1166e3d5-70ac-403e-9ab5-d5c31c5810a8.jsonl`):

```
encoded: -Users-daniel--grove-github-com-DongGukMon-harness-cli-worktrees-experimental-todo
real session files: 6
result: {
  input: 590,
  output: 121973,
  cacheRead: 12552271,
  cacheCreate: 553133,
  total: 13227967
}
```

Arithmetic identity holds: `590 + 121973 + 12552271 + 553133 === 13227967`. Confirms path encoding, JSONL parse, and aggregation all behave correctly on real Claude Code output.

A full end-to-end `harness run --enable-logging` smoke (building into the Desktop experimental dist and running a trivial task to observe `events.jsonl`) requires an interactive Claude session in another process and is left for post-merge validation. The spec's §4 acceptance criteria (four subfields + arithmetic identity + `total > 0` on at least one phase) are directly verifiable from the unit fixture above.

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm vitest run` — 514 passed / 1 skipped (baseline 497 + 17 new)
- [x] `pnpm build` produces dist with the new module
- [x] Parser real-data smoke against a past dog-fooding jsonl
- [ ] Post-merge: run `harness run --enable-logging "<trivial task>"` from experimental worktree and confirm `events.jsonl` `phase_end` entries for Claude interactive phases carry `claudeTokens` with the four subfields + total.

## Out of scope
- Codex interactive token capture (Codex runner exposes tokens only on gate runs today).
- Gate/verify phase re-capture (gate already has `tokensTotal`; verify has no preset).
- Cost/pricing calculations.
- CLAUDE.md event-schema table refresh (per repo convention, deferred to next session-index refresh).