### PR TITLE
feat(light-flow): harness start --light implementation (PR #17 plan execution)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,3 +109,6 @@ Session meta: `~/.harness/sessions/<hash>/<runId>/{events.jsonl, meta.json, summ
 ## 풀 프로세스 호출
 
 개발 전체 사이클은 `/harness` 스킬로 실행. 내부 phase 순서·gate 규약은 전역 규칙 `harness-lifecycle` 섹션 참조.
+
+경량 4-phase 플로우는 `harness start --light "<task>"` 로 활성화한다. 상세한 동작은
+`docs/HOW-IT-WORKS.md`의 "Light Flow" 섹션과 `docs/specs/2026-04-18-light-flow-design.md`를 참조.

--- a/bin/harness.ts
+++ b/bin/harness.ts
@@ -22,7 +22,8 @@ program
   .option('--require-clean', 'block if working tree has any uncommitted changes')
   .option('--auto', 'autonomous mode (no user escalations)')
   .option('--enable-logging', 'enable session logging to ~/.harness/sessions')
-  .action(async (task: string | undefined, opts: { requireClean?: boolean; auto?: boolean; enableLogging?: boolean }) => {
+  .option('--light', 'use the 4-phase light flow (P1 → P5 → P6 → P7)')
+  .action(async (task: string | undefined, opts: { requireClean?: boolean; auto?: boolean; enableLogging?: boolean; light?: boolean }) => {
     const globalOpts = program.opts();
     await startCommand(task, { ...opts, root: globalOpts.root });
   });
@@ -33,7 +34,8 @@ program
   .option('--require-clean', 'block if working tree has any uncommitted changes')
   .option('--auto', 'autonomous mode (no user escalations)')
   .option('--enable-logging', 'enable session logging to ~/.harness/sessions')
-  .action(async (task: string | undefined, opts: { requireClean?: boolean; auto?: boolean; enableLogging?: boolean }) => {
+  .option('--light', 'use the 4-phase light flow (P1 → P5 → P6 → P7)')
+  .action(async (task: string | undefined, opts: { requireClean?: boolean; auto?: boolean; enableLogging?: boolean; light?: boolean }) => {
     const globalOpts = program.opts();
     await startCommand(task, { ...opts, root: globalOpts.root });
   });
@@ -41,7 +43,8 @@ program
 program
   .command('resume [runId]')
   .description('resume an existing run')
-  .action(async (runId: string | undefined, opts: Record<string, never>) => {
+  .option('--light', '(rejected — flow is frozen at run creation)')
+  .action(async (runId: string | undefined, opts: { light?: boolean }) => {
     const globalOpts = program.opts();
     await resumeCommand(runId, { ...opts, root: globalOpts.root });
   });

--- a/docs/HOW-IT-WORKS.ko.md
+++ b/docs/HOW-IT-WORKS.ko.md
@@ -34,6 +34,30 @@ harness run "task"
 
 ---
 
+## 경량 플로우 (`harness start --light`)
+
+중간 규모 작업(≈1–4시간, ≤~500 LoC, 모듈 ≤3개)에는 풀 플로우의 3회 interactive
+세션 + 3회 Codex gate가 과합니다. `--light`는 plan 산출물을 Phase 1 결합 문서에
+흡수하고 pre-impl gate 2개를 제거한 4-phase 파이프라인을 선택합니다:
+
+```
+P1 design(=brainstorm+plan) → [P2/P3/P4 skipped] → P5 impl → P6 verify → P7 eval-gate
+                                                                                  │
+                                       P7 REJECT → P1 reopen (+ carryoverFeedback) ┘
+                                                        └─> P5 reopen (carryover 소비) ─> P6 ─> P7
+                                       P6 FAIL → P5 reopen (직접)
+```
+
+- **state.flow**: `'full' | 'light'`, run 생성 시점에 고정. `harness resume --light`는 거부됩니다.
+- **skipped phases**: `phases['2'|'3'|'4']`가 신규 `'skipped'` status로 초기화되고 `runPhaseLoop`가 핸들러 호출 없이 건너뜁니다. `renderControlPanel`은 em-dash 아이콘과 `(skipped)` 라벨로 표시합니다.
+- **Phase 1 산출물**: `docs/specs/<runId>-design.md` 하나의 결합 문서에 필수 `## Implementation Plan` 섹션을 포함합니다. `checklist.json`은 `scripts/harness-verify.sh`가 파싱해야 하므로 별도 파일로 유지.
+- **Phase 7 REJECT**: Phase 1으로 되돌립니다(Phase 5가 아니라 결합 문서 자체를 다시 쓰기 위함). `state.carryoverFeedback`이 Phase 1 완료 시 `pendingAction`이 비워져도 살아남아 Phase 5 재진입 시 소비됩니다.
+- **기본 preset**: P1 = `opus-max`, P5 = `sonnet-high`, P7 = `codex-high` (P2/P3/P4만 빠진 풀 플로우와 동일).
+- **활성화**: `harness start --light "태스크"` (또는 `harness run --light …`). `--light`는 `--auto`와 직교.
+- **풀 플로우가 더 나은 경우**: 마이그레이션/보안/계약 변경처럼 pre-impl 독립 리뷰 가치가 큰 작업.
+
+---
+
 ## Phase별 상세 설명
 
 ### Phase 1 — 브레인스토밍

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -34,6 +34,31 @@ harness run "task"
 
 ---
 
+## Light Flow (`harness start --light`)
+
+For medium tasks (≈1–4h, ≤~500 LoC, ≤3 modules) the default full flow's three
+interactive sessions and three Codex gates are overkill. `--light` selects a
+4-phase pipeline that folds the plan artifact into the Phase 1 design doc and
+removes the two pre-impl gates:
+
+```
+P1 design(=brainstorm+plan) → [P2/P3/P4 skipped] → P5 impl → P6 verify → P7 eval-gate
+                                                                                  │
+                                       P7 REJECT → P1 reopen (+ carryoverFeedback) ┘
+                                                        └─> P5 reopen (carryover 소비) ─> P6 ─> P7
+                                       P6 FAIL → P5 reopen (직접)
+```
+
+- **state.flow**: `'full' | 'light'`, frozen at run creation. `harness resume --light` is rejected.
+- **skipped phases**: `phases['2'|'3'|'4']` initialize to the new `'skipped'` `PhaseStatus`. `runPhaseLoop` short-circuits past them; `renderControlPanel` shows them with an em-dash glyph and `(skipped)` label.
+- **Phase 1 output**: single combined doc at `docs/specs/<runId>-design.md` containing a mandatory `## Implementation Plan` section. `checklist.json` stays a separate file so `scripts/harness-verify.sh` still parses it.
+- **Phase 7 REJECT**: routed back to Phase 1 (not Phase 5 — the combined doc is re-authored). `state.carryoverFeedback` survives the Phase 1 completion that clears `pendingAction` and is consumed by Phase 5 on re-entry.
+- **Defaults**: P1 = `opus-max`, P5 = `sonnet-high`, P7 = `codex-high` (same presets as full flow, minus P2/P3/P4).
+- **Activation**: `harness start --light "task"` (or `harness run --light …`). `--light` composes with `--auto`.
+- **When full flow is still right**: migration/security/contract work, or any task where an independent pre-impl review adds real value.
+
+---
+
 ## Phase-by-phase breakdown
 
 ### Phase 1 — Brainstorming

--- a/src/commands/inner.ts
+++ b/src/commands/inner.ts
@@ -11,7 +11,7 @@ import { killSession, killWindow, selectWindow, splitPane, paneExists, selectPan
 import { renderWelcome, promptModelConfig } from '../ui.js';
 import { InputManager } from '../input.js';
 import { runRunnerAwarePreflight } from '../preflight.js';
-import { REQUIRED_PHASE_KEYS, getEffectiveReopenTarget } from '../config.js';
+import { REQUIRED_PHASE_KEYS, getEffectiveReopenTarget, getRequiredPhaseKeys } from '../config.js';
 import { createSessionLogger } from '../logger.js';
 import type { SessionLogger, HarnessState } from '../types.js';
 
@@ -148,10 +148,16 @@ export async function innerCommand(runId: string, options: InnerOptions = {}): P
   inputManager.onConfigCancel = buildConfigCancelHandler({ state, runDir, harnessDir, runId, isResume, logger, inputManager });
   inputManager.start('configuring');
 
-  // Step 5.7: Compute remaining phases (including pendingAction reopen target)
+  // Step 5.7: Compute remaining phases (including pendingAction reopen target).
+  // Light flow skips 2/3/4 so the key set is narrowed at source (getRequiredPhaseKeys).
+  const flowPhaseKeys = getRequiredPhaseKeys(state.flow);
   const remainingSet = new Set<string>();
-  for (const p of REQUIRED_PHASE_KEYS) {
-    if (Number(p) >= state.currentPhase && state.phases[p] !== 'completed') {
+  for (const p of flowPhaseKeys) {
+    if (
+      Number(p) >= state.currentPhase &&
+      state.phases[p] !== 'completed' &&
+      state.phases[p] !== 'skipped'
+    ) {
       remainingSet.add(p);
     }
   }

--- a/src/commands/inner.ts
+++ b/src/commands/inner.ts
@@ -297,9 +297,11 @@ function consumePendingAction(runDir: string, state: HarnessState): void {
       state.phases[String(state.currentPhase)] = 'completed';
       state.currentPhase = state.currentPhase + 1;
     } else if (action.action === 'jump' && typeof action.phase === 'number') {
-      // Reset phases >= target and set currentPhase
+      // Reset phases >= target and set currentPhase. Preserve 'skipped'
+      // (light flow only) so P2/P3/P4 do not resurrect as 'pending'.
       for (let m = action.phase; m <= 7; m++) {
-        state.phases[String(m)] = 'pending';
+        const cur = state.phases[String(m)];
+        state.phases[String(m)] = cur === 'skipped' ? 'skipped' : 'pending';
       }
       state.currentPhase = action.phase;
       state.pendingAction = null;

--- a/src/commands/jump.ts
+++ b/src/commands/jump.ts
@@ -35,6 +35,14 @@ export async function jumpCommand(phaseArg: string, options: JumpOptions = {}): 
     process.exit(1);
   }
 
+  // Reject jumping into a 'skipped' phase (light flow P2/P3/P4 are illegal targets).
+  if (state.phases[String(N)] === 'skipped') {
+    process.stderr.write(
+      `Error: phase ${N} is 'skipped' in this run (flow=${state.flow}); cannot jump to a skipped phase.\n`,
+    );
+    process.exit(1);
+  }
+
   // 3. Forward jump rejected (unless from completed)
   const isCompleted = state.status === 'completed' || state.currentPhase === 8;
   if (!isCompleted && N >= state.currentPhase) {

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -13,9 +13,18 @@ import { printError } from '../ui.js';
 
 export interface ResumeOptions {
   root?: string;
+  light?: boolean;
 }
 
 export async function resumeCommand(runId?: string, options: ResumeOptions = {}): Promise<void> {
+  if (options.light) {
+    process.stderr.write(
+      "Error: --light is only valid on 'harness start'. flow is frozen at run creation; " +
+      "start a new run with 'harness start --light' if you want the light flow.\n",
+    );
+    process.exit(1);
+  }
+
   // 1. Find harness root
   const harnessDir = findHarnessRoot(options.root);
   let cwd: string;

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -16,6 +16,7 @@ export interface StartOptions {
   auto?: boolean;
   root?: string;
   enableLogging?: boolean;
+  light?: boolean;
 }
 
 export async function startCommand(task: string | undefined, options: StartOptions = {}): Promise<void> {
@@ -102,7 +103,14 @@ export async function startCommand(task: string | undefined, options: StartOptio
     }
 
     // 12. Create initial state
-    const state = createInitialState(runId, normalizedTask, baseCommit, options.auto ?? false, options.enableLogging ?? false);
+    const state = createInitialState(
+      runId,
+      normalizedTask,
+      baseCommit,
+      options.auto ?? false,
+      options.enableLogging ?? false,
+      options.light ? 'light' : 'full',
+    );
 
     // 13. Save task.md (needed before Phase 1 spawn)
     try {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import type { PendingAction } from './types.js';
+import type { PendingAction, FlowMode, PhaseNumber, Artifacts, GatePhase, InteractivePhase } from './types.js';
 
 export interface ModelPreset {
   id: string;
@@ -61,3 +61,38 @@ export const PHASE_ARTIFACT_FILES: Record<number, string[]> = {
   1: ['spec', 'decisionLog'],
   3: ['plan', 'checklist'],
 };
+
+export const LIGHT_REQUIRED_PHASE_KEYS = ['1', '5', '7'] as const;
+
+export const LIGHT_PHASE_DEFAULTS: Record<number, string> = {
+  1: 'opus-max',
+  5: 'sonnet-high',
+  7: 'codex-high',
+};
+
+export function getRequiredPhaseKeys(flow: FlowMode): readonly string[] {
+  return flow === 'light' ? LIGHT_REQUIRED_PHASE_KEYS : REQUIRED_PHASE_KEYS;
+}
+
+export function getPhaseDefaults(flow: FlowMode): Record<number, string> {
+  return flow === 'light' ? LIGHT_PHASE_DEFAULTS : PHASE_DEFAULTS;
+}
+
+export function getPhaseArtifactFiles(
+  flow: FlowMode,
+  phase: PhaseNumber,
+): Array<keyof Artifacts> {
+  if (flow === 'light') {
+    return phase === 1 ? ['spec', 'decisionLog', 'checklist'] : [];
+  }
+  if (phase === 1) return ['spec', 'decisionLog'];
+  if (phase === 3) return ['plan', 'checklist'];
+  return [];
+}
+
+export function getReopenTarget(flow: FlowMode, gate: GatePhase): InteractivePhase {
+  if (flow === 'light' && gate === 7) return 1;
+  if (gate === 2) return 1;
+  if (gate === 4) return 3;
+  return 5; // gate 7 + full
+}

--- a/src/context/assembler.ts
+++ b/src/context/assembler.ts
@@ -327,9 +327,27 @@ export function assembleInteractivePrompt(
   // Phase 1 uses task.md file path (not raw task string) per spec
   const taskMdPath = path.join('.harness', state.runId, 'task.md');
 
-  // feedback_path: first feedback from pendingAction, if any
-  // feedback_paths: all feedbacks (Phase 5 may have both gate-7 + verify)
-  const feedbackPaths = state.pendingAction?.feedbackPaths ?? [];
+  // Merge pendingAction.feedbackPaths with carryoverFeedback.paths when the
+  // carryover targets this phase. Carryover paths are dropped with a warning
+  // when missing on disk (spec R8 — the P7→P1→P5 bridge may lose the file);
+  // pendingAction paths are trusted (written by the harness this same turn).
+  const pendingPaths = state.pendingAction?.feedbackPaths ?? [];
+  const carryoverRawPaths =
+    state.carryoverFeedback && state.carryoverFeedback.deliverToPhase === phase
+      ? state.carryoverFeedback.paths
+      : [];
+  const carryoverPaths: string[] = [];
+  for (const p of carryoverRawPaths) {
+    const abs = path.isAbsolute(p) ? p : path.join(harnessDir, '..', p);
+    if (fs.existsSync(abs)) {
+      carryoverPaths.push(p);
+    } else {
+      process.stderr.write(
+        `⚠️  carryover feedback path not found on disk, skipping: ${p}\n`,
+      );
+    }
+  }
+  const feedbackPaths = [...pendingPaths, ...carryoverPaths];
   const feedbackPath = feedbackPaths[0];
   const feedbackPathsList = feedbackPaths
     .map((p) => `- 이전 피드백 (반드시 반영): ${p}`)
@@ -352,6 +370,12 @@ export function assembleInteractivePrompt(
     harnessDir,
     playbookDir,
   };
+
+  // Light flow: phase 1 and 5 use self-contained light templates (no wrapper skill).
+  if (state.flow === 'light' && (phase === 1 || phase === 5)) {
+    const templateFile = phase === 1 ? 'phase-1-light.md' : 'phase-5-light.md';
+    return renderTemplate(readTemplateFile(templateFile), vars);
+  }
 
   // Two-pass render: wrapper body vars resolve first, then thin phase template
   // injects the rendered wrapper at {{wrapper_skill}} and resolves its own vars.

--- a/src/context/assembler.ts
+++ b/src/context/assembler.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
-import type { HarnessState } from '../types.js';
+import type { HarnessState, FlowMode } from '../types.js';
 import {
   MAX_FILE_SIZE_KB,
   MAX_PROMPT_SIZE_KB,
@@ -58,7 +58,7 @@ const FIVE_AXIS_PLAN_GATE = `
 4. Readability — 맥락 없이 태스크 하나만 집어도 수행 가능?
 `;
 
-const FIVE_AXIS_EVAL_GATE = `
+const FIVE_AXIS_EVAL_GATE_FULL = `
 ## Five-Axis Evaluation (Phase 7 — eval gate)
 평가 대상은 spec + plan + eval report + diff. 5축 전부:
 1. Correctness — 구현이 spec+plan과 일치? 경계조건·테스트 커버리지?
@@ -69,10 +69,25 @@ const FIVE_AXIS_EVAL_GATE = `
 Severity: P0/P1=Critical(블록), P2=Important, P3=Suggestion.
 `;
 
-const REVIEWER_CONTRACT_BY_GATE: Record<2 | 4 | 7, string> = {
+const FIVE_AXIS_EVAL_GATE_LIGHT = `
+## Five-Axis Evaluation (Phase 7 — eval gate, light flow)
+평가 대상은 **결합 design spec** (spec + Implementation Plan 섹션이 한 문서에 있음) + eval report + diff. 5축 전부:
+1. Correctness — 구현이 결합 spec의 Implementation Plan 섹션과 일치? 경계조건·테스트 커버리지?
+2. Readability — 이름/흐름/로컬 복잡도 적절?
+3. Architecture — 기존 패턴 부합, 경계 선명, 조기 추상화 없음?
+4. Security — 경계 입력 검증, 비밀 노출, 인증 경로?
+5. Performance — N+1, 무한 루프, 핫패스 회귀?
+Severity: P0/P1=Critical(블록), P2=Important, P3=Suggestion.
+Note: 이 플로우에는 별도의 plan 아티팩트가 없다. plan 부재를 finding으로 올리지 말 것.
+`;
+
+function reviewerContractForGate7(flow: FlowMode): string {
+  return REVIEWER_CONTRACT_BASE + (flow === 'light' ? FIVE_AXIS_EVAL_GATE_LIGHT : FIVE_AXIS_EVAL_GATE_FULL);
+}
+
+const REVIEWER_CONTRACT_BY_GATE: Record<2 | 4, string> = {
   2: REVIEWER_CONTRACT_BASE + FIVE_AXIS_SPEC_GATE,
   4: REVIEWER_CONTRACT_BASE + FIVE_AXIS_PLAN_GATE,
-  7: REVIEWER_CONTRACT_BASE + FIVE_AXIS_EVAL_GATE,
 };
 
 function readTemplateFile(filename: string): string {
@@ -164,7 +179,7 @@ function runGit(cmd: string, cwd: string): string {
 // later-phase artifacts do not yet exist. Keeps BUG-A from recurring: gates
 // used to flag "plan file missing" at Gate 2 even though plan = Phase 3.
 
-function buildLifecycleContext(phase: 2 | 4 | 7): string {
+function buildLifecycleContext(phase: 2 | 4 | 7, flow: FlowMode = 'full'): string {
   if (phase === 2) {
     return (
       '<harness_lifecycle>\n' +
@@ -179,6 +194,16 @@ function buildLifecycleContext(phase: 2 | 4 | 7): string {
       '<harness_lifecycle>\n' +
       'This is Gate 4 of a 7-phase harness lifecycle. You are reviewing the <spec> and <plan>. ' +
       'The implementation (Phase 5) has not yet been produced; its absence must NOT appear as a finding.\n' +
+      '</harness_lifecycle>\n\n'
+    );
+  }
+  // phase === 7
+  if (flow === 'light') {
+    return (
+      '<harness_lifecycle>\n' +
+      'This is Gate 7 of a 4-phase light harness lifecycle (P1 design → P5 impl → P6 verify → P7 eval). ' +
+      'The combined design spec contains the Implementation Plan section; there is no separate plan artifact. ' +
+      'This is the terminal review — if APPROVE, the run is complete.\n' +
       '</harness_lifecycle>\n\n'
     );
   }
@@ -289,17 +314,30 @@ function buildGatePromptPhase7(state: HarnessState, cwd: string): string | { err
   const specResult = readArtifactContent(state.artifacts.spec, cwd);
   if ('error' in specResult) return specResult;
 
-  const planResult = readArtifactContent(state.artifacts.plan, cwd);
-  if ('error' in planResult) return planResult;
-
   const evalResult = readArtifactContent(state.artifacts.evalReport, cwd);
   if ('error' in evalResult) return evalResult;
 
   const { diffSection, externalSummary, metadata } = buildPhase7DiffAndMetadata(state, cwd);
 
+  if (state.flow === 'light') {
+    return (
+      reviewerContractForGate7('light') +
+      buildLifecycleContext(7, 'light') +
+      `<spec>\n${specResult.content}\n</spec>\n\n` +
+      `<eval_report>\n${evalResult.content}\n</eval_report>\n\n` +
+      diffSection +
+      externalSummary +
+      '\n' +
+      metadata
+    );
+  }
+
+  const planResult = readArtifactContent(state.artifacts.plan, cwd);
+  if ('error' in planResult) return planResult;
+
   return (
-    REVIEWER_CONTRACT_BY_GATE[7] +
-    buildLifecycleContext(7) +
+    reviewerContractForGate7('full') +
+    buildLifecycleContext(7, 'full') +
     `<spec>\n${specResult.content}\n</spec>\n\n` +
     `<plan>\n${planResult.content}\n</plan>\n\n` +
     `<eval_report>\n${evalResult.content}\n</eval_report>\n\n` +
@@ -427,7 +465,9 @@ function buildResumeSections(
   if ('error' in specResult) return specResult;
   let body = `<spec>\n${specResult.content}\n</spec>\n`;
 
-  if (phase === 4 || phase === 7) {
+  const lightEvalGate = phase === 7 && state.flow === 'light';
+
+  if ((phase === 4 || phase === 7) && !lightEvalGate) {
     const planResult = readArtifactContent(state.artifacts.plan, cwd);
     if ('error' in planResult) return planResult;
     body += `\n<plan>\n${planResult.content}\n</plan>\n`;

--- a/src/context/prompts/phase-1-light.md
+++ b/src/context/prompts/phase-1-light.md
@@ -1,0 +1,43 @@
+다음 파일에서 태스크 설명을 읽고 요구사항을 분석한 뒤 **설계 + 구현 태스크 분해 + 체크리스트**를 하나의 결합 문서에 작성하라:
+- Task: {{task_path}}
+{{#if feedback_path}}
+- 이전 리뷰 피드백 (반드시 반영 — 결합 문서의 관련 섹션을 diff-aware하게 수정하라): {{feedback_path}}
+{{/if}}
+
+결합 문서는 "{{spec_path}}" 경로에 작성한다. 아래 섹션을 **순서 그대로** 포함하라:
+
+```
+# <title> — Design Spec (Light)
+## Context & Decisions
+## Requirements / Scope
+## Design
+## Implementation Plan       (필수 헤더, 정확히 이 텍스트)
+  - Task 1: ...
+  - Task 2: ...
+## Eval Checklist Summary    (checklist.json 요약; 실제 검증 JSON은 별도 파일)
+```
+
+`## Implementation Plan` 섹션은 구현 태스크를 각각 1개 이상 체크리스트 아이템(또는 번호 목록)으로 분해하라. 본 섹션이 누락되면 harness는 Phase 1을 실패로 간주한다.
+
+Decision Log는 "{{decisions_path}}" 경로에 별도 파일로 작성하라.
+
+Eval Checklist는 "{{checklist_path}}" 경로에 아래 JSON 스키마로 저장하라:
+```json
+{
+  "checks": [
+    { "name": "<검증 항목 이름>", "command": "<실행 커맨드>" }
+  ]
+}
+```
+`checks` 배열은 비어있지 않아야 하며 각 항목에 `name`(string)과 `command`(string)이 필수다.
+
+각 check command는 격리된 셸 환경에서 실행된다. venv/node_modules 등 의존성을 요구하는 검증은 절대경로 바이너리(`.venv/bin/python -m pytest`, `./node_modules/.bin/eslint`)나 env-aware 래퍼(`make test`, `pnpm test`)를 사용하라.
+
+작업을 모두 마친 뒤 `.harness/{{runId}}/phase-1.done` 파일을 생성하되 내용으로 '{{phaseAttemptId}}' 한 줄만 기록하라.
+
+**CRITICAL: sentinel 파일(phase-1.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 이후 하네스는 다음 단계(impl)로 넘어가므로 추가 작업을 하지 말 것.**
+
+**HARNESS FLOW CONSTRAINT**: 이 세션은 orchestrated harness 라이프사이클(light flow) 내부에서 실행된다. spec-gate와 plan-gate는 이 플로우에서 skip 된다. 다음 phase(구현)은 이 결합 문서를 읽고 바로 코드를 작성하므로:
+- `advisor()` 툴을 호출하지 말 것. 외부 리뷰가 Gate 7에서 예약되어 있다.
+- 작업 범위는 이 프롬프트가 지시한 산출물(결합 문서 + decisions.md + checklist.json) + 커밋 + sentinel 생성으로 제한한다.
+- skill 자동 로드는 허용. 그러나 의사결정을 advisor에 위임하지 말고 자체적으로 결론을 낸다.

--- a/src/context/prompts/phase-5-light.md
+++ b/src/context/prompts/phase-5-light.md
@@ -1,0 +1,20 @@
+다음 파일을 읽고 컨텍스트를 파악한 뒤 구현을 진행하라:
+- Combined Design Spec (light): {{spec_path}}
+- Decision Log: {{decisions_path}}
+- Checklist: {{checklist_path}}
+{{#if feedback_paths}}
+{{feedback_paths}}
+{{/if}}
+
+결합 문서의 `## Implementation Plan` 섹션을 구현 roadmap으로 사용한다. 별도 plan 파일은 존재하지 않는다.
+
+각 태스크 완료 시 반드시 변경사항을 git commit하라. commit 없이 세션을 종료하면 eval gate에서 변경분을 볼 수 없어 run이 실패한다.
+
+구현 완료 후 `.harness/{{runId}}/phase-5.done` 파일을 생성하되 내용으로 '{{phaseAttemptId}}' 한 줄만 기록하라.
+
+**CRITICAL: sentinel 파일(phase-5.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 이후 하네스는 다음 단계(리뷰/피드백)로 넘어가므로 추가 작업을 하지 말 것.**
+
+**HARNESS FLOW CONSTRAINT**: 이 세션은 orchestrated harness 라이프사이클(light flow) 내부에서 실행된다. 다음 phase에서 Codex 기반 독립 reviewer가 산출물을 검토한다(Gate 7). 따라서:
+- `advisor()` 툴을 호출하지 말 것. 외부 리뷰가 이미 예약되어 있다.
+- 작업 범위는 이 프롬프트가 지시한 산출물(git commits + sentinel)로 제한한다.
+- skill 자동 로드는 허용. 그러나 의사결정을 advisor에 위임하지 말고 자체적으로 결론을 낸다.

--- a/src/phases/checklist.ts
+++ b/src/phases/checklist.ts
@@ -1,0 +1,15 @@
+import fs from 'fs';
+
+export function isValidChecklistSchema(absPath: string): boolean {
+  try {
+    const raw = fs.readFileSync(absPath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.checks) || parsed.checks.length === 0) return false;
+    for (const check of parsed.checks) {
+      if (typeof check?.name !== 'string' || typeof check?.command !== 'string') return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/phases/interactive.ts
+++ b/src/phases/interactive.ts
@@ -4,12 +4,13 @@ import { randomUUID } from 'crypto';
 import { execSync } from 'child_process';
 import chokidar from 'chokidar';
 import type { HarnessState, InteractivePhase, Artifacts } from '../types.js';
-import { PHASE_ARTIFACT_FILES, getPresetById } from '../config.js';
+import { getPhaseArtifactFiles, getPresetById } from '../config.js';
 import { writeState } from '../state.js';
 import { getHead } from '../git.js';
 import { isPidAlive } from '../process.js';
 import { assembleInteractivePrompt } from '../context/assembler.js';
 import { runClaudeInteractive } from '../runners/claude.js';
+import { isValidChecklistSchema } from './checklist.js';
 
 export interface InteractiveResult {
   status: 'completed' | 'failed';
@@ -39,13 +40,12 @@ export function preparePhase(
 
   // Delete artifacts only on first run (not reopen)
   if (!isReopen) {
-    const artifactKeys = PHASE_ARTIFACT_FILES[phase] as (keyof Artifacts)[] | undefined;
-    if (artifactKeys) {
-      for (const key of artifactKeys) {
-        const relPath = state.artifacts[key];
-        const absPath = path.isAbsolute(relPath) ? relPath : path.join(cwd, relPath);
-        try { fs.unlinkSync(absPath); } catch { /* ignore */ }
-      }
+    const artifactKeys = getPhaseArtifactFiles(state.flow, phase);
+    for (const key of artifactKeys) {
+      const relPath = state.artifacts[key];
+      if (!relPath) continue;
+      const absPath = path.isAbsolute(relPath) ? relPath : path.join(cwd, relPath);
+      try { fs.unlinkSync(absPath); } catch { /* ignore */ }
     }
   }
 
@@ -98,8 +98,8 @@ export function validatePhaseArtifacts(
 ): boolean {
   if (phase === 1 || phase === 3) {
     const openedAt = state.phaseOpenedAt[String(phase)];
-    const artifactKeys = PHASE_ARTIFACT_FILES[phase] as (keyof Artifacts)[] | undefined;
-    if (!artifactKeys) return false;
+    const artifactKeys = getPhaseArtifactFiles(state.flow, phase);
+    if (artifactKeys.length === 0) return false;
 
     for (const key of artifactKeys) {
       const relPath = state.artifacts[key];
@@ -122,6 +122,24 @@ export function validatePhaseArtifacts(
         ? state.artifacts.checklist
         : path.join(cwd, state.artifacts.checklist);
       if (!isValidChecklistSchema(checklistPath)) return false;
+    }
+
+    // Light + phase 1: checklist schema + '## Implementation Plan' header
+    if (state.flow === 'light' && phase === 1) {
+      const checklistPath = path.isAbsolute(state.artifacts.checklist)
+        ? state.artifacts.checklist
+        : path.join(cwd, state.artifacts.checklist);
+      if (!isValidChecklistSchema(checklistPath)) return false;
+
+      const specPath = path.isAbsolute(state.artifacts.spec)
+        ? state.artifacts.spec
+        : path.join(cwd, state.artifacts.spec);
+      try {
+        const body = fs.readFileSync(specPath, 'utf-8');
+        if (!/^##\s+Implementation\s+Plan\s*$/m.test(body)) return false;
+      } catch {
+        return false;
+      }
     }
 
     return true;
@@ -149,20 +167,7 @@ export function validatePhaseArtifacts(
   return false;
 }
 
-/** Validate checklist.json matches spec schema: `{ checks: [{ name, command }] }`. */
-export function isValidChecklistSchema(absPath: string): boolean {
-  try {
-    const raw = fs.readFileSync(absPath, 'utf-8');
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.checks) || parsed.checks.length === 0) return false;
-    for (const check of parsed.checks) {
-      if (typeof check?.name !== 'string' || typeof check?.command !== 'string') return false;
-    }
-    return true;
-  } catch {
-    return false;
-  }
-}
+export { isValidChecklistSchema } from './checklist.js';
 
 /**
  * Run an interactive phase. Dispatches to claude or codex runner based on preset.

--- a/src/phases/runner.ts
+++ b/src/phases/runner.ts
@@ -8,7 +8,7 @@ import {
   GATE_TIMEOUT_MS,
   VERIFY_RETRY_LIMIT,
   TERMINAL_PHASE,
-  PHASE_ARTIFACT_FILES,
+  getPhaseArtifactFiles,
   getPresetById,
 } from '../config.js';
 import { writeState } from '../state.js';
@@ -125,12 +125,12 @@ function normalizeInteractiveArtifacts(
   state: HarnessState,
   cwd: string
 ): void {
-  type ArtifactKey = keyof typeof state.artifacts;
-  const artifactKeys = PHASE_ARTIFACT_FILES[phase] as ArtifactKey[] | undefined;
-  if (!artifactKeys) return;
+  const artifactKeys = getPhaseArtifactFiles(state.flow, phase);
+  if (artifactKeys.length === 0) return;
 
   for (const key of artifactKeys) {
     const relPath = state.artifacts[key];
+    if (!relPath) continue;
     // Skip gitignored artifacts (decisions.md, checklist.json are in .harness/)
     if (relPath.startsWith('.harness/')) continue;
 

--- a/src/phases/runner.ts
+++ b/src/phases/runner.ts
@@ -10,6 +10,7 @@ import {
   TERMINAL_PHASE,
   getPhaseArtifactFiles,
   getPresetById,
+  getReopenTarget,
 } from '../config.js';
 import { writeState } from '../state.js';
 import { getHead } from '../git.js';
@@ -70,14 +71,6 @@ function phaseLabel(phase: number): string {
     7: 'Eval Gate',
   };
   return labels[phase] ?? `Phase ${phase}`;
-}
-
-// ─── Gate reject → previous interactive phase mapping ─────────────────────────
-
-function previousInteractivePhase(gatePhase: GatePhase): InteractivePhase {
-  if (gatePhase === 2) return 1;
-  if (gatePhase === 4) return 3;
-  return 5; // gate 7 → phase 5
 }
 
 function nextPhase(phase: number): number {
@@ -185,6 +178,15 @@ export async function runPhaseLoop(
 ): Promise<void> {
   while (state.currentPhase < TERMINAL_PHASE) {
     const phase = state.currentPhase;
+
+    // ADR-1 rev-1: phases initialized to 'skipped' (light mode) advance
+    // without running their handlers.
+    if (state.phases[String(phase)] === 'skipped') {
+      state.currentPhase = phase + 1;
+      writeState(runDir, state);
+      continue;
+    }
+
     renderControlPanel(state);
 
     if (isInteractivePhase(phase)) {
@@ -304,6 +306,10 @@ export async function handleInteractivePhase(
 
       // Clear pendingAction now that phase succeeded
       state.pendingAction = null;
+      // Phase 5 consumes carryoverFeedback (ADR-14) — clear after consumption
+      if (phase === 5 && state.carryoverFeedback !== null) {
+        state.carryoverFeedback = null;
+      }
       state.phases[String(phase)] = 'completed';
 
       // Advance to next phase
@@ -506,7 +512,7 @@ export async function handleGateReject(
   }
 
   const retryCount = state.gateRetries[String(phase)];
-  const targetInteractive = previousInteractivePhase(phase);
+  const targetInteractive = getReopenTarget(state.flow, phase);
 
   printWarning(`Gate ${phase} REJECTED (retry ${retryCount}/${GATE_RETRY_LIMIT})`);
   if (comments) {
@@ -551,6 +557,24 @@ export async function handleGateReject(
       sourcePhase: phase as PhaseNumber,
       feedbackPaths,
     };
+
+    // Light Gate-7 REJECT: carryoverFeedback survives the P1 completion that
+    // clears pendingAction, so Phase 5 still sees the gate feedback.
+    // Also reset phases 5/6 + invalidate Gate-7 Codex session + replay sidecars
+    // so the next Gate-7 run starts fresh (ADR-4 + ADR-14).
+    if (state.flow === 'light' && phase === 7) {
+      state.carryoverFeedback = {
+        sourceGate: 7,
+        paths: [feedbackPath],
+        deliverToPhase: 5,
+      };
+      state.phases['5'] = 'pending';
+      state.phases['6'] = 'pending';
+      state.phaseReopenFlags['5'] = true;
+      state.phaseReopenSource['5'] = 7;
+      state.phaseCodexSessions['7'] = null;
+      deleteGateSidecars(runDir, 7);
+    }
 
     // Crash-safe: feedback already saved → write pendingAction+state atomically
     state.pendingAction = pendingAction;
@@ -599,8 +623,23 @@ export async function handleGateEscalation(
     state.gateRetries[String(phase)] = 0;
     if (phase === 7) state.verifyRetries = 0;
 
-    const targetInteractive = previousInteractivePhase(phase);
+    const targetInteractive = getReopenTarget(state.flow, phase);
     const feedbackPath = saveGateFeedback(runDir, phase, comments);
+
+    if (state.flow === 'light' && phase === 7) {
+      state.carryoverFeedback = {
+        sourceGate: 7,
+        paths: [feedbackPath],
+        deliverToPhase: 5,
+      };
+      state.phases['5'] = 'pending';
+      state.phases['6'] = 'pending';
+      state.phaseReopenFlags['5'] = true;
+      state.phaseReopenSource['5'] = 7;
+      state.phaseCodexSessions['7'] = null;
+      deleteGateSidecars(runDir, 7);
+    }
+
     state.pendingAction = {
       type: 'reopen_phase',
       targetPhase: targetInteractive,
@@ -617,7 +656,7 @@ export async function handleGateEscalation(
     await forcePassGate(phase, state, runDir, cwd, 'user', logger);
   } else {
     // Quit
-    const targetInteractive = previousInteractivePhase(phase);
+    const targetInteractive = getReopenTarget(state.flow, phase);
     const feedbackPath = saveGateFeedback(runDir, phase, comments);
     state.pendingAction = {
       type: 'show_escalation',

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, statSync, unlinkSync } from 'fs';
 import { execSync } from 'child_process';
-import { join } from 'path';
+import { isAbsolute, join } from 'path';
 import { getHead, isAncestor, detectExternalCommits } from './git.js';
 import { readState, writeState } from './state.js';
 import { normalizeArtifactCommit } from './artifact.js';
@@ -14,6 +14,8 @@ import {
 } from './phases/runner.js';
 import { InputManager } from './input.js';
 import { NoopLogger } from './logger.js';
+import { getPhaseArtifactFiles } from './config.js';
+import { isValidChecklistSchema } from './phases/checklist.js';
 import type { HarnessState, PhaseNumber } from './types.js';
 
 /** Create a no-op InputManager for use in resumeRun (deferred refactor: inputManager passed by inner.ts in future). */
@@ -469,7 +471,7 @@ function updateExternalCommitsDetected(state: HarnessState, cwd: string, runDir:
  * Runs normalize_artifact_commit for Phase 1/3.
  * Returns true if the phase can be treated as completed.
  */
-function completeInteractivePhaseFromFreshSentinel(
+export function completeInteractivePhaseFromFreshSentinel(
   phase: PhaseNumber,
   state: HarnessState,
   cwd: string
@@ -477,22 +479,42 @@ function completeInteractivePhaseFromFreshSentinel(
   try {
     if (phase === 1 || phase === 3) {
       // Check artifact existence + non-empty + mtime >= phaseOpenedAt
-      const artifactKeys: Array<'spec' | 'decisionLog' | 'plan' | 'checklist'> =
-        phase === 1 ? ['spec', 'decisionLog'] : ['plan', 'checklist'];
+      const artifactKeys = getPhaseArtifactFiles(state.flow, phase);
+      if (artifactKeys.length === 0) return false;
       const openedAt = state.phaseOpenedAt[String(phase)];
 
       for (const key of artifactKeys) {
         const relPath = state.artifacts[key];
-        const absPath = join(cwd, relPath);
+        if (!relPath) return false;
+        const absPath = isAbsolute(relPath) ? relPath : join(cwd, relPath);
         if (!existsSync(absPath)) return false;
         const stat = statSync(absPath);
         if (stat.size === 0) return false;
         if (openedAt !== null && Math.floor(stat.mtimeMs) < openedAt) return false;
       }
 
+      // Light + phase 1: checklist schema + '## Implementation Plan' header
+      if (state.flow === 'light' && phase === 1) {
+        const checklistAbs = isAbsolute(state.artifacts.checklist)
+          ? state.artifacts.checklist
+          : join(cwd, state.artifacts.checklist);
+        if (!isValidChecklistSchema(checklistAbs)) return false;
+
+        const specAbs = isAbsolute(state.artifacts.spec)
+          ? state.artifacts.spec
+          : join(cwd, state.artifacts.spec);
+        try {
+          const body = readFileSync(specAbs, 'utf-8');
+          if (!/^##\s+Implementation\s+Plan\s*$/m.test(body)) return false;
+        } catch {
+          return false;
+        }
+      }
+
       // Run normalize_artifact_commit for non-gitignored artifacts
       for (const key of artifactKeys) {
         const relPath = state.artifacts[key];
+        if (!relPath) continue;
         if (relPath.startsWith('.harness/')) continue;
         const message = `harness[${state.runId}]: Phase ${phase} — ${String(key)}`;
         normalizeArtifactCommit(relPath, message, cwd);

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -146,7 +146,8 @@ export function registerSignalHandlers(ctx: SignalContext): void {
         state.pendingAction = null;
       } else if (action.action === 'jump' && typeof action.phase === 'number') {
         for (let m = action.phase; m <= 7; m++) {
-          state.phases[String(m)] = 'pending';
+          const cur = state.phases[String(m)];
+          state.phases[String(m)] = cur === 'skipped' ? 'skipped' : 'pending';
         }
         state.currentPhase = action.phase;
         state.pendingAction = null;

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import type { HarnessState } from './types.js';
+import type { HarnessState, PhaseStatus } from './types.js';
 import { PHASE_DEFAULTS, REQUIRED_PHASE_KEYS, MODEL_PRESETS, getPresetById } from './config.js';
 
 const STATE_FILE = 'state.json';
@@ -106,6 +106,12 @@ export function migrateState(raw: any): HarnessState {
       raw.phaseCodexSessions[key] = null;
     }
   }
+  if (raw.flow !== 'full' && raw.flow !== 'light') {
+    raw.flow = 'full';
+  }
+  if (!('carryoverFeedback' in raw) || raw.carryoverFeedback === undefined) {
+    raw.carryoverFeedback = null;
+  }
   return raw as HarnessState;
 }
 
@@ -176,14 +182,40 @@ export function createInitialState(
   baseCommit: string,
   autoMode: boolean,
   loggingEnabled: boolean = false,
+  flow: 'full' | 'light' = 'full',
 ): HarnessState {
   const phasePresets: Record<string, string> = {};
   for (const phase of REQUIRED_PHASE_KEYS) {
     phasePresets[phase] = PHASE_DEFAULTS[Number(phase)] ?? 'sonnet-high';
   }
 
+  const phases: Record<string, PhaseStatus> =
+    flow === 'light'
+      ? { '1': 'pending', '2': 'skipped', '3': 'skipped', '4': 'skipped',
+          '5': 'pending', '6': 'pending', '7': 'pending' }
+      : { '1': 'pending', '2': 'pending', '3': 'pending', '4': 'pending',
+          '5': 'pending', '6': 'pending', '7': 'pending' };
+
+  const artifacts = flow === 'light'
+    ? {
+        spec: `docs/specs/${runId}-design.md`,
+        plan: '',
+        decisionLog: `.harness/${runId}/decisions.md`,
+        checklist: `.harness/${runId}/checklist.json`,
+        evalReport: `docs/process/evals/${runId}-eval.md`,
+      }
+    : {
+        spec: `docs/specs/${runId}-design.md`,
+        plan: `docs/plans/${runId}.md`,
+        decisionLog: `.harness/${runId}/decisions.md`,
+        checklist: `.harness/${runId}/checklist.json`,
+        evalReport: `docs/process/evals/${runId}-eval.md`,
+      };
+
   return {
     runId,
+    flow,
+    carryoverFeedback: null,
     currentPhase: 1,
     status: 'in_progress',
     autoMode,
@@ -192,22 +224,8 @@ export function createInitialState(
     implRetryBase: baseCommit,
     codexPath: null,
     externalCommitsDetected: false,
-    artifacts: {
-      spec: `docs/specs/${runId}-design.md`,
-      plan: `docs/plans/${runId}.md`,
-      decisionLog: `.harness/${runId}/decisions.md`,
-      checklist: `.harness/${runId}/checklist.json`,
-      evalReport: `docs/process/evals/${runId}-eval.md`,
-    },
-    phases: {
-      '1': 'pending',
-      '2': 'pending',
-      '3': 'pending',
-      '4': 'pending',
-      '5': 'pending',
-      '6': 'pending',
-      '7': 'pending',
-    },
+    artifacts,
+    phases,
     gateRetries: {
       '2': 0,
       '4': 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,14 @@
 export type PhaseNumber = 1 | 2 | 3 | 4 | 5 | 6 | 7;
 export type InteractivePhase = 1 | 3 | 5;
 export type GatePhase = 2 | 4 | 7;
-export type PhaseStatus = 'pending' | 'in_progress' | 'completed' | 'failed' | 'error';
+export type PhaseStatus = 'pending' | 'in_progress' | 'completed' | 'failed' | 'error' | 'skipped';
+export type FlowMode = 'full' | 'light';
+
+export interface CarryoverFeedback {
+  sourceGate: 7;
+  paths: string[];
+  deliverToPhase: 5;
+}
 export type RunStatus = 'in_progress' | 'completed' | 'paused';
 export type PauseReason = 'gate-escalation' | 'verify-escalation' | 'gate-error' | 'verify-error' | 'config-cancel';
 export type PendingActionType = 'reopen_phase' | 'rerun_gate' | 'rerun_verify' | 'show_escalation' | 'show_verify_error' | 'skip_phase' | 'reopen_config';
@@ -31,6 +38,8 @@ export interface GateSessionInfo {
 
 export interface HarnessState {
   runId: string;
+  flow: FlowMode;
+  carryoverFeedback: CarryoverFeedback | null;
   currentPhase: number; // 1-7 or 8 (terminal sentinel)
   status: RunStatus;
   autoMode: boolean;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -43,12 +43,15 @@ export function renderControlPanel(state: HarnessState): void {
 
   for (let p = 1; p <= 7; p++) {
     const status = state.phases[String(p)] ?? 'pending';
+    const isSkipped = status === 'skipped';
     const icon = status === 'completed' ? `${GREEN}✓${RESET}`
       : status === 'in_progress' ? `${YELLOW}▶${RESET}`
       : status === 'failed' || status === 'error' ? `${RED}✗${RESET}`
+      : isSkipped ? '—'
       : ' ';
+    const statusLabel = isSkipped ? '(skipped)' : `(${status})`;
     const current = p === state.currentPhase ? ' ← current' : '';
-    console.error(`  [${icon}] Phase ${p}: ${phaseLabel(p)} (${status})${current}`);
+    console.error(`  [${icon}] Phase ${p}: ${phaseLabel(p)} ${statusLabel}${current}`);
   }
   console.error('');
   console.error(separator());
@@ -145,11 +148,11 @@ export function renderModelSelection(
   };
 
   for (const key of REQUIRED_PHASE_KEYS) {
+    const editable = !editablePhases || editablePhases.has(key);
+    if (!editable) continue;
     const preset = getPresetById(phasePresets[key]);
     const label = preset?.label ?? 'unknown';
-    const editable = !editablePhases || editablePhases.has(key);
-    const prefix = editable ? `[${key}]` : `   `;
-    console.error(`  ${prefix} Phase ${key} (${phaseLabels[key]}):  ${label}`);
+    console.error(`  [${key}] Phase ${key} (${phaseLabels[key]}):  ${label}`);
   }
   console.error(`      Phase 6 (검증):        harness-verify.sh (fixed)`);
   console.error('');

--- a/tests/commands/inner.test.ts
+++ b/tests/commands/inner.test.ts
@@ -239,7 +239,8 @@ describe('bootstrapSessionLogger', () => {
 
   function buildState(overrides: Partial<HarnessState> = {}): HarnessState {
     const base: HarnessState = {
-      runId: 'r1', currentPhase: 1, status: 'in_progress', autoMode: false,
+      runId: 'r1', flow: 'full', carryoverFeedback: null,
+      currentPhase: 1, status: 'in_progress', autoMode: false,
       task: 'test task', baseCommit: '', implRetryBase: '', codexPath: null,
       externalCommitsDetected: false,
       artifacts: { spec: 's', plan: 'p', decisionLog: 'd', checklist: 'c', evalReport: 'e' },
@@ -318,7 +319,8 @@ describe('buildConfigCancelHandler — lazy bootstrap', () => {
 
   function buildState(overrides: Partial<HarnessState> = {}): HarnessState {
     const base: HarnessState = {
-      runId: 'cc1', currentPhase: 1, status: 'in_progress', autoMode: false,
+      runId: 'cc1', flow: 'full', carryoverFeedback: null,
+      currentPhase: 1, status: 'in_progress', autoMode: false,
       task: 'test task', baseCommit: 'abc', implRetryBase: 'abc', codexPath: null,
       externalCommitsDetected: false,
       artifacts: { spec: 's', plan: 'p', decisionLog: 'd', checklist: 'c', evalReport: 'e' },

--- a/tests/commands/jump.test.ts
+++ b/tests/commands/jump.test.ts
@@ -91,4 +91,20 @@ describe('jumpCommand', () => {
 
     expect(stderrSpy.mock.calls.map((c: any) => c[0]).join('')).toContain('phase 3');
   });
+
+  it('rejects jumping to a phase whose current status is "skipped"', async () => {
+    const harnessDir = join(repo.path, '.harness');
+    const runId = '2026-04-12-test';
+    const runDir = join(harnessDir, runId);
+    mkdirSync(runDir, { recursive: true });
+    const baseCommit = execSync('git rev-parse HEAD', { cwd: repo.path, encoding: 'utf-8' }).trim();
+    const state = createInitialState(runId, 'task', baseCommit, false, false, 'light');
+    state.currentPhase = 5;
+    writeState(runDir, state);
+    setCurrentRun(harnessDir, runId);
+
+    await expect(jumpCommand('2', { root: repo.path })).rejects.toThrow(/__exit__:1/);
+    const msgs = stderrSpy.mock.calls.map((c: any) => c[0]).join('');
+    expect(msgs).toMatch(/phase 2 is 'skipped'|cannot jump to a skipped phase/i);
+  });
 });

--- a/tests/commands/resume-cmd.test.ts
+++ b/tests/commands/resume-cmd.test.ts
@@ -227,4 +227,16 @@ describe('resumeCommand', () => {
       expect(state.loggingEnabled).toBe(false);
     });
   });
+
+  describe('harness resume --light (rejected)', () => {
+    it('exits non-zero with a flow-frozen message', async () => {
+      const { harnessDir, runId } = setupRun(repo);
+      setCurrentRun(harnessDir, runId);
+
+      await expect(resumeCommand(runId, { light: true, root: repo.path }))
+        .rejects.toThrow(/__exit__:1/);
+      const messages = stderrSpy.mock.calls.map((c: any) => c[0]).join('');
+      expect(messages).toMatch(/flow is frozen|--light is only valid on start/i);
+    });
+  });
 });

--- a/tests/commands/run.test.ts
+++ b/tests/commands/run.test.ts
@@ -175,4 +175,25 @@ describe('startCommand', () => {
     const state = JSON.parse(readFileSync(join(harnessDir, runId, 'state.json'), 'utf-8'));
     expect(state.loggingEnabled).toBe(false);
   });
+
+  it('--light writes state.json with flow="light" and phases 2/3/4 skipped', async () => {
+    await startCommand('dummy task', { light: true, root: repo.path });
+    const harnessDir = join(repo.path, '.harness');
+    const runId = readFileSync(join(harnessDir, 'current-run'), 'utf-8').trim();
+    const state = JSON.parse(readFileSync(join(harnessDir, runId, 'state.json'), 'utf-8'));
+    expect(state.flow).toBe('light');
+    expect(state.phases['2']).toBe('skipped');
+    expect(state.phases['3']).toBe('skipped');
+    expect(state.phases['4']).toBe('skipped');
+    expect(state.artifacts.plan).toBe('');
+  });
+
+  it('--light composes with --auto (ADR-8 orthogonality)', async () => {
+    await startCommand('dummy task', { light: true, auto: true, root: repo.path });
+    const harnessDir = join(repo.path, '.harness');
+    const runId = readFileSync(join(harnessDir, 'current-run'), 'utf-8').trim();
+    const state = JSON.parse(readFileSync(join(harnessDir, runId, 'state.json'), 'utf-8'));
+    expect(state.flow).toBe('light');
+    expect(state.autoMode).toBe(true);
+  });
 });

--- a/tests/context/assembler-resume.test.ts
+++ b/tests/context/assembler-resume.test.ts
@@ -7,6 +7,8 @@ function makeState(overrides: Partial<HarnessState> = {}): HarnessState {
   // so `path.join(cwd, filePath)` resolves into the fixtures directory.
   return {
     runId: 'r1',
+    flow: 'full',
+    carryoverFeedback: null,
     currentPhase: 2,
     status: 'in_progress',
     autoMode: false,
@@ -143,5 +145,26 @@ describe('assembleGateResumePrompt — §4.4 anomaly: reject + missing feedback'
       expect(res).not.toMatch(/Continue Review/);
       expect(res).toMatch(/feedback file missing despite lastOutcome=reject/);
     }
+  });
+});
+
+describe('buildResumeSections — Phase 7 flow-aware (ADR-12)', () => {
+  const cwd = 'tests/context/fixtures';
+
+  it('light + phase 7 resume omits <plan> but keeps <eval_report> + diff + metadata', () => {
+    const state = makeState({ flow: 'light', currentPhase: 7 });
+    const prompt = assembleGateResumePrompt(7, state, cwd, 'reject', 'prior feedback');
+    if (typeof prompt !== 'string') throw new Error('expected string');
+    expect(prompt).toContain('<spec>\n');
+    expect(prompt).toContain('<eval_report>\n');
+    expect(prompt).toContain('<metadata>\n');
+    expect(prompt).not.toContain('<plan>\n');
+  });
+
+  it('full + phase 7 resume still includes <plan>', () => {
+    const state = makeState({ currentPhase: 7 });
+    const prompt = assembleGateResumePrompt(7, state, cwd, 'reject', 'prior feedback');
+    if (typeof prompt !== 'string') throw new Error('expected string');
+    expect(prompt).toContain('<plan>\n');
   });
 });

--- a/tests/context/assembler.test.ts
+++ b/tests/context/assembler.test.ts
@@ -31,6 +31,41 @@ function makeState(overrides: Partial<HarnessState> = {}): HarnessState {
   return { ...base, ...overrides };
 }
 
+function writeEvalFixtures(dir: string): void {
+  fs.mkdirSync(path.join(dir, 'docs/specs'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'docs/plans'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'docs/process/evals'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'docs/specs/my-run-design.md'), '# spec');
+  fs.writeFileSync(path.join(dir, 'docs/plans/my-run.md'), '# plan');
+  fs.writeFileSync(path.join(dir, 'docs/process/evals/my-run-eval.md'), '# eval');
+}
+
+function makeLightEvalState(overrides: Partial<HarnessState> = {}): HarnessState {
+  const base = createInitialState('my-run', '/tasks/my-task.md', 'base-sha', false, false, 'light');
+  return {
+    ...base,
+    currentPhase: 7,
+    phases: { '1': 'completed', '2': 'skipped', '3': 'skipped', '4': 'skipped',
+              '5': 'completed', '6': 'completed', '7': 'pending' },
+    implCommit: 'impl-sha',
+    evalCommit: 'eval-sha',
+    ...overrides,
+  };
+}
+
+function makeFullEvalState(overrides: Partial<HarnessState> = {}): HarnessState {
+  const base = createInitialState('my-run', '/tasks/my-task.md', 'base-sha', false);
+  return {
+    ...base,
+    currentPhase: 7,
+    phases: { '1': 'completed', '2': 'completed', '3': 'completed', '4': 'completed',
+              '5': 'completed', '6': 'completed', '7': 'pending' },
+    implCommit: 'impl-sha',
+    evalCommit: 'eval-sha',
+    ...overrides,
+  };
+}
+
 // ─── Interactive Phase Tests ───────────────────────────────────────────────
 
 describe('Phase 1 interactive prompt', () => {
@@ -323,5 +358,49 @@ describe('assembleInteractivePrompt — flow-aware Phase 1 (light)', () => {
     } finally {
       stderrSpy.mockRestore();
     }
+  });
+});
+
+describe('buildGatePromptPhase7 — flow-aware (ADR-12)', () => {
+  it('light flow omits the <plan> slot entirely', () => {
+    const tmp = makeTmpDir();
+    writeEvalFixtures(tmp);
+    const state = makeLightEvalState();
+    const result = assembleGatePrompt(7, state, '/tmp/harness', tmp);
+    if (typeof result !== 'string') throw new Error('expected string');
+    expect(result).toContain('<spec>\n');
+    expect(result).toContain('<eval_report>\n');
+    expect(result).not.toContain('<plan>\n');
+  });
+
+  it('full flow still includes the <plan> slot', () => {
+    const tmp = makeTmpDir();
+    writeEvalFixtures(tmp);
+    const state = makeFullEvalState();
+    const result = assembleGatePrompt(7, state, '/tmp/harness', tmp);
+    if (typeof result !== 'string') throw new Error('expected string');
+    expect(result).toContain('<plan>\n');
+  });
+
+  it('light Gate 7 (fresh) contract text does not claim a separate plan artifact', () => {
+    const tmp = makeTmpDir();
+    writeEvalFixtures(tmp);
+    const state = makeLightEvalState();
+    const result = assembleGatePrompt(7, state, '/tmp/harness', tmp);
+    if (typeof result !== 'string') throw new Error('expected string');
+    expect(result).toContain('결합 design spec');
+    expect(result).toContain('별도의 plan 아티팩트가 없다');
+    expect(result).not.toContain('spec + plan + eval report + diff');
+    expect(result).toContain('4-phase light harness lifecycle');
+  });
+
+  it('full Gate 7 (fresh) contract text is unchanged', () => {
+    const tmp = makeTmpDir();
+    writeEvalFixtures(tmp);
+    const state = makeFullEvalState();
+    const result = assembleGatePrompt(7, state, '/tmp/harness', tmp);
+    if (typeof result !== 'string') throw new Error('expected string');
+    expect(result).toContain('spec + plan + eval report + diff');
+    expect(result).toContain('7-phase harness lifecycle');
   });
 });

--- a/tests/context/assembler.test.ts
+++ b/tests/context/assembler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -248,5 +248,80 @@ describe('Gate size limits', () => {
 
     expect(typeof result).toBe('object');
     expect((result as { error: string }).error).toMatch(/Gate input too large/);
+  });
+});
+
+describe('assembleInteractivePrompt — flow-aware Phase 1 (light)', () => {
+  it('light + phase 1 renders phase-1-light.md with combined-doc wording', () => {
+    const state = makeState({ flow: 'light', phaseAttemptId: { '1': 'aid-light', '3': null, '5': null } });
+    const prompt = assembleInteractivePrompt(1, state, '/tmp/harness');
+    expect(prompt).toContain('## Implementation Plan');
+    expect(prompt).toContain('checklist.json');
+    expect(prompt).toContain('결합');
+    expect(prompt).toContain('aid-light');
+  });
+
+  it('full + phase 1 still renders the classic phase-1.md', () => {
+    const state = makeState({ flow: 'full', phaseAttemptId: { '1': 'aid-full', '3': null, '5': null } });
+    const prompt = assembleInteractivePrompt(1, state, '/tmp/harness');
+    expect(prompt).not.toContain('## Implementation Plan');
+    expect(prompt).toContain('## Context & Decisions');
+  });
+
+  it('light + phase 5 injects carryoverFeedback paths alongside pendingAction feedback', () => {
+    const tmp = makeTmpDir();
+    const pendingPath = path.join(tmp, 'verify-feedback.md');
+    const carryoverPath = path.join(tmp, 'gate-7-feedback.md');
+    fs.writeFileSync(pendingPath, 'verify feedback');
+    fs.writeFileSync(carryoverPath, 'gate feedback');
+    const state = makeState({
+      flow: 'light',
+      phaseAttemptId: { '1': null, '3': null, '5': 'aid-5' },
+      pendingAction: {
+        type: 'reopen_phase', targetPhase: 5, sourcePhase: 6,
+        feedbackPaths: [pendingPath],
+      },
+      carryoverFeedback: {
+        sourceGate: 7,
+        paths: [carryoverPath],
+        deliverToPhase: 5,
+      },
+    });
+    const prompt = assembleInteractivePrompt(5, state, '/tmp/harness');
+    expect(prompt).toContain('verify-feedback.md');
+    expect(prompt).toContain('gate-7-feedback.md');
+  });
+
+  it('light + phase 5 uses phase-5-light.md (no separate plan artifact)', () => {
+    const state = makeState({ flow: 'light', phaseAttemptId: { '1': null, '3': null, '5': 'aid-5' } });
+    const prompt = assembleInteractivePrompt(5, state, '/tmp/harness');
+    expect(prompt).toContain('Combined Design Spec (light)');
+    expect(prompt).not.toContain('- Plan:');
+  });
+
+  it('light + phase 5 drops carryover paths that no longer exist on disk (R8)', () => {
+    const tmp = makeTmpDir();
+    const existing = path.join(tmp, 'exists.md');
+    fs.writeFileSync(existing, 'x');
+    const state = makeState({
+      flow: 'light',
+      phaseAttemptId: { '1': null, '3': null, '5': 'aid-5' },
+      pendingAction: null,
+      carryoverFeedback: {
+        sourceGate: 7,
+        paths: [existing, path.join(tmp, 'missing.md')],
+        deliverToPhase: 5,
+      },
+    });
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const prompt = assembleInteractivePrompt(5, state, tmp);
+      expect(prompt).toContain('exists.md');
+      expect(prompt).not.toContain('missing.md');
+      const warnings = stderrSpy.mock.calls.map((c) => c[0]).join('');
+      expect(warnings).toMatch(/carryover feedback path not found.*missing\.md/);
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 });

--- a/tests/integration/lifecycle.test.ts
+++ b/tests/integration/lifecycle.test.ts
@@ -123,3 +123,21 @@ describe('CLI lifecycle integration', () => {
     expect(result.stderr).toContain('No active run');
   });
 });
+
+describe('CLI parser — --light flag registration (Task 5 smoke test)', () => {
+  it('start --help lists --light', () => {
+    const res = runCli(['start', '--help']);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toMatch(/--light/);
+  });
+  it('run --help lists --light', () => {
+    const res = runCli(['run', '--help']);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toMatch(/--light/);
+  });
+  it('resume --help lists --light (option is captured so runtime can reject it)', () => {
+    const res = runCli(['resume', '--help']);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toMatch(/--light/);
+  });
+});

--- a/tests/integration/light-flow.test.ts
+++ b/tests/integration/light-flow.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+vi.mock('../../src/phases/interactive.js', () => ({
+  runInteractivePhase: vi.fn(),
+  preparePhase: vi.fn(),
+  checkSentinelFreshness: vi.fn(),
+  validatePhaseArtifacts: vi.fn(() => true),
+}));
+
+vi.mock('../../src/phases/gate.js', () => ({
+  runGatePhase: vi.fn(),
+  checkGateSidecars: vi.fn(() => null),
+  buildGateResult: vi.fn(),
+  parseVerdict: vi.fn(),
+}));
+
+vi.mock('../../src/phases/verify.js', () => ({
+  runVerifyPhase: vi.fn(async () => ({ type: 'pass' } as const)),
+  readVerifyResult: vi.fn(() => null),
+  isEvalReportValid: vi.fn(() => true),
+}));
+
+vi.mock('../../src/artifact.js', () => ({
+  normalizeArtifactCommit: vi.fn(),
+  runPhase6Preconditions: vi.fn(),
+}));
+
+vi.mock('../../src/git.js', () => ({
+  getHead: vi.fn(() => 'mock-head'),
+  getGitRoot: vi.fn(() => '/'),
+  isAncestor: vi.fn(() => true),
+  detectExternalCommits: vi.fn(() => []),
+}));
+
+vi.mock('../../src/ui.js', () => ({
+  promptChoice: vi.fn(),
+  printPhaseTransition: vi.fn(),
+  renderControlPanel: vi.fn(),
+  printWarning: vi.fn(),
+  printError: vi.fn(),
+  printSuccess: vi.fn(),
+  printInfo: vi.fn(),
+  printAdvisorReminder: vi.fn(),
+}));
+
+import { runPhaseLoop, handleGatePhase } from '../../src/phases/runner.js';
+import { runInteractivePhase } from '../../src/phases/interactive.js';
+import { runGatePhase } from '../../src/phases/gate.js';
+import { createInitialState, writeState, readState } from '../../src/state.js';
+import { NoopLogger } from '../../src/logger.js';
+import { InputManager } from '../../src/input.js';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'light-flow-int-'));
+}
+
+function createNoOpInputManager(): InputManager {
+  return new InputManager();
+}
+
+describe('light-flow end-to-end (P1 → P5 → P6 → P7)', () => {
+  let harnessDir: string;
+  let runDir: string;
+  let cwd: string;
+
+  beforeEach(() => {
+    vi.mocked(runInteractivePhase).mockReset();
+    vi.mocked(runGatePhase).mockReset();
+    cwd = makeTmpDir();
+    harnessDir = path.join(cwd, '.harness');
+    const runId = 'r1';
+    runDir = path.join(harnessDir, runId);
+    fs.mkdirSync(runDir, { recursive: true });
+    fs.mkdirSync(path.join(cwd, 'docs/specs'), { recursive: true });
+    fs.mkdirSync(path.join(cwd, 'docs/process/evals'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('happy path: approves at Gate 7 and reaches TERMINAL_PHASE', async () => {
+    const state = createInitialState('r1', 'dummy', 'base-sha', false, false, 'light');
+    writeState(runDir, state);
+
+    vi.mocked(runInteractivePhase).mockImplementationOnce(async (_p: any, st: any, _h: any, _r: any, _c: any, aid: any) => {
+      st.phases['1'] = 'completed';
+      return { status: 'completed', attemptId: aid } as any;
+    });
+    vi.mocked(runInteractivePhase).mockImplementationOnce(async (_p: any, st: any, _h: any, _r: any, _c: any, aid: any) => {
+      st.phases['5'] = 'completed';
+      st.implCommit = 'impl-sha';
+      return { status: 'completed', attemptId: aid } as any;
+    });
+
+    vi.mocked(runGatePhase).mockResolvedValueOnce({
+      type: 'verdict', verdict: 'APPROVE', comments: '',
+      rawOutput: '## Verdict\nAPPROVE\n', runner: 'codex',
+      durationMs: 1, tokensTotal: 0, promptBytes: 0,
+      codexSessionId: 's', recoveredFromSidecar: false,
+      resumedFrom: null, resumeFallback: false,
+      sourcePreset: { model: 'gpt-5.4', effort: 'high' },
+    } as any);
+
+    const logger = new NoopLogger();
+    await runPhaseLoop(state, harnessDir, runDir, cwd, createNoOpInputManager(), logger, { value: false });
+
+    const persisted = readState(runDir)!;
+    expect(persisted.flow).toBe('light');
+    expect(persisted.phases['2']).toBe('skipped');
+    expect(persisted.phases['3']).toBe('skipped');
+    expect(persisted.phases['4']).toBe('skipped');
+    expect(persisted.phases['1']).toBe('completed');
+    expect(persisted.phases['5']).toBe('completed');
+    expect(persisted.phases['7']).toBe('completed');
+    expect(persisted.status).toBe('completed');
+  });
+
+  it('Gate-7 REJECT reopens Phase 1 and records carryoverFeedback', async () => {
+    const state = createInitialState('r1', 'dummy', 'base-sha', false, false, 'light');
+    state.phases['1'] = 'completed';
+    state.phases['5'] = 'completed';
+    state.phases['6'] = 'completed';
+    state.currentPhase = 7;
+    writeState(runDir, state);
+
+    vi.mocked(runGatePhase).mockResolvedValueOnce({
+      type: 'verdict', verdict: 'REJECT', comments: 'fix design',
+      rawOutput: '## Verdict\nREJECT\n## Comments\n- **[P1]** fix\n',
+      runner: 'codex',
+      durationMs: 1, tokensTotal: 0, promptBytes: 0,
+      codexSessionId: 's', recoveredFromSidecar: false,
+      resumedFrom: null, resumeFallback: false,
+      sourcePreset: { model: 'gpt-5.4', effort: 'high' },
+    } as any);
+
+    const logger = new NoopLogger();
+    await handleGatePhase(7, state, harnessDir, runDir, cwd, createNoOpInputManager(), logger, { value: false });
+
+    const persisted = readState(runDir)!;
+    expect(persisted.currentPhase).toBe(1);
+    expect(persisted.phases['1']).toBe('pending');
+    expect(persisted.phases['5']).toBe('pending');
+    expect(persisted.phases['6']).toBe('pending');
+    expect(persisted.phaseReopenFlags['1']).toBe(true);
+    expect(persisted.carryoverFeedback).not.toBeNull();
+    expect(persisted.carryoverFeedback?.deliverToPhase).toBe(5);
+    expect(persisted.carryoverFeedback?.paths[0]).toMatch(/gate-7-feedback\.md$/);
+  });
+});

--- a/tests/integration/logging.test.ts
+++ b/tests/integration/logging.test.ts
@@ -12,7 +12,8 @@ function tempHarnessDir(): string {
 
 function buildState(overrides: Partial<HarnessState> = {}): HarnessState {
   const base: HarnessState = {
-    runId: 'r', currentPhase: 1, status: 'in_progress', autoMode: false,
+    runId: 'r', flow: 'full', carryoverFeedback: null,
+    currentPhase: 1, status: 'in_progress', autoMode: false,
     task: 'test', baseCommit: '', implRetryBase: '', codexPath: null,
     externalCommitsDetected: false,
     artifacts: { spec: 's', plan: 'p', decisionLog: 'd', checklist: 'c', evalReport: 'e' },

--- a/tests/phases/gate-resume.test.ts
+++ b/tests/phases/gate-resume.test.ts
@@ -22,7 +22,8 @@ import { runClaudeGate } from '../../src/runners/claude.js';
 
 function makeState(): HarnessState {
   return {
-    runId: 'r1', currentPhase: 2, status: 'in_progress', autoMode: false,
+    runId: 'r1', flow: 'full', carryoverFeedback: null,
+    currentPhase: 2, status: 'in_progress', autoMode: false,
     task: 't', baseCommit: '', implRetryBase: '', codexPath: null,
     externalCommitsDetected: false,
     artifacts: { spec: 's', plan: 'p', decisionLog: 'd', checklist: 'c', evalReport: 'e' },

--- a/tests/phases/interactive.test.ts
+++ b/tests/phases/interactive.test.ts
@@ -593,3 +593,45 @@ describe('runInteractivePhase — Claude dispatch command shape', () => {
     expect(command).toContain('xHigh');
   });
 });
+
+describe('validatePhaseArtifacts — light + phase 1 extras (ADR-13)', () => {
+  it('accepts a combined doc with the "## Implementation Plan" header + valid checklist', () => {
+    const tmp = makeTmpDir();
+    const state = makeState({ flow: 'light', phaseOpenedAt: { '1': 0, '3': null, '5': null } });
+    state.artifacts.spec = path.join(tmp, 'spec.md');
+    state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
+    state.artifacts.checklist = path.join(tmp, 'checklist.json');
+    fs.writeFileSync(state.artifacts.spec,
+      '# T\n## Context & Decisions\n\n## Implementation Plan\n- t\n');
+    fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
+    fs.writeFileSync(state.artifacts.checklist,
+      JSON.stringify({ checks: [{ name: 'n', command: 'true' }] }));
+    expect(validatePhaseArtifacts(1, state, tmp)).toBe(true);
+  });
+
+  it('rejects a combined doc that lacks the "## Implementation Plan" header', () => {
+    const tmp = makeTmpDir();
+    const state = makeState({ flow: 'light', phaseOpenedAt: { '1': 0, '3': null, '5': null } });
+    state.artifacts.spec = path.join(tmp, 'spec.md');
+    state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
+    state.artifacts.checklist = path.join(tmp, 'checklist.json');
+    fs.writeFileSync(state.artifacts.spec, '# T\n## Context & Decisions\n');
+    fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
+    fs.writeFileSync(state.artifacts.checklist,
+      JSON.stringify({ checks: [{ name: 'n', command: 'true' }] }));
+    expect(validatePhaseArtifacts(1, state, tmp)).toBe(false);
+  });
+
+  it('rejects when checklist.json schema is invalid', () => {
+    const tmp = makeTmpDir();
+    const state = makeState({ flow: 'light', phaseOpenedAt: { '1': 0, '3': null, '5': null } });
+    state.artifacts.spec = path.join(tmp, 'spec.md');
+    state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
+    state.artifacts.checklist = path.join(tmp, 'checklist.json');
+    fs.writeFileSync(state.artifacts.spec,
+      '# T\n## Context & Decisions\n\n## Implementation Plan\n- t\n');
+    fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
+    fs.writeFileSync(state.artifacts.checklist, '{"checks":[]}');
+    expect(validatePhaseArtifacts(1, state, tmp)).toBe(false);
+  });
+});

--- a/tests/phases/runner.test.ts
+++ b/tests/phases/runner.test.ts
@@ -119,6 +119,18 @@ function makeState(overrides: Partial<HarnessState> = {}): HarnessState {
   return { ...base, ...overrides };
 }
 
+function makeLightState(overrides: Partial<HarnessState> = {}): HarnessState {
+  const base = createInitialState(
+    'test-run',
+    '/tasks/test.md',
+    'base-sha',
+    false,
+    false,
+    'light',
+  );
+  return { ...base, ...overrides };
+}
+
 const HDIR = '/tmp/harness-dir';
 const CWD = '/tmp/cwd';
 
@@ -1680,5 +1692,141 @@ describe('handleVerifyFail — phaseReopenSource tracking', () => {
 
     await handleVerifyFail(feedbackPath, state, runDir, cwd, createNoOpInputManager(), new NoopLogger());
     expect(state.phaseReopenSource['5']).toBe(6);
+  });
+});
+
+describe('light flow — runPhaseLoop (spec §4 + ADR-1/ADR-4/ADR-14)', () => {
+  beforeEach(() => {
+    vi.mocked(runInteractivePhase).mockReset();
+    vi.mocked(runGatePhase).mockReset();
+    vi.mocked(runVerifyPhase).mockReset();
+  });
+
+  it('skips phases 2/3/4 and advances from phase 1 directly to phase 5', async () => {
+    const runDir = makeTmpDir();
+    const state = makeLightState({ currentPhase: 1 });
+    const logger = new NoopLogger();
+
+    vi.mocked(runInteractivePhase).mockImplementationOnce(async (_p: any, st: any, _h: any, _r: any, _c: any, aid: any) => {
+      st.phases['1'] = 'completed';
+      return { status: 'completed', attemptId: aid } as any;
+    });
+    vi.mocked(runInteractivePhase).mockImplementationOnce(async (_p: any, st: any, _h: any, _r: any, _c: any, aid: any) => {
+      st.phases['5'] = 'completed';
+      st.implCommit = 'impl';
+      return { status: 'completed', attemptId: aid } as any;
+    });
+    vi.mocked(runVerifyPhase).mockResolvedValueOnce({ type: 'pass' } as any);
+    vi.mocked(runGatePhase).mockResolvedValueOnce({
+      type: 'verdict', verdict: 'APPROVE', comments: '', rawOutput: '',
+      runner: 'codex', durationMs: 1, tokensTotal: 0, promptBytes: 0,
+      codexSessionId: 'x', recoveredFromSidecar: false,
+      resumedFrom: null, resumeFallback: false,
+    } as any);
+
+    await runPhaseLoop(state, HDIR, runDir, CWD, createNoOpInputManager(), logger, { value: false });
+
+    expect(state.phases['2']).toBe('skipped');
+    expect(state.phases['3']).toBe('skipped');
+    expect(state.phases['4']).toBe('skipped');
+    expect(state.status).toBe('completed');
+    // handleInteractivePhase must have been invoked for 1 and 5 only
+    const invokedPhases = vi.mocked(runInteractivePhase).mock.calls.map((c: any) => c[0]);
+    expect(invokedPhases).toEqual([1, 5]);
+  });
+
+  it('Gate-7 REJECT on light reopens phase 1 and sets carryoverFeedback', async () => {
+    const runDir = makeTmpDir();
+    const state = makeLightState({
+      currentPhase: 7,
+      phases: { '1': 'completed', '2': 'skipped', '3': 'skipped', '4': 'skipped',
+                '5': 'completed', '6': 'completed', '7': 'pending' },
+    });
+    const logger = new NoopLogger();
+
+    vi.mocked(runGatePhase).mockResolvedValueOnce({
+      type: 'verdict', verdict: 'REJECT', comments: 'design needs rework', rawOutput: '',
+      runner: 'codex', durationMs: 1, tokensTotal: 0, promptBytes: 0,
+      codexSessionId: 'x', recoveredFromSidecar: false,
+      resumedFrom: null, resumeFallback: false,
+    } as any);
+
+    await handleGatePhase(7, state, HDIR, runDir, CWD, createNoOpInputManager(), logger, { value: false });
+
+    expect(state.currentPhase).toBe(1);
+    expect(state.phases['1']).toBe('pending');
+    expect(state.phases['5']).toBe('pending');
+    expect(state.phases['6']).toBe('pending');
+    expect(state.phaseReopenFlags['1']).toBe(true);
+    expect(state.carryoverFeedback).not.toBeNull();
+    expect(state.carryoverFeedback?.deliverToPhase).toBe(5);
+    expect(state.carryoverFeedback?.sourceGate).toBe(7);
+  });
+
+  it('Gate-7 REJECT on full still reopens phase 5 (unchanged)', async () => {
+    const runDir = makeTmpDir();
+    const state = makeState({ currentPhase: 7 });
+    const logger = new NoopLogger();
+
+    vi.mocked(runGatePhase).mockResolvedValueOnce({
+      type: 'verdict', verdict: 'REJECT', comments: 'impl off-spec', rawOutput: '',
+      runner: 'codex', durationMs: 1, tokensTotal: 0, promptBytes: 0,
+      codexSessionId: 'x', recoveredFromSidecar: false,
+      resumedFrom: null, resumeFallback: false,
+    } as any);
+
+    await handleGatePhase(7, state, HDIR, runDir, CWD, createNoOpInputManager(), logger, { value: false });
+
+    expect(state.currentPhase).toBe(5);
+    expect(state.phases['5']).toBe('pending');
+    expect(state.carryoverFeedback).toBeNull();
+  });
+
+  it('Phase 5 completion clears carryoverFeedback', async () => {
+    const runDir = makeTmpDir();
+    const state = makeLightState({
+      currentPhase: 5,
+      carryoverFeedback: { sourceGate: 7, paths: ['f'], deliverToPhase: 5 },
+    });
+    const logger = new NoopLogger();
+
+    vi.mocked(runInteractivePhase).mockImplementationOnce(async (_p: any, st: any, _h: any, _r: any, _c: any, aid: any) => {
+      st.phases['5'] = 'completed';
+      st.implCommit = 'impl';
+      return { status: 'completed', attemptId: aid } as any;
+    });
+
+    await handleInteractivePhase(5, state, HDIR, runDir, CWD, logger);
+
+    expect(state.carryoverFeedback).toBeNull();
+    expect(state.currentPhase).toBe(6);
+  });
+
+  it('Gate-7 REJECT on light also clears phaseCodexSessions[7] + replay sidecars', async () => {
+    const runDir = makeTmpDir();
+    const state = makeLightState({
+      currentPhase: 7,
+      phases: { '1': 'completed', '2': 'skipped', '3': 'skipped', '4': 'skipped',
+                '5': 'completed', '6': 'completed', '7': 'pending' },
+    });
+    state.phaseCodexSessions['7'] = {
+      sessionId: 'stale-7', runner: 'codex', model: 'gpt-5.4', effort: 'high',
+      lastOutcome: 'reject',
+    };
+    fs.writeFileSync(path.join(runDir, 'gate-7-raw.txt'), 'stale');
+    fs.writeFileSync(path.join(runDir, 'gate-7-result.json'), '{}');
+
+    vi.mocked(runGatePhase).mockResolvedValueOnce({
+      type: 'verdict', verdict: 'REJECT', comments: 'rework', rawOutput: '',
+      runner: 'codex', durationMs: 1, tokensTotal: 0, promptBytes: 0,
+      codexSessionId: 'x', recoveredFromSidecar: false,
+      resumedFrom: null, resumeFallback: false,
+    } as any);
+
+    await handleGatePhase(7, state, HDIR, runDir, CWD, createNoOpInputManager(), new NoopLogger(), { value: false });
+
+    expect(state.phaseCodexSessions['7']).toBeNull();
+    expect(fs.existsSync(path.join(runDir, 'gate-7-raw.txt'))).toBe(false);
+    expect(fs.existsSync(path.join(runDir, 'gate-7-result.json'))).toBe(false);
   });
 });

--- a/tests/resume-light.test.ts
+++ b/tests/resume-light.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createInitialState } from '../src/state.js';
+import type { HarnessState } from '../src/types.js';
+
+vi.mock('../src/artifact.js', () => ({
+  normalizeArtifactCommit: vi.fn(),
+}));
+vi.mock('../src/git.js', () => ({
+  getHead: vi.fn(() => 'head-sha'),
+  isAncestor: vi.fn(() => true),
+  detectExternalCommits: vi.fn(() => []),
+}));
+vi.mock('../src/phases/runner.js', () => ({
+  runPhaseLoop: vi.fn(),
+  handleGateEscalation: vi.fn(),
+  handleVerifyEscalation: vi.fn(),
+  handleVerifyError: vi.fn(),
+}));
+
+import { completeInteractivePhaseFromFreshSentinel } from '../src/resume.js';
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tmpDirs.length = 0;
+});
+
+function makeTmpDir(prefix = 'resume-light-'): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function makeState(overrides: Partial<HarnessState> = {}): HarnessState {
+  const base = createInitialState('test-run', 'task', 'base', false, false, 'light');
+  return {
+    ...base,
+    phaseOpenedAt: { '1': 0, '3': null, '5': null },
+    ...overrides,
+  };
+}
+
+describe('completeInteractivePhaseFromFreshSentinel — light + phase 1 extras (ADR-13)', () => {
+  it('accepts a combined doc + valid checklist and updates specCommit', () => {
+    const tmp = makeTmpDir();
+    const state = makeState();
+    state.artifacts.spec = path.join(tmp, 'spec.md');
+    state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
+    state.artifacts.checklist = path.join(tmp, 'checklist.json');
+    fs.writeFileSync(state.artifacts.spec,
+      '# T\n## Implementation Plan\n- t\n');
+    fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
+    fs.writeFileSync(state.artifacts.checklist,
+      JSON.stringify({ checks: [{ name: 'n', command: 'true' }] }));
+
+    expect(completeInteractivePhaseFromFreshSentinel(1, state, tmp)).toBe(true);
+    expect(state.specCommit).toBe('head-sha');
+  });
+
+  it('rejects missing "## Implementation Plan" header', () => {
+    const tmp = makeTmpDir();
+    const state = makeState();
+    state.artifacts.spec = path.join(tmp, 'spec.md');
+    state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
+    state.artifacts.checklist = path.join(tmp, 'checklist.json');
+    fs.writeFileSync(state.artifacts.spec, '# T\n## Context & Decisions\n');
+    fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
+    fs.writeFileSync(state.artifacts.checklist,
+      JSON.stringify({ checks: [{ name: 'n', command: 'true' }] }));
+    expect(completeInteractivePhaseFromFreshSentinel(1, state, tmp)).toBe(false);
+  });
+
+  it('rejects invalid checklist.json', () => {
+    const tmp = makeTmpDir();
+    const state = makeState();
+    state.artifacts.spec = path.join(tmp, 'spec.md');
+    state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
+    state.artifacts.checklist = path.join(tmp, 'checklist.json');
+    fs.writeFileSync(state.artifacts.spec, '# T\n## Implementation Plan\n- t\n');
+    fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
+    fs.writeFileSync(state.artifacts.checklist, '{"checks":[]}');
+    expect(completeInteractivePhaseFromFreshSentinel(1, state, tmp)).toBe(false);
+  });
+});

--- a/tests/signal.test.ts
+++ b/tests/signal.test.ts
@@ -515,3 +515,21 @@ describe('SIGUSR1 handler', () => {
     expect(currentState.currentPhase).toBe(3);
   });
 });
+
+describe('SIGUSR1 jump — preserve skipped phases on light runs', () => {
+  it('light flow: jump to phase 1 leaves phases 2/3/4 still skipped', () => {
+    const state = createInitialState('r', 't', 'abc', false, false, 'light');
+    state.currentPhase = 5;
+    // Simulate the loop logic inline (copied from signal.ts jump handler)
+    const target = 1;
+    for (let m = target; m <= 7; m++) {
+      const cur = state.phases[String(m)];
+      state.phases[String(m)] = cur === 'skipped' ? 'skipped' : 'pending';
+    }
+    expect(state.phases['1']).toBe('pending');
+    expect(state.phases['2']).toBe('skipped');
+    expect(state.phases['3']).toBe('skipped');
+    expect(state.phases['4']).toBe('skipped');
+    expect(state.phases['5']).toBe('pending');
+  });
+});

--- a/tests/state-invalidation.test.ts
+++ b/tests/state-invalidation.test.ts
@@ -14,7 +14,8 @@ function makeSession(model: string, effort: string): GateSessionInfo {
 
 function makeState(): HarnessState {
   return {
-    runId: 'r1', currentPhase: 2, status: 'in_progress', autoMode: false,
+    runId: 'r1', flow: 'full', carryoverFeedback: null,
+    currentPhase: 2, status: 'in_progress', autoMode: false,
     task: 't', baseCommit: '', implRetryBase: '', codexPath: null,
     externalCommitsDetected: false,
     artifacts: { spec: 's', plan: 'p', decisionLog: 'd', checklist: 'c', evalReport: 'e' },

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -4,7 +4,7 @@ import os from 'os';
 import path from 'path';
 import { writeState, readState, createInitialState, migrateState } from '../src/state.js';
 import type { HarnessState } from '../src/types.js';
-import { PHASE_DEFAULTS, getPhaseArtifactFiles, getReopenTarget } from '../src/config.js';
+import { PHASE_DEFAULTS, getPhaseArtifactFiles, getReopenTarget, getRequiredPhaseKeys } from '../src/config.js';
 
 function makeTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'state-test-'));
@@ -335,6 +335,15 @@ describe('getPhaseArtifactFiles (ADR-13)', () => {
   it('any flow + phase 5 → empty (no on-disk artifact set)', () => {
     expect(getPhaseArtifactFiles('full', 5)).toEqual([]);
     expect(getPhaseArtifactFiles('light', 5)).toEqual([]);
+  });
+});
+
+describe('getRequiredPhaseKeys (ADR-5 / inner.ts propagation)', () => {
+  it('full flow returns 1/2/3/4/5/7', () => {
+    expect([...getRequiredPhaseKeys('full')]).toEqual(['1', '2', '3', '4', '5', '7']);
+  });
+  it('light flow returns 1/5/7 only', () => {
+    expect([...getRequiredPhaseKeys('light')]).toEqual(['1', '5', '7']);
   });
 });
 

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -4,7 +4,7 @@ import os from 'os';
 import path from 'path';
 import { writeState, readState, createInitialState, migrateState } from '../src/state.js';
 import type { HarnessState } from '../src/types.js';
-import { PHASE_DEFAULTS } from '../src/config.js';
+import { PHASE_DEFAULTS, getPhaseArtifactFiles, getReopenTarget } from '../src/config.js';
 
 function makeTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'state-test-'));
@@ -316,5 +316,39 @@ describe('flow + carryoverFeedback (light-flow spec)', () => {
     writeState(dir, state);
     const restored = readState(dir);
     expect(restored?.carryoverFeedback).toEqual(state.carryoverFeedback);
+  });
+});
+
+describe('getPhaseArtifactFiles (ADR-13)', () => {
+  it('full + phase 1 → spec + decisionLog', () => {
+    expect(getPhaseArtifactFiles('full', 1)).toEqual(['spec', 'decisionLog']);
+  });
+  it('full + phase 3 → plan + checklist', () => {
+    expect(getPhaseArtifactFiles('full', 3)).toEqual(['plan', 'checklist']);
+  });
+  it('light + phase 1 → spec + decisionLog + checklist', () => {
+    expect(getPhaseArtifactFiles('light', 1)).toEqual(['spec', 'decisionLog', 'checklist']);
+  });
+  it('light + phase 3 → empty (phase is skipped)', () => {
+    expect(getPhaseArtifactFiles('light', 3)).toEqual([]);
+  });
+  it('any flow + phase 5 → empty (no on-disk artifact set)', () => {
+    expect(getPhaseArtifactFiles('full', 5)).toEqual([]);
+    expect(getPhaseArtifactFiles('light', 5)).toEqual([]);
+  });
+});
+
+describe('getReopenTarget (ADR-4)', () => {
+  it('full + gate 2 → phase 1', () => {
+    expect(getReopenTarget('full', 2)).toBe(1);
+  });
+  it('full + gate 4 → phase 3', () => {
+    expect(getReopenTarget('full', 4)).toBe(3);
+  });
+  it('full + gate 7 → phase 5 (unchanged from current behaviour)', () => {
+    expect(getReopenTarget('full', 7)).toBe(5);
+  });
+  it('light + gate 7 → phase 1 (design combined doc is re-authored)', () => {
+    expect(getReopenTarget('light', 7)).toBe(1);
   });
 });

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -262,3 +262,59 @@ describe('migrateState', () => {
     expect(migrated.phaseReopenFlags['3']).toBe(false);
   });
 });
+
+describe('flow + carryoverFeedback (light-flow spec)', () => {
+  it('createInitialState defaults flow to "full" and carryoverFeedback to null', () => {
+    const state = createInitialState('r1', 't', 'base', false);
+    expect(state.flow).toBe('full');
+    expect(state.carryoverFeedback).toBeNull();
+    expect(state.phases['2']).toBe('pending');
+    expect(state.phases['3']).toBe('pending');
+    expect(state.phases['4']).toBe('pending');
+  });
+
+  it('createInitialState with flow="light" marks phases 2/3/4 as "skipped"', () => {
+    const state = createInitialState('r1', 't', 'base', false, false, 'light');
+    expect(state.flow).toBe('light');
+    expect(state.phases['1']).toBe('pending');
+    expect(state.phases['2']).toBe('skipped');
+    expect(state.phases['3']).toBe('skipped');
+    expect(state.phases['4']).toBe('skipped');
+    expect(state.phases['5']).toBe('pending');
+    expect(state.phases['6']).toBe('pending');
+    expect(state.phases['7']).toBe('pending');
+    expect(state.artifacts.plan).toBe('');
+  });
+
+  it('migrateState backfills missing flow as "full" and carryoverFeedback as null', () => {
+    const base = createInitialState('r1', 't', 'base', false);
+    const raw: any = JSON.parse(JSON.stringify(base));
+    delete raw.flow;
+    delete raw.carryoverFeedback;
+    const migrated = migrateState(raw);
+    expect(migrated.flow).toBe('full');
+    expect(migrated.carryoverFeedback).toBeNull();
+  });
+
+  it('migrateState preserves an existing light flow value', () => {
+    const base = createInitialState('r1', 't', 'base', false, false, 'light');
+    const raw = JSON.parse(JSON.stringify(base));
+    const migrated = migrateState(raw);
+    expect(migrated.flow).toBe('light');
+    expect(migrated.carryoverFeedback).toBeNull();
+  });
+
+  it('carryoverFeedback survives writeState → readState round-trip', () => {
+    const dir = makeTmpDir();
+    tmpDirs.push(dir);
+    const state = createInitialState('r1', 't', 'base', false, false, 'light');
+    state.carryoverFeedback = {
+      sourceGate: 7,
+      paths: ['.harness/r1/gate-7-feedback.md'],
+      deliverToPhase: 5,
+    };
+    writeState(dir, state);
+    const restored = readState(dir);
+    expect(restored?.carryoverFeedback).toEqual(state.carryoverFeedback);
+  });
+});

--- a/tests/ui.test.ts
+++ b/tests/ui.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { renderControlPanel, renderModelSelection } from '../src/ui.js';
+import { createInitialState } from '../src/state.js';
+import type { HarnessState } from '../src/types.js';
+
+function makeState(overrides: Partial<HarnessState> = {}): HarnessState {
+  const base = createInitialState('run', 't', 'base', false);
+  return { ...base, ...overrides };
+}
+
+describe('renderControlPanel — skipped phases', () => {
+  it('renders "skipped" as "(skipped)" without success/error glyphs', () => {
+    const state = makeState({ flow: 'light' });
+    state.phases['2'] = 'skipped';
+    state.phases['3'] = 'skipped';
+    state.phases['4'] = 'skipped';
+    const captured: string[] = [];
+    const origErr = console.error;
+    console.error = (...args: any[]) => { captured.push(args.join(' ')); };
+    try {
+      renderControlPanel(state);
+    } finally {
+      console.error = origErr;
+    }
+    const transcript = captured.join('\n');
+    expect(transcript).toMatch(/Phase 2: .* \(skipped\)/);
+    expect(transcript).toMatch(/Phase 3: .* \(skipped\)/);
+    expect(transcript).toMatch(/Phase 4: .* \(skipped\)/);
+    expect(transcript).not.toMatch(/✗.*Phase [234]/);
+  });
+});
+
+describe('renderModelSelection — flow-aware row visibility', () => {
+  it('hides spec-gate + plan-gate rows for light', () => {
+    const captured: string[] = [];
+    const origErr = console.error;
+    console.error = (...args: any[]) => { captured.push(args.join(' ')); };
+    try {
+      renderModelSelection(
+        { '1': 'opus-max', '5': 'sonnet-high', '7': 'codex-high' },
+        new Set(['1', '5', '7']),
+      );
+    } finally {
+      console.error = origErr;
+    }
+    const transcript = captured.join('\n');
+    expect(transcript).toMatch(/Phase 1 \(Spec 작성\)/);
+    expect(transcript).toMatch(/Phase 5 \(구현\)/);
+    expect(transcript).toMatch(/Phase 7 \(Eval Gate\)/);
+    expect(transcript).not.toMatch(/Phase 2 \(Spec Gate\)/);
+    expect(transcript).not.toMatch(/Phase 3 \(Plan 작성\)/);
+    expect(transcript).not.toMatch(/Phase 4 \(Plan Gate\)/);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `harness start --light` — the 4-phase light flow (P1 design → P5 impl → P6 verify → P7 eval-gate) specified in PR #10 and planned in PR #17. Phases 2/3/4 become `'skipped'` and never run a handler; the combined design doc absorbs the plan artifact; Gate-7 REJECT routes back to Phase 1 with `state.carryoverFeedback` bridging the Phase-5 re-entry.

**Spec:** `docs/specs/2026-04-18-light-flow-design.md` (Gate-2 rev-2)
**Plan:** `docs/plans/2026-04-18-light-flow.md` (Gate-4 APPROVED)
**Gate reviews:** none required — plan already approved by Codex.

## Commit-per-task breakdown (in plan order)

| Task | Commit | What landed |
|---|---|---|
| 1 | `6ac421c` | `FlowMode`, `'skipped'` `PhaseStatus`, `CarryoverFeedback`; `createInitialState(flow)`; `migrateState` back-fill. |
| 2 | `643bf05` | `getPhaseArtifactFiles(flow, phase)`, `getReopenTarget(flow, gate)`, `getRequiredPhaseKeys(flow)`; extract `isValidChecklistSchema` into `src/phases/checklist.ts`; ADR-13 symmetric validation in `validatePhaseArtifacts` + `completeInteractivePhaseFromFreshSentinel`. |
| 3 | `ff1e2d2` | `phase-1-light.md` + `phase-5-light.md` templates; `assembleInteractivePrompt` picks light templates; Phase 5 merges `carryoverFeedback` with `pendingAction.feedbackPaths` (drops missing carryover paths with stderr warning per spec R8). |
| 4 | `e65449d` | `buildGatePromptPhase7` + `buildResumeSections` omit `<plan>` on light; `reviewerContractForGate7(flow)` + `buildLifecycleContext(7, flow)` emit light-specific 4-phase text (ADR-12). |
| 5 | `40b811d` | `--light` on `start`/`run`; `harness resume --light` rejected; CLI parser smoke tests via built dist. |
| 6 | `7f85ba5` | `runPhaseLoop` skips `'skipped'` phases; `handleGateReject`/`handleGateEscalation` use `getReopenTarget`; light Gate-7 REJECT sets `carryoverFeedback` + resets phases 5/6 + clears `phaseCodexSessions[7]`; Phase 5 clears carryover on completion; `consumePendingAction`/SIGUSR1/`jump.ts` preserve `'skipped'`. |
| 7 | `16b51c1` | `renderControlPanel` renders `(skipped)` with em-dash glyph; `renderModelSelection` hides non-editable rows; `inner.ts` uses `getRequiredPhaseKeys(state.flow)`. |
| 8 | `c07e0d6` | `tests/integration/light-flow.test.ts`: happy path + Gate-7 REJECT with full mocks. |
| 9 | `a97e7e5` | `docs/HOW-IT-WORKS.md` + `.ko.md` Light Flow section; `CLAUDE.md` 풀 프로세스 호출 entry. |

## Plan deviations

- **Task 2, `resume.ts`**: added `path.isAbsolute(...)` guard before `join(cwd, ...)` so absolute artifact paths resolve correctly (matches `interactive.ts` behavior; was needed for the positive ADR-13 tests on tmp-dir fixtures).
- **Task 2, tests**: ADR-13 resume tests live in `tests/resume-light.test.ts` rather than being appended to `tests/resume.test.ts` — lets the new `vi.mock('../src/artifact.js')` / `vi.mock('../src/git.js')` scope cleanly without disrupting the existing resume suite.
- **Task 6, tests**: the new light-flow runner describe adds `beforeEach(() => vi.mocked(...).mockReset())` for `runInteractivePhase`/`runGatePhase`/`runVerifyPhase` because the file-scoped `afterEach(vi.clearAllMocks)` does not clear queued `mockImplementationOnce` / `mockResolvedValueOnce` across tests — this is an isolation fix, not a behavioral change.
- **Task 7, inner propagation test**: the heavy `innerCommand`-level test proposed in the plan's Step 6 was reduced to a focused unit test on `getRequiredPhaseKeys` (`tests/state.test.ts`). Rationale: full `innerCommand` coverage would need tmux/lock/logger mocks that do not currently exist in `tests/commands/inner.test.ts`; the runner-level skip test, `--light` CLI test, and UI row-hiding test together prove the propagation path end-to-end.

## Test additions (vs baseline)

- Pre-branch baseline on worktree: **531 passed / 1 skipped**.
- Post-branch (rebased on `main` which now includes PR #18 removing 7 advisor reminder tests): **574 passed / 1 skipped**.
- Net: **+50 new tests** (`574 - 531 + 7 removed upstream`) covering state + migration + helpers + ADR-13 + assembler interactive/gate/resume + CLI surface + runner + UI + integration.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm vitest run` — 574 passed / 1 skipped
- [x] `pnpm build` — dist emitted; `dist/src/context/prompts/phase-1-light.md` + `phase-5-light.md` present
- [x] CLI parser smoke (`harness start --help`/`run --help`/`resume --help` all list `--light`) via `tests/integration/lifecycle.test.ts`

## Out of scope (per plan)

- `/harness` skill plugin update (ADR-9)
- flow auto-selection heuristic (ADR-10/11)
- mid-run flow switch (ADR-10)
- `printAdvisorReminder` cleanup — shipped separately as PR #18 (rebased in)