### PR TITLE
feat(codex): isolate HOME for gate subprocess — Issue #13 (BUG-C permanent fix)

### DIFF
--- a/bin/harness.ts
+++ b/bin/harness.ts
@@ -23,7 +23,8 @@ program
   .option('--auto', 'autonomous mode (no user escalations)')
   .option('--enable-logging', 'enable session logging to ~/.harness/sessions')
   .option('--light', 'use the 4-phase light flow (P1 → P5 → P6 → P7)')
-  .action(async (task: string | undefined, opts: { requireClean?: boolean; auto?: boolean; enableLogging?: boolean; light?: boolean }) => {
+  .option('--codex-no-isolate', 'bypass CODEX_HOME isolation for codex subprocesses (not recommended)')
+  .action(async (task: string | undefined, opts: { requireClean?: boolean; auto?: boolean; enableLogging?: boolean; light?: boolean; codexNoIsolate?: boolean }) => {
     const globalOpts = program.opts();
     await startCommand(task, { ...opts, root: globalOpts.root });
   });
@@ -35,7 +36,8 @@ program
   .option('--auto', 'autonomous mode (no user escalations)')
   .option('--enable-logging', 'enable session logging to ~/.harness/sessions')
   .option('--light', 'use the 4-phase light flow (P1 → P5 → P6 → P7)')
-  .action(async (task: string | undefined, opts: { requireClean?: boolean; auto?: boolean; enableLogging?: boolean; light?: boolean }) => {
+  .option('--codex-no-isolate', 'bypass CODEX_HOME isolation for codex subprocesses (not recommended)')
+  .action(async (task: string | undefined, opts: { requireClean?: boolean; auto?: boolean; enableLogging?: boolean; light?: boolean; codexNoIsolate?: boolean }) => {
     const globalOpts = program.opts();
     await startCommand(task, { ...opts, root: globalOpts.root });
   });

--- a/docs/specs/2026-04-18-codex-home-isolation-design.md
+++ b/docs/specs/2026-04-18-codex-home-isolation-design.md
@@ -157,6 +157,16 @@ Migration (`src/state.ts` `migrateState`): `if (raw.codexNoIsolate === undefined
 
 `createInitialState(runId, task, baseCommit, autoMode, loggingEnabled, codexNoIsolate = false)` threads the option.
 
+**Test fixture sweep**. This repo has hand-written `HarnessState` objects in multiple test files that must be updated to include the new field, or `pnpm tsc --noEmit` fails. The sweep target list (discovered via `rg 'HarnessState' tests/`):
+
+- `tests/state.test.ts` — migration + round-trip tests (update + add a `codexNoIsolate` migration case).
+- `tests/phases/gate-resume.test.ts` — state fixtures used for resume/lineage tests.
+- `tests/commands/inner.test.ts` — state fixtures for inner command tests.
+- `tests/integration/logging.test.ts` — state fixtures that produce the session meta.
+- Any additional files surfaced by `rg 'HarnessState' tests/` at impl time.
+
+Each fixture either (a) uses `createInitialState(...)` — zero-diff thanks to default `codexNoIsolate = false`, or (b) constructs a state literal — requires adding `codexNoIsolate: false`.
+
 ### 4.6 CLI flag
 
 New option on `harness start` and `harness run` in `bin/harness.ts`:
@@ -172,6 +182,12 @@ Not surfaced on `harness resume` — decision is fixed at run-start time. Resume
 ### 4.7 Logging
 
 Add `codexHome` (absolute path) to `SessionMeta` (`~/.harness/sessions/<hash>/<runId>/meta.json`). Written once on session bootstrap by `sessionLogger.writeMeta(…)`. No per-event overhead.
+
+Concrete integration points:
+
+- `src/types.ts` — extend `SessionMeta` with `codexHome?: string` (optional for back-compat when `--codex-no-isolate` is set).
+- `src/commands/inner.ts` — the bootstrap call site is `logger.writeMeta({ task: state.task })`. Extend to `logger.writeMeta({ task: state.task, codexHome: state.codexNoIsolate ? undefined : codexHomeFor(runDir) })`. Use `codexHomeFor` (pure function — no FS side effect) so meta reflects the planned path even before the first gate runs.
+- `src/logger.ts` — `writeMeta` already merges the partial into meta.json; no logic change beyond type.
 
 This is pure observability — post-mortem debugging ("where did that session rollout file go?") without bloating `events.jsonl`.
 
@@ -250,12 +266,12 @@ Fallback policy: **abort, not silent bypass**. Silent fallback to non-isolated w
 
 ## 8. Eval checklist (consumed by Phase 6 `harness-verify.sh`)
 
+Structural (build gates):
+
 ```
 - pnpm tsc --noEmit            → exit 0
 - pnpm vitest run              → all pass (baseline 531 + new tests)
 - pnpm build                   → exit 0 (tsc + copy-assets)
-- test exists: tests/runners/codex-isolation.test.ts
-- test exists: assertion "CODEX_HOME" in tests/runners/codex.test.ts OR codex-resume.test.ts
 - file exists: src/runners/codex-isolation.ts
 - grep-assert: "codexNoIsolate" present in src/types.ts
 - grep-assert: "CODEX_HOME" present in src/runners/codex.ts
@@ -263,19 +279,64 @@ Fallback policy: **abort, not silent bypass**. Silent fallback to non-isolated w
 - grep-assert: "Scope rules" still present in src/context/assembler.ts (defense-in-depth retained)
 ```
 
+Behavioral (prove the fix, not just surface changes):
+
+```
+- test passes: "ensureCodexIsolation creates <runDir>/codex-home/ with auth.json symlink" in tests/runners/codex-isolation.test.ts
+- test passes: "ensureCodexIsolation is idempotent on second call" in tests/runners/codex-isolation.test.ts
+- test passes: "ensureCodexIsolation throws CodexIsolationError when real auth.json missing" in tests/runners/codex-isolation.test.ts
+- test passes: "runCodexGate spawn env contains CODEX_HOME=<provided path>" in tests/runners/codex.test.ts OR codex-resume.test.ts
+- test passes: "runCodexGate spawn env does NOT contain CODEX_HOME when codexHome is null (escape hatch)" (same file)
+- test passes: "runCodexInteractive spawn env contains CODEX_HOME=<provided path>" (same file)
+- test passes: "gate.ts propagates CodexIsolationError as gate_error (no retry)" in tests/phases/gate.test.ts
+- test passes: "interactive.ts propagates CodexIsolationError as phase error" in tests/phases/interactive.test.ts
+- test passes: "startCommand with --codex-no-isolate sets state.codexNoIsolate=true and emits stderr warning" in tests/commands/run.test.ts
+- test passes: "migrateState adds codexNoIsolate=false to legacy state" in tests/state.test.ts
+- test passes: "SessionMeta contains codexHome path when isolation enabled" in tests/integration/logging.test.ts (or tests/logger.test.ts)
+- test passes: "SessionMeta does NOT contain codexHome when --codex-no-isolate" (same file)
+```
+
+Evidence (attached to PR body):
+
+```
+- Manual smoke artifact: harness run in a throwaway repo produces
+  .harness/<runId>/codex-home/auth.json as a symlink pointing at real auth.
+- Manual smoke artifact: .harness/<runId>/codex-home/sessions/YYYY/MM/DD/rollout-*.jsonl
+  is populated after first gate fires.
+- Manual smoke artifact: gate verdict (gate-2-raw.txt) does NOT reference user's
+  personal convention content (grep -i 'lore commit protocol' returns no hits).
+- Manual smoke artifact: harness run --codex-no-isolate does NOT create codex-home/,
+  state.json contains "codexNoIsolate": true, stderr warning line visible.
+```
+
 ## 9. Implementation plan (ordered)
 
-1. **Scaffold `src/runners/codex-isolation.ts`** (§4.3). Export `CodexIsolationError`, `codexHomeFor`, `ensureCodexIsolation`.
-2. **Unit test `tests/runners/codex-isolation.test.ts`** (§7.1) — TDD: write first, fail, then step 1 makes them pass.
-3. **Type + state migration**: `HarnessState.codexNoIsolate`, `migrateState`, `createInitialState` signature. Update existing call sites (`start.ts`).
-4. **Runner signature extension**: `runCodexInteractive` + `runCodexGate` accept `codexHome: string | null`. Spawn `env` branch. Existing tests still pass (backward-compat default).
-5. **Runner env tests** (§7.2) — extend existing codex test files with env-capture assertions.
-6. **Caller integration**: `src/phases/gate.ts` + `src/phases/interactive.ts` call `ensureCodexIsolation(runDir)` unless `state.codexNoIsolate`.
-7. **CLI flag**: `bin/harness.ts` + `StartOptions` (`src/commands/start.ts`).
-8. **Logging**: add `codexHome` to `SessionMeta` write-through.
-9. **Integration test updates** (§7.3) — extend `tests/commands/run.test.ts` and related.
-10. **Typecheck + full vitest run + build**. Fix any breakage.
-11. **Manual smoke** (§7.4). Capture output in PR body.
+TDD rhythm: where a test is listed before its implementation, write the failing test first, then the code that makes it pass. Where an interface change precedes tests (e.g. adding a required state field), the fixture sweep is mechanical and tests come after.
+
+1. **Write failing unit tests for `ensureCodexIsolation`** — `tests/runners/codex-isolation.test.ts` per §7.1. These fail because the module doesn't exist.
+2. **Scaffold `src/runners/codex-isolation.ts`** (§4.3). Export `CodexIsolationError`, `codexHomeFor`, `ensureCodexIsolation`. Step 1 tests now pass.
+3. **Type + state migration**:
+   - `src/types.ts`: add `HarnessState.codexNoIsolate: boolean` and `SessionMeta.codexHome?: string`.
+   - `src/state.ts`: `migrateState` defaults `codexNoIsolate = false`; extend `createInitialState` signature.
+   - **Fixture sweep** (§4.5): update every hand-written `HarnessState` literal in tests to include `codexNoIsolate: false`. Run `pnpm tsc --noEmit` iteratively until clean.
+   - Add one migration test case to `tests/state.test.ts`: legacy state (no field) → migrated state has `codexNoIsolate: false`.
+4. **Runner signature extension**: `runCodexInteractive` + `runCodexGate` accept `codexHome: string | null` param. Spawn `env` branch per §4.2. Existing tests still pass (default null preserves current spawn options).
+5. **Runner env tests** (§7.2) — extend `tests/runners/codex.test.ts` + `codex-resume.test.ts` with env-capture assertions: when `codexHome` is a path, `spawn.mock.calls[i][2].env.CODEX_HOME === codexHome`; when null, no `CODEX_HOME` present. Both fresh and resume spawn paths asserted.
+6. **Caller integration** (gate):
+   - Write failing test in `tests/phases/gate.test.ts` asserting `CodexIsolationError` → `gate_error` (no retry).
+   - Modify `src/phases/gate.ts` to call `ensureCodexIsolation(runDir)` unless `state.codexNoIsolate`; wrap in try/catch producing a `GatePhaseResult` error. Test passes.
+7. **Caller integration** (interactive):
+   - Write failing test in `tests/phases/interactive.test.ts` for the codex-interactive branch asserting propagation.
+   - Modify `src/phases/interactive.ts` codex branch with same pattern. Test passes.
+8. **CLI flag + warning**:
+   - `bin/harness.ts`: add `--codex-no-isolate` option on `start` and `run` subcommands.
+   - `src/commands/start.ts`: `StartOptions.codexNoIsolate?: boolean`, threaded into `createInitialState`. On `true`, emit stderr warning: `⚠️  CODEX_HOME isolation disabled. Codex subprocess may load personal conventions (BUG-C risk).`
+   - Extend `tests/commands/run.test.ts` with two cases: flag sets `state.codexNoIsolate = true` AND emits the warning line; absence of flag leaves it `false`.
+9. **Logger/SessionMeta integration**:
+   - `src/commands/inner.ts`: change the bootstrap `logger.writeMeta({ task: state.task })` to include `codexHome: state.codexNoIsolate ? undefined : codexHomeFor(runDir)`.
+   - Extend `tests/integration/logging.test.ts` (or `tests/logger.test.ts`) with assertions per §8: meta.json includes `codexHome` when isolation enabled; absent under `--codex-no-isolate`.
+10. **Typecheck + full vitest run + build**. Fix any breakage surfaced by the fixture sweep.
+11. **Manual smoke** (§7.4). Capture evidence per §8 Evidence block. Save to PR body.
 12. **PR**.
 
 ## 10. Open Questions — resolved

--- a/docs/specs/2026-04-18-codex-home-isolation-design.md
+++ b/docs/specs/2026-04-18-codex-home-isolation-design.md
@@ -1,0 +1,306 @@
+# Codex Subprocess `CODEX_HOME` Isolation — BUG-C Permanent Fix
+
+**Status**: design + impl plan + eval checklist (combined, per compressed `/harness` flow)
+**Issue**: Project `CLAUDE.md` open-issues table row #13
+**Date**: 2026-04-18
+
+## Cross-references
+
+- `docs/specs/2026-04-18-gate-prompt-hardening-design.md` §BUG-C — original contamination path + prompt-level mitigation (PR #11)
+- `src/context/assembler.ts` `REVIEWER_CONTRACT_BASE` — "Scope rules" stanza from PR #11 (retained as defense in depth)
+- `src/runners/codex.ts` — `runCodexInteractive` L25 + `runCodexGate` L312 (the two spawn sites)
+- `src/types.ts` `HarnessState` — gains one new field (`codexNoIsolate`)
+
+## 1. Background
+
+Codex gate subprocesses spawn from harness inherit the parent's `HOME`. Codex then loads `~/.codex/AGENTS.md`, which contains the user's personal conventions (e.g., "Lore Commit Protocol"). When codex is acting as reviewer of an *external* project, it applies those personal conventions to the work under review — a reviewer-domain leak known as **BUG-C**.
+
+PR #11 added a "Scope rules" stanza to `REVIEWER_CONTRACT_BASE` telling the reviewer to ignore personal `AGENTS.md` conventions. That is a prompt-level *mitigation* — effective against a cooperative reviewer, but brittle (a distracted/adversarial reviewer can still leak). This spec is the root-cause fix: make the personal `AGENTS.md` *unreadable* to the subprocess.
+
+## 2. Goal / Non-goal
+
+**Goal**: Codex gate + codex-interactive subprocesses run in an isolated codex home where the user's personal `AGENTS.md` (and other customizations: `agents/`, `prompts/`, `skills/`, `rules/`, `memories/`, `hooks.json`) are not reachable, while auth + session-resume continue to work.
+
+**Non-goals**:
+- Claude runner HOME isolation (separate issue).
+- Modifying the user's real `~/.codex/` directory contents.
+- Removing the PR #11 scope-rules stanza (retained as defense in depth).
+
+## 3. Key finding (spike)
+
+`codex exec` — both the fresh `exec` form and `exec resume` — respects the `CODEX_HOME` environment variable. Verified by manual smoke test:
+
+```bash
+# Spike 1: fresh exec with CODEX_HOME → only auth.json symlink → succeeds
+mkdir -p /tmp/iso && ln -sf ~/.codex/auth.json /tmp/iso/auth.json
+CODEX_HOME=/tmp/iso codex exec --model <m> 'FIRST_OK'   # → session id: <sid>
+# Session file written under /tmp/iso/sessions/YYYY/MM/DD/rollout-*.jsonl
+
+# Spike 2: resume round-trips, recalls prior context
+CODEX_HOME=/tmp/iso codex exec resume <sid> --model <m> 'recall first reply'
+# → codex replies: "RESUMED_OK FIRST_OK" (session fully reachable)
+```
+
+This means we can override `CODEX_HOME` (not full `HOME`) and bootstrap the isolated dir with **only `auth.json`**. `config.toml` is not required (codex falls back to defaults, which is what we want — the user's profile/aliases shouldn't apply to reviewer runs).
+
+## 4. Design
+
+### 4.1 Isolated directory layout — per-run
+
+For each harness run, the isolated codex home lives at:
+
+```
+<runDir>/codex-home/            (= <harnessDir>/<runId>/codex-home/)
+├── auth.json   → symlink to <real-codex-home>/auth.json
+├── sessions/   (created by codex as needed — gate session rollouts)
+└── …           (cache/, logs_2.sqlite, etc. — codex creates at will)
+```
+
+Where *real codex home* is resolved as: `process.env.CODEX_HOME || path.join(os.homedir(), '.codex')` — this respects users who have already set `CODEX_HOME` globally for their own terminal sessions.
+
+**Why per-run (not per-project or global)**:
+- Matches existing harness artifact layout (runDir holds `state.json`, `events.jsonl`, feedback files, etc.). One more subdir is natural.
+- Run cleanup is automatic: deleting `.harness/<runId>/` reclaims codex artifacts too.
+- Resume works because *all* gate invocations within one run see the same `runDir` → same `codex-home/` → same `sessions/` dir.
+- No cross-run / cross-project session leakage.
+
+**What gets symlinked**: only `auth.json`. Omitting `config.toml` means:
+- No user profile leak (profiles in `config.toml` can re-introduce AGENTS-like prompts).
+- Reviewer runs use codex defaults — deterministic.
+- We already pass `--model` + `-c model_reasoning_effort=…` on every spawn, so defaults are fine.
+
+**What is deliberately NOT present**: `AGENTS.md`, `agents/`, `prompts/`, `skills/`, `rules/`, `memories/`, `hooks.json`. Absence is the point — codex loads nothing personal.
+
+### 4.2 Spawn-time env override
+
+Both codex spawns (L55 `exec` and L197 `exec resume`) add:
+
+```ts
+spawn(codexBin, args, {
+  …existing options…,
+  env: codexHome === null
+    ? process.env                                   // --codex-no-isolate escape
+    : { ...process.env, CODEX_HOME: codexHome },
+});
+```
+
+`codexHome: string | null` is a new parameter threaded in from the runner's caller:
+- `runCodexInteractive(phase, state, preset, harnessDir, runDir, promptFile, cwd, codexHome)`
+- `runCodexGate(phase, preset, prompt, harnessDir, cwd, resumeSessionId?, buildFreshPromptOnFallback?, codexHome?)`
+
+`null` means "no isolation" (escape hatch). The default caller behavior is to always pass a non-null path.
+
+### 4.3 Bootstrap — `ensureCodexIsolation(runDir)`
+
+New module `src/runners/codex-isolation.ts`:
+
+```ts
+export class CodexIsolationError extends Error { readonly code = 'CODEX_ISOLATION_FAILED'; }
+
+export function codexHomeFor(runDir: string): string {
+  return path.join(runDir, 'codex-home');
+}
+
+export function ensureCodexIsolation(runDir: string): string {
+  const codexHome = codexHomeFor(runDir);
+  fs.mkdirSync(codexHome, { recursive: true });
+
+  const realHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+  const authSrc = path.join(realHome, 'auth.json');
+  if (!fs.existsSync(authSrc)) {
+    throw new CodexIsolationError(
+      `Codex auth not found at ${authSrc}. Run 'codex login' first, ` +
+      `or pass --codex-no-isolate to bypass isolation (not recommended).`
+    );
+  }
+
+  const authDst = path.join(codexHome, 'auth.json');
+  try { fs.unlinkSync(authDst); } catch { /* missing ok */ }
+  fs.symlinkSync(authSrc, authDst);
+
+  return codexHome;
+}
+```
+
+**Idempotent**: every gate call re-runs `ensureCodexIsolation(runDir)`. `mkdirSync({recursive: true})` is a no-op on existing dirs; `unlink + symlink` refreshes the auth link (handles the edge case where the user re-logged in mid-run and `~/.codex/auth.json` was rewritten — symlinks resolve live, but an unlinked+remade symlink is guaranteed correct).
+
+**Failure mode**: throws `CodexIsolationError` with an actionable message. Caller converts to gate-error (no retry — surfaces to user immediately).
+
+### 4.4 Caller integration
+
+```ts
+// src/phases/gate.ts  (around L272)
+const codexHome = state.codexNoIsolate ? null : ensureCodexIsolation(runDir);
+const result = await runCodexGate(phase, preset, prompt, harnessDir, cwd,
+                                  resumeSessionId, fallbackBuilder, codexHome);
+
+// src/phases/interactive.ts  (around L213 for codex-interactive branch)
+const codexHome = state.codexNoIsolate ? null : ensureCodexIsolation(runDir);
+const result = await runCodexInteractive(phase, state, preset, harnessDir, runDir,
+                                         promptFile, cwd, codexHome);
+```
+
+`ensureCodexIsolation` throwing propagates up to the normal error-handling path (`CodexIsolationError` is a subclass of `Error` so the existing try/catch boundaries catch it). Gate path converts to a `gate_error` event; interactive path fails the phase with the isolation error written to a sidecar `codex-<phase>-error.md`.
+
+### 4.5 State + migration
+
+Add one field to `HarnessState`:
+
+```ts
+export interface HarnessState {
+  …existing fields…
+  codexNoIsolate: boolean;  // escape hatch decision, persisted for resume
+}
+```
+
+Migration (`src/state.ts` `migrateState`): `if (raw.codexNoIsolate === undefined) raw.codexNoIsolate = false;`
+
+`createInitialState(runId, task, baseCommit, autoMode, loggingEnabled, codexNoIsolate = false)` threads the option.
+
+### 4.6 CLI flag
+
+New option on `harness start` and `harness run` in `bin/harness.ts`:
+
+```ts
+.option('--codex-no-isolate', 'bypass CODEX_HOME isolation for codex subprocesses (not recommended)')
+```
+
+`StartOptions.codexNoIsolate?: boolean` → passed to `createInitialState`.
+
+Not surfaced on `harness resume` — decision is fixed at run-start time. Resume reads `state.codexNoIsolate` and honors it.
+
+### 4.7 Logging
+
+Add `codexHome` (absolute path) to `SessionMeta` (`~/.harness/sessions/<hash>/<runId>/meta.json`). Written once on session bootstrap by `sessionLogger.writeMeta(…)`. No per-event overhead.
+
+This is pure observability — post-mortem debugging ("where did that session rollout file go?") without bloating `events.jsonl`.
+
+### 4.8 Defense in depth
+
+The PR #11 scope-rules stanza in `REVIEWER_CONTRACT_BASE` **stays**. Reasons:
+
+- Cheap (prompt tokens are fixed cost per run).
+- Survives hypothetical bypasses of isolation (future bug in `ensureCodexIsolation`, new codex feature that ignores `CODEX_HOME`, etc.).
+- Fail-closed: even if isolation silently degrades, the reviewer is still told "ignore personal conventions".
+
+## 5. Scope
+
+**Modify**
+- `src/runners/codex.ts` — add `codexHome` param to both runner functions; thread to spawn `env`.
+- `src/phases/gate.ts` — call `ensureCodexIsolation(runDir)` before `runCodexGate`.
+- `src/phases/interactive.ts` — same, for codex-interactive branch.
+- `src/types.ts` — `HarnessState.codexNoIsolate: boolean`.
+- `src/state.ts` — migration default + `createInitialState` param.
+- `src/commands/start.ts` — `StartOptions.codexNoIsolate` plumbing.
+- `bin/harness.ts` — `--codex-no-isolate` option on `start` + `run`.
+- `src/logger.ts` (or wherever `SessionMeta` is written) — include `codexHome` in meta.
+
+**Create**
+- `src/runners/codex-isolation.ts` — module described in §4.3.
+- `tests/runners/codex-isolation.test.ts` — unit tests (§7).
+
+**Do NOT modify**
+- `src/context/assembler.ts` — `REVIEWER_CONTRACT_BASE` scope-rules stanza retained.
+- Claude runner (`src/runners/claude.ts`) — separate issue.
+- Real `~/.codex/` contents — never touched, only read via symlink.
+- Gate prompt construction / verdict parsing — isolation is orthogonal.
+
+## 6. Error handling
+
+| Failure | Handling |
+|---|---|
+| `mkdir` fails (permission / disk full) | `CodexIsolationError` → gate error, visible to user. No retry. |
+| Real `auth.json` missing | `CodexIsolationError` with "run `codex login`" message. No retry. |
+| `symlink` syscall fails | `CodexIsolationError` with underlying errno. No retry. |
+| Real `auth.json` exists but points at broken target | Codex spawn fails with auth error (same as today without isolation). |
+| User passes `--codex-no-isolate` | Isolation skipped entirely. Log warning line in stderr at run-start. |
+
+Fallback policy: **abort, not silent bypass**. Silent fallback to non-isolated would re-expose BUG-C with no signal. The escape hatch flag is the explicit user-authorized path.
+
+## 7. Testing
+
+### 7.1 Unit — `tests/runners/codex-isolation.test.ts` (new)
+
+- `ensureCodexIsolation` creates `<runDir>/codex-home/` when absent.
+- `ensureCodexIsolation` is idempotent (second call on same `runDir` succeeds).
+- Symlink points at real `auth.json` (use `tmpdir` + fake real-home fixture; override `process.env.CODEX_HOME` for the test).
+- Throws `CodexIsolationError` when real `auth.json` missing.
+- Throws `CodexIsolationError` when `mkdir` fails (e.g., target path is an existing file).
+
+### 7.2 Unit — `tests/runners/codex.test.ts` + `codex-resume.test.ts` (extend)
+
+- When `codexHome` non-null is passed to `runCodexGate`, `spawn.mock.calls[0][2].env.CODEX_HOME` equals that path.
+- When `codexHome` is null (escape hatch), `spawn.mock.calls[0][2].env` does NOT contain `CODEX_HOME` (or equals `process.env` unchanged — whichever the impl does).
+- `runCodexInteractive` variant of the same check.
+- Resume path: `CODEX_HOME` passed on both initial resume and fresh-fallback spawns.
+
+### 7.3 Integration — existing harness
+
+- Default `harness start`/`harness run` new-run creates `<runDir>/codex-home/auth.json` (symlink) before any gate fires.
+- `--codex-no-isolate` flag: `codex-home/` is NOT created; `state.codexNoIsolate === true`.
+- `harness resume` on a run started with `--codex-no-isolate` preserves the decision.
+
+### 7.4 Manual smoke (documented in PR body)
+
+- Run `harness run --enable-logging "say hi"` in a throwaway git repo. Verify:
+  - `.harness/<runId>/codex-home/auth.json` exists as a symlink.
+  - `.harness/<runId>/codex-home/sessions/…/rollout-*.jsonl` is created by the first gate.
+  - Gate verdict does NOT reference user's personal convention content (e.g., "Lore Commit Protocol" keywords absent from `gate-2-raw.txt`).
+- Run with `--codex-no-isolate` and confirm `codex-home/` is not created.
+
+## 8. Eval checklist (consumed by Phase 6 `harness-verify.sh`)
+
+```
+- pnpm tsc --noEmit            → exit 0
+- pnpm vitest run              → all pass (baseline 531 + new tests)
+- pnpm build                   → exit 0 (tsc + copy-assets)
+- test exists: tests/runners/codex-isolation.test.ts
+- test exists: assertion "CODEX_HOME" in tests/runners/codex.test.ts OR codex-resume.test.ts
+- file exists: src/runners/codex-isolation.ts
+- grep-assert: "codexNoIsolate" present in src/types.ts
+- grep-assert: "CODEX_HOME" present in src/runners/codex.ts
+- grep-assert: "--codex-no-isolate" present in bin/harness.ts
+- grep-assert: "Scope rules" still present in src/context/assembler.ts (defense-in-depth retained)
+```
+
+## 9. Implementation plan (ordered)
+
+1. **Scaffold `src/runners/codex-isolation.ts`** (§4.3). Export `CodexIsolationError`, `codexHomeFor`, `ensureCodexIsolation`.
+2. **Unit test `tests/runners/codex-isolation.test.ts`** (§7.1) — TDD: write first, fail, then step 1 makes them pass.
+3. **Type + state migration**: `HarnessState.codexNoIsolate`, `migrateState`, `createInitialState` signature. Update existing call sites (`start.ts`).
+4. **Runner signature extension**: `runCodexInteractive` + `runCodexGate` accept `codexHome: string | null`. Spawn `env` branch. Existing tests still pass (backward-compat default).
+5. **Runner env tests** (§7.2) — extend existing codex test files with env-capture assertions.
+6. **Caller integration**: `src/phases/gate.ts` + `src/phases/interactive.ts` call `ensureCodexIsolation(runDir)` unless `state.codexNoIsolate`.
+7. **CLI flag**: `bin/harness.ts` + `StartOptions` (`src/commands/start.ts`).
+8. **Logging**: add `codexHome` to `SessionMeta` write-through.
+9. **Integration test updates** (§7.3) — extend `tests/commands/run.test.ts` and related.
+10. **Typecheck + full vitest run + build**. Fix any breakage.
+11. **Manual smoke** (§7.4). Capture output in PR body.
+12. **PR**.
+
+## 10. Open Questions — resolved
+
+| # | Question | Resolution |
+|---|---|---|
+| Q1 | Isolated dir location | **(A) per-run** `<runDir>/codex-home/` — matches harness layout, auto-cleanup, same dir across gates in one run enables resume. |
+| Q2 | Files to bootstrap | **`auth.json` only** (symlink). No `config.toml` — spike confirmed not required; also prevents profile-via-config leak. AGENTS.md absent by design. |
+| Q3 | Env strategy | **`CODEX_HOME` override**, NOT full `HOME` override. Codex supports `CODEX_HOME` natively (confirmed by spike); preserves auth without symlink dance around credential files that may or may not live in `~/.codex/`. |
+| Q4 | Resume compat | Same `runDir` → same `codex-home/` → same `sessions/` dir. Spike round-tripped `exec` → `exec resume` cleanly. |
+| Q5 | Fallback | **Abort** on isolation failure (not silent bypass). Escape hatch = explicit `--codex-no-isolate` CLI flag, persisted to `state.codexNoIsolate`. |
+| Q6 | Scope-rules stanza | **Keep** as defense-in-depth. Low cost, survives future isolation bypass bugs. |
+
+## 11. Risks + mitigations
+
+- **Risk: codex refreshes auth token and the symlink behavior under atomic-rename breaks**. Mitigation: symlinks resolve at read time; atomic rename of the real `auth.json` is seen by the next `open()` through the symlink. Tested: the real codex CLI uses `~/.codex/` directly and atomic-replaces; no observed issue during spike. If it ever becomes a concern, we can switch to a hard link (within same filesystem) or a copy-and-refresh heuristic.
+- **Risk: user runs `codex login` mid-harness-session and the auth state diverges**. Mitigation: `ensureCodexIsolation` is called before every gate spawn and refreshes the symlink. Any subsequent gate sees the live `auth.json`.
+- **Risk: Windows filesystem symlink permissions**. Not a concern — harness is macOS/Linux only (preflight gate already checks `platform`).
+- **Risk: `CODEX_HOME` semantics change in a future codex release**. Mitigation: scope-rules stanza is still in the prompt; if `CODEX_HOME` silently stops working, the mitigation still blocks contamination. We'd see it in test output and can adjust.
+
+## 12. Out of scope (explicit)
+
+- Claude runner HOME isolation (separate PR, separate issue).
+- Light-flow code (Group A).
+- `advisor()` removal / orphan text fix (Group B).
+- CLAUDE.md doc refresh (Group C).
+- Changes to user's real `~/.codex/` directory.
+- Enforcing codex login — if the user hasn't logged in, `ensureCodexIsolation` surfaces the missing-auth error, same UX as today.

--- a/docs/specs/2026-04-18-codex-home-isolation-design.md
+++ b/docs/specs/2026-04-18-codex-home-isolation-design.md
@@ -312,11 +312,12 @@ Behavioral (prove the fix, not just surface changes):
 - test passes: "runCodexInteractive spawn env contains CODEX_HOME=<provided path>" (same file)
 - test passes: "gate.ts propagates CodexIsolationError as gate_error (no retry)" in tests/phases/gate.test.ts
 - test passes: "interactive.ts propagates CodexIsolationError as phase error" in tests/phases/interactive.test.ts
+- test passes: "codex-interactive branch in interactive.ts calls ensureCodexIsolation(runDir) and passes codexHomeFor(runDir) to runCodexInteractive" in tests/phases/interactive.test.ts
 - test passes: "startCommand with --codex-no-isolate sets state.codexNoIsolate=true and emits stderr warning" in tests/commands/run.test.ts
 - test passes: "migrateState adds codexNoIsolate=false to legacy state" in tests/state.test.ts
 - test passes: "resumeCommand preserves state.codexNoIsolate=true across resume" in tests/commands (or equivalent resume test file)
 - test passes: "first gate invocation creates <runDir>/codex-home/auth.json symlink" in tests/phases/gate.test.ts (lazy-at-first-use, not startCommand)
-- test passes: "ensureCodexIsolation creates ONLY auth.json (no config.toml, no AGENTS.md) in <runDir>/codex-home/" in tests/runners/codex-isolation.test.ts — explicit absence check for config.toml
+- test passes: "ensureCodexIsolation bootstraps ONLY auth.json — absent: AGENTS.md, config.toml, agents/, prompts/, skills/, rules/, memories/, hooks.json" in tests/runners/codex-isolation.test.ts
 - test passes: "SessionMeta contains codexHome path when isolation enabled" in tests/integration/logging.test.ts (or tests/logger.test.ts)
 - test passes: "SessionMeta does NOT contain codexHome when --codex-no-isolate" (same file)
 - test passes: "updateMeta lazy-bootstrap path (resume with missing meta.json) persists codexHome" in tests/logger.test.ts
@@ -355,8 +356,10 @@ TDD rhythm: where a test is listed before its implementation, write the failing 
    - Write failing test in `tests/phases/gate.test.ts` asserting `CodexIsolationError` → `gate_error` (no retry).
    - Modify `src/phases/gate.ts` to call `ensureCodexIsolation(runDir)` unless `state.codexNoIsolate`; wrap in try/catch producing a `GatePhaseResult` error. Test passes.
 7. **Caller integration** (interactive):
-   - Write failing test in `tests/phases/interactive.test.ts` for the codex-interactive branch asserting propagation.
-   - Modify `src/phases/interactive.ts` codex branch with same pattern. Test passes.
+   - Write failing tests in `tests/phases/interactive.test.ts` for the codex-interactive branch:
+     - **Positive path**: when `state.codexNoIsolate === false`, `ensureCodexIsolation(runDir)` is invoked and `codexHomeFor(runDir)` is passed to `runCodexInteractive` (spy on `ensureCodexIsolation` + assert `runCodexInteractive.mock.calls[0]` includes the expected path arg).
+     - **Error propagation**: when `ensureCodexIsolation` throws `CodexIsolationError`, the phase surfaces it as an interactive phase error (not a retry-eligible condition).
+   - Modify `src/phases/interactive.ts` codex branch with same pattern as gate. Tests pass.
 8. **CLI flag + warning**:
    - `bin/harness.ts`: add `--codex-no-isolate` option on `start` and `run` subcommands.
    - `src/commands/start.ts`: `StartOptions.codexNoIsolate?: boolean`, threaded into `createInitialState`. On `true`, emit stderr warning: `⚠️  CODEX_HOME isolation disabled. Codex subprocess may load personal conventions (BUG-C risk).`

--- a/docs/specs/2026-04-18-codex-home-isolation-design.md
+++ b/docs/specs/2026-04-18-codex-home-isolation-design.md
@@ -203,10 +203,13 @@ Concrete integration points:
 - `src/logger.ts` — **both** `FileSessionLogger.writeMeta` and `FileSessionLogger.updateMeta` build the `meta: SessionMeta` object from a fixed field list; neither spreads `partial`. A new `codexHome?` field would be silently dropped unless wired explicitly. Required changes:
   - `writeMeta`: add `...(partial.codexHome !== undefined ? { codexHome: partial.codexHome } : {})` to the constructed meta literal.
   - `updateMeta`: accept `codexHome` in the `update` param type; on the lazy-bootstrap branch (resume with missing meta.json), include it in the constructed meta; on the merge branch (meta.json exists), set `meta.codexHome = update.codexHome` when provided. Matches `task` handling semantics.
-- `src/commands/inner.ts` — **two** call sites must be updated:
-  1. `bootstrapSessionLogger` (L281): `logger.writeMeta({ task: state.task })` → `logger.writeMeta({ task: state.task, codexHome: state.codexNoIsolate ? undefined : codexHomeFor(runDir) })`.
-  2. `buildConfigCancelHandler` (L246): same change (this path fires after config cancel — same meta shape required).
-- Use `codexHomeFor` (pure function — no FS side effect) so meta reflects the planned path even before the first gate runs.
+- `src/commands/inner.ts` — **all five** meta-writing call sites must thread `codexHome`. Using the helper `const codexHome = state.codexNoIsolate ? undefined : codexHomeFor(runDir);` at function entry:
+  1. `bootstrapSessionLogger` L281 (fresh-start branch, `writeMeta`): `{ task: state.task }` → `{ task: state.task, codexHome }`.
+  2. `bootstrapSessionLogger` L274 (resume branch, `updateMeta`): `{ pushResumedAt: Date.now(), task: state.task }` → `{ pushResumedAt: Date.now(), task: state.task, codexHome }`.
+  3. `bootstrapSessionLogger` L278 (idempotent re-entry branch, `updateMeta`): `{ pushResumedAt: Date.now() }` → `{ pushResumedAt: Date.now(), codexHome }`.
+  4. `buildConfigCancelHandler` L246 (fresh-start branch, `writeMeta`): same change as #1.
+  5. `buildConfigCancelHandler` L243 (resume branch, `updateMeta`): same change as #2.
+- Use `codexHomeFor` (pure function — no FS side effect) so meta reflects the planned path even before the first codex-phase invocation.
 
 This is pure observability — post-mortem debugging ("where did that session rollout file go?") without bloating `events.jsonl`.
 
@@ -358,18 +361,22 @@ TDD rhythm: where a test is listed before its implementation, write the failing 
    - `bin/harness.ts`: add `--codex-no-isolate` option on `start` and `run` subcommands.
    - `src/commands/start.ts`: `StartOptions.codexNoIsolate?: boolean`, threaded into `createInitialState`. On `true`, emit stderr warning: `⚠️  CODEX_HOME isolation disabled. Codex subprocess may load personal conventions (BUG-C risk).`
    - Extend `tests/commands/run.test.ts` with two cases: flag sets `state.codexNoIsolate = true` AND emits the warning line; absence of flag leaves it `false`.
-9. **Logger/SessionMeta integration** (per §4.7 — three file edits + two call-site updates):
+9. **Logger/SessionMeta integration** (per §4.7 — three file edits + five call-site updates):
    - `src/types.ts`: add `codexHome?: string` to `SessionMeta`.
    - `src/logger.ts` — `FileSessionLogger.writeMeta`: extend the constructed `meta: SessionMeta` literal with `...(partial.codexHome !== undefined ? { codexHome: partial.codexHome } : {})`. Mirror pattern used today for `bootstrapOnResume`.
    - `src/logger.ts` — `FileSessionLogger.updateMeta`: extend the `update` param type to include `codexHome?: string`. In the lazy-bootstrap branch, include it in the freshly constructed meta. In the merge branch, set `meta.codexHome = update.codexHome` when provided.
-   - `src/commands/inner.ts` — **two** call-site updates (both pass `codexHome: state.codexNoIsolate ? undefined : codexHomeFor(runDir)`):
-     1. `bootstrapSessionLogger`, the `logger.writeMeta({ task: state.task })` call (around L281).
-     2. `buildConfigCancelHandler`, the `logger.writeMeta({ task: state.task })` call (around L246).
+   - `src/commands/inner.ts` — **five** call-site updates. At the top of each function compute `const codexHome = state.codexNoIsolate ? undefined : codexHomeFor(runDir);`, then thread to every meta write:
+     1. `bootstrapSessionLogger` L281: `writeMeta({ task: state.task, codexHome })`.
+     2. `bootstrapSessionLogger` L274 (resume): `updateMeta({ pushResumedAt: Date.now(), task: state.task, codexHome })`.
+     3. `bootstrapSessionLogger` L278 (idempotent re-entry): `updateMeta({ pushResumedAt: Date.now(), codexHome })`.
+     4. `buildConfigCancelHandler` L246: `writeMeta({ task: state.task, codexHome })`.
+     5. `buildConfigCancelHandler` L243 (resume): `updateMeta({ pushResumedAt: Date.now(), task: state.task, codexHome })`.
    - Tests (extending `tests/integration/logging.test.ts` or `tests/logger.test.ts`):
      - `meta.json` includes `codexHome` path after normal bootstrap.
      - `meta.json` does NOT include `codexHome` when `--codex-no-isolate`.
-     - Lazy-bootstrap path: `updateMeta` on a run with missing `meta.json` persists `codexHome` (resume scenario).
-     - Config-cancel path: re-`writeMeta` preserves `codexHome` (regression guard for the second call site).
+     - Lazy-bootstrap (resume with missing `meta.json`) via `bootstrapSessionLogger` path persists `codexHome`.
+     - Idempotent re-entry via `bootstrapSessionLogger` L278 path preserves/writes `codexHome`.
+     - Config-cancel path (both fresh-start and resume branches) writes/preserves `codexHome`.
 10. **Typecheck + full vitest run + build**. Fix any breakage surfaced by the fixture sweep.
 11. **Manual smoke** (§7.4). Capture evidence per §8 Evidence block. Save to PR body.
 12. **PR**.

--- a/docs/specs/2026-04-18-codex-home-isolation-design.md
+++ b/docs/specs/2026-04-18-codex-home-isolation-design.md
@@ -271,9 +271,9 @@ Fallback policy: **abort, not silent bypass**. Silent fallback to non-isolated w
 
 ### 7.3 Integration — existing harness
 
-- Default `harness start`/`harness run` new-run creates `<runDir>/codex-home/auth.json` (symlink) before any gate fires.
-- `--codex-no-isolate` flag: `codex-home/` is NOT created; `state.codexNoIsolate === true`.
-- `harness resume` on a run started with `--codex-no-isolate` preserves the decision.
+- First codex-phase invocation (gate or codex-interactive) creates `<runDir>/codex-home/auth.json` (symlink). Creation is lazy-at-first-use, not at `harness start` — this keeps the start path unchanged and auth errors surface as gate errors (the same boundary where they're already handled). `SessionMeta.codexHome` is pre-populated with the *planned* path at bootstrap time (via pure `codexHomeFor(runDir)`), so observability doesn't depend on creation timing.
+- `--codex-no-isolate` flag: `codex-home/` is NOT created; `state.codexNoIsolate === true`; runner spawns without `CODEX_HOME`.
+- `harness resume` on a run started with `--codex-no-isolate` preserves the decision (state already has the flag; resume doesn't re-ask).
 
 ### 7.4 Manual smoke (documented in PR body)
 
@@ -310,13 +310,16 @@ Behavioral (prove the fix, not just surface changes):
 - test passes: "gate.ts propagates CodexIsolationError as gate_error (no retry)" in tests/phases/gate.test.ts
 - test passes: "interactive.ts propagates CodexIsolationError as phase error" in tests/phases/interactive.test.ts
 - test passes: "startCommand with --codex-no-isolate sets state.codexNoIsolate=true and emits stderr warning" in tests/commands/run.test.ts
-- test passes: "startCommand default new-run creates <runDir>/codex-home/auth.json symlink" in tests/commands/run.test.ts (or dedicated integration)
 - test passes: "migrateState adds codexNoIsolate=false to legacy state" in tests/state.test.ts
 - test passes: "resumeCommand preserves state.codexNoIsolate=true across resume" in tests/commands (or equivalent resume test file)
+- test passes: "first gate invocation creates <runDir>/codex-home/auth.json symlink" in tests/phases/gate.test.ts (lazy-at-first-use, not startCommand)
+- test passes: "ensureCodexIsolation creates ONLY auth.json (no config.toml, no AGENTS.md) in <runDir>/codex-home/" in tests/runners/codex-isolation.test.ts — explicit absence check for config.toml
 - test passes: "SessionMeta contains codexHome path when isolation enabled" in tests/integration/logging.test.ts (or tests/logger.test.ts)
 - test passes: "SessionMeta does NOT contain codexHome when --codex-no-isolate" (same file)
 - test passes: "updateMeta lazy-bootstrap path (resume with missing meta.json) persists codexHome" in tests/logger.test.ts
+- test passes: "buildConfigCancelHandler writeMeta path persists codexHome (regression guard for second call site)" in tests/logger.test.ts OR tests/commands/inner.test.ts
 - test passes: "ensureCodexIsolation wraps mkdir/symlink EACCES failures as CodexIsolationError" in tests/runners/codex-isolation.test.ts
+- test passes: "resume-fallback path (session_missing → fresh) — BOTH spawn calls carry CODEX_HOME=<provided path>" in tests/runners/codex-resume.test.ts
 ```
 
 Evidence (attached to PR body):

--- a/docs/specs/2026-04-18-codex-home-isolation-design.md
+++ b/docs/specs/2026-04-18-codex-home-isolation-design.md
@@ -103,7 +103,13 @@ export function codexHomeFor(runDir: string): string {
 
 export function ensureCodexIsolation(runDir: string): string {
   const codexHome = codexHomeFor(runDir);
-  fs.mkdirSync(codexHome, { recursive: true });
+  try {
+    fs.mkdirSync(codexHome, { recursive: true });
+  } catch (err) {
+    throw new CodexIsolationError(
+      `Failed to create isolated codex home at ${codexHome}: ${(err as Error).message}`
+    );
+  }
 
   const realHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
   const authSrc = path.join(realHome, 'auth.json');
@@ -116,13 +122,21 @@ export function ensureCodexIsolation(runDir: string): string {
 
   const authDst = path.join(codexHome, 'auth.json');
   try { fs.unlinkSync(authDst); } catch { /* missing ok */ }
-  fs.symlinkSync(authSrc, authDst);
+  try {
+    fs.symlinkSync(authSrc, authDst);
+  } catch (err) {
+    throw new CodexIsolationError(
+      `Failed to symlink codex auth into ${authDst}: ${(err as Error).message}`
+    );
+  }
 
   return codexHome;
 }
 ```
 
 **Idempotent**: every gate call re-runs `ensureCodexIsolation(runDir)`. `mkdirSync({recursive: true})` is a no-op on existing dirs; `unlink + symlink` refreshes the auth link (handles the edge case where the user re-logged in mid-run and `~/.codex/auth.json` was rewritten — symlinks resolve live, but an unlinked+remade symlink is guaranteed correct).
+
+**All filesystem failures wrap to `CodexIsolationError`**: `mkdir`, the `auth.json` existence check, and `symlink` each live inside their own try/catch (or explicit existence check) that rethrows a `CodexIsolationError` with the underlying message. Raw EACCES/ENOENT/etc. never escape this function.
 
 **Failure mode**: throws `CodexIsolationError` with an actionable message. Caller converts to gate-error (no retry — surfaces to user immediately).
 
@@ -186,8 +200,13 @@ Add `codexHome` (absolute path) to `SessionMeta` (`~/.harness/sessions/<hash>/<r
 Concrete integration points:
 
 - `src/types.ts` — extend `SessionMeta` with `codexHome?: string` (optional for back-compat when `--codex-no-isolate` is set).
-- `src/commands/inner.ts` — the bootstrap call site is `logger.writeMeta({ task: state.task })`. Extend to `logger.writeMeta({ task: state.task, codexHome: state.codexNoIsolate ? undefined : codexHomeFor(runDir) })`. Use `codexHomeFor` (pure function — no FS side effect) so meta reflects the planned path even before the first gate runs.
-- `src/logger.ts` — `writeMeta` already merges the partial into meta.json; no logic change beyond type.
+- `src/logger.ts` — **both** `FileSessionLogger.writeMeta` and `FileSessionLogger.updateMeta` build the `meta: SessionMeta` object from a fixed field list; neither spreads `partial`. A new `codexHome?` field would be silently dropped unless wired explicitly. Required changes:
+  - `writeMeta`: add `...(partial.codexHome !== undefined ? { codexHome: partial.codexHome } : {})` to the constructed meta literal.
+  - `updateMeta`: accept `codexHome` in the `update` param type; on the lazy-bootstrap branch (resume with missing meta.json), include it in the constructed meta; on the merge branch (meta.json exists), set `meta.codexHome = update.codexHome` when provided. Matches `task` handling semantics.
+- `src/commands/inner.ts` — **two** call sites must be updated:
+  1. `bootstrapSessionLogger` (L281): `logger.writeMeta({ task: state.task })` → `logger.writeMeta({ task: state.task, codexHome: state.codexNoIsolate ? undefined : codexHomeFor(runDir) })`.
+  2. `buildConfigCancelHandler` (L246): same change (this path fires after config cancel — same meta shape required).
+- Use `codexHomeFor` (pure function — no FS side effect) so meta reflects the planned path even before the first gate runs.
 
 This is pure observability — post-mortem debugging ("where did that session rollout file go?") without bloating `events.jsonl`.
 
@@ -291,9 +310,13 @@ Behavioral (prove the fix, not just surface changes):
 - test passes: "gate.ts propagates CodexIsolationError as gate_error (no retry)" in tests/phases/gate.test.ts
 - test passes: "interactive.ts propagates CodexIsolationError as phase error" in tests/phases/interactive.test.ts
 - test passes: "startCommand with --codex-no-isolate sets state.codexNoIsolate=true and emits stderr warning" in tests/commands/run.test.ts
+- test passes: "startCommand default new-run creates <runDir>/codex-home/auth.json symlink" in tests/commands/run.test.ts (or dedicated integration)
 - test passes: "migrateState adds codexNoIsolate=false to legacy state" in tests/state.test.ts
+- test passes: "resumeCommand preserves state.codexNoIsolate=true across resume" in tests/commands (or equivalent resume test file)
 - test passes: "SessionMeta contains codexHome path when isolation enabled" in tests/integration/logging.test.ts (or tests/logger.test.ts)
 - test passes: "SessionMeta does NOT contain codexHome when --codex-no-isolate" (same file)
+- test passes: "updateMeta lazy-bootstrap path (resume with missing meta.json) persists codexHome" in tests/logger.test.ts
+- test passes: "ensureCodexIsolation wraps mkdir/symlink EACCES failures as CodexIsolationError" in tests/runners/codex-isolation.test.ts
 ```
 
 Evidence (attached to PR body):
@@ -332,9 +355,18 @@ TDD rhythm: where a test is listed before its implementation, write the failing 
    - `bin/harness.ts`: add `--codex-no-isolate` option on `start` and `run` subcommands.
    - `src/commands/start.ts`: `StartOptions.codexNoIsolate?: boolean`, threaded into `createInitialState`. On `true`, emit stderr warning: `⚠️  CODEX_HOME isolation disabled. Codex subprocess may load personal conventions (BUG-C risk).`
    - Extend `tests/commands/run.test.ts` with two cases: flag sets `state.codexNoIsolate = true` AND emits the warning line; absence of flag leaves it `false`.
-9. **Logger/SessionMeta integration**:
-   - `src/commands/inner.ts`: change the bootstrap `logger.writeMeta({ task: state.task })` to include `codexHome: state.codexNoIsolate ? undefined : codexHomeFor(runDir)`.
-   - Extend `tests/integration/logging.test.ts` (or `tests/logger.test.ts`) with assertions per §8: meta.json includes `codexHome` when isolation enabled; absent under `--codex-no-isolate`.
+9. **Logger/SessionMeta integration** (per §4.7 — three file edits + two call-site updates):
+   - `src/types.ts`: add `codexHome?: string` to `SessionMeta`.
+   - `src/logger.ts` — `FileSessionLogger.writeMeta`: extend the constructed `meta: SessionMeta` literal with `...(partial.codexHome !== undefined ? { codexHome: partial.codexHome } : {})`. Mirror pattern used today for `bootstrapOnResume`.
+   - `src/logger.ts` — `FileSessionLogger.updateMeta`: extend the `update` param type to include `codexHome?: string`. In the lazy-bootstrap branch, include it in the freshly constructed meta. In the merge branch, set `meta.codexHome = update.codexHome` when provided.
+   - `src/commands/inner.ts` — **two** call-site updates (both pass `codexHome: state.codexNoIsolate ? undefined : codexHomeFor(runDir)`):
+     1. `bootstrapSessionLogger`, the `logger.writeMeta({ task: state.task })` call (around L281).
+     2. `buildConfigCancelHandler`, the `logger.writeMeta({ task: state.task })` call (around L246).
+   - Tests (extending `tests/integration/logging.test.ts` or `tests/logger.test.ts`):
+     - `meta.json` includes `codexHome` path after normal bootstrap.
+     - `meta.json` does NOT include `codexHome` when `--codex-no-isolate`.
+     - Lazy-bootstrap path: `updateMeta` on a run with missing `meta.json` persists `codexHome` (resume scenario).
+     - Config-cancel path: re-`writeMeta` preserves `codexHome` (regression guard for the second call site).
 10. **Typecheck + full vitest run + build**. Fix any breakage surfaced by the fixture sweep.
 11. **Manual smoke** (§7.4). Capture evidence per §8 Evidence block. Save to PR body.
 12. **PR**.

--- a/src/commands/inner.ts
+++ b/src/commands/inner.ts
@@ -13,6 +13,7 @@ import { InputManager } from '../input.js';
 import { runRunnerAwarePreflight } from '../preflight.js';
 import { REQUIRED_PHASE_KEYS, getEffectiveReopenTarget, getRequiredPhaseKeys } from '../config.js';
 import { createSessionLogger } from '../logger.js';
+import { codexHomeFor } from '../runners/codex-isolation.js';
 import type { SessionLogger, HarnessState } from '../types.js';
 
 export interface InnerOptions {
@@ -243,13 +244,15 @@ export function buildConfigCancelHandler(args: ConfigCancelHandlerArgs): () => v
     };
     writeState(runDir, state);
 
+    const codexHome = state.codexNoIsolate ? undefined : codexHomeFor(runDir);
+
     // Lazy bootstrap session open event if not yet emitted
     if (!logger.hasEmittedSessionOpen()) {
       if (isResume) {
-        logger.updateMeta({ pushResumedAt: Date.now(), task: state.task });
+        logger.updateMeta({ pushResumedAt: Date.now(), task: state.task, codexHome });
         logger.logEvent({ event: 'session_resumed', fromPhase: state.currentPhase, stateStatus: 'paused' });
       } else {
-        logger.writeMeta({ task: state.task });
+        logger.writeMeta({ task: state.task, codexHome });
         logger.logEvent({ event: 'session_start', task: state.task, autoMode: state.autoMode, baseCommit: state.baseCommit, harnessVersion: '0.1.0' });
       }
     }
@@ -276,15 +279,17 @@ export async function bootstrapSessionLogger(
     baseCommit: state.baseCommit,
     sessionsRoot: options.sessionsRoot,
   });
+  const runDir = join(harnessDir, runId);
+  const codexHome = state.codexNoIsolate ? undefined : codexHomeFor(runDir);
   if (isResume) {
-    logger.updateMeta({ pushResumedAt: Date.now(), task: state.task });
+    logger.updateMeta({ pushResumedAt: Date.now(), task: state.task, codexHome });
     logger.logEvent({ event: 'session_resumed', fromPhase: state.currentPhase, stateStatus: state.status });
   } else if (logger.hasBootstrapped()) {
     // Idempotent case: meta.json already exists on disk (e.g., crash re-entry)
-    logger.updateMeta({ pushResumedAt: Date.now() });
+    logger.updateMeta({ pushResumedAt: Date.now(), codexHome });
     logger.logEvent({ event: 'session_resumed', fromPhase: state.currentPhase, stateStatus: state.status });
   } else {
-    logger.writeMeta({ task: state.task });
+    logger.writeMeta({ task: state.task, codexHome });
     logger.logEvent({ event: 'session_start', task: state.task, autoMode: state.autoMode, baseCommit: state.baseCommit, harnessVersion: '0.1.0' });
   }
   return logger;

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -17,6 +17,7 @@ export interface StartOptions {
   root?: string;
   enableLogging?: boolean;
   light?: boolean;
+  codexNoIsolate?: boolean;
 }
 
 export async function startCommand(task: string | undefined, options: StartOptions = {}): Promise<void> {
@@ -110,7 +111,16 @@ export async function startCommand(task: string | undefined, options: StartOptio
       options.auto ?? false,
       options.enableLogging ?? false,
       options.light ? 'light' : 'full',
+      options.codexNoIsolate ?? false,
     );
+
+    if (options.codexNoIsolate) {
+      // BUG-C risk surface: user explicitly bypassed isolation.
+      process.stderr.write(
+        '⚠️  CODEX_HOME isolation disabled. Codex subprocess may load personal ' +
+        'conventions from ~/.codex/AGENTS.md (BUG-C risk).\n',
+      );
+    }
 
     // 13. Save task.md (needed before Phase 1 spawn)
     try {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -11,7 +11,7 @@ export function computeRepoKey(harnessDir: string): string {
 export class NoopLogger implements SessionLogger {
   logEvent(_event: DistributiveOmit<LogEvent, 'v' | 'ts' | 'runId'>): void { /* no-op */ }
   writeMeta(_partial: Partial<SessionMeta> & { task: string }): void { /* no-op */ }
-  updateMeta(_update: { pushResumedAt?: number; task?: string }): void { /* no-op */ }
+  updateMeta(_update: { pushResumedAt?: number; task?: string; codexHome?: string }): void { /* no-op */ }
   finalizeSummary(_state: HarnessState): void { /* no-op */ }
   close(): void { /* no-op */ }
   hasBootstrapped(): boolean { return true; }
@@ -91,6 +91,7 @@ export class FileSessionLogger implements SessionLogger {
         harnessVersion: partial.harnessVersion ?? this.options.harnessVersion ?? '0.1.0',
         resumedAt: partial.resumedAt ?? [],
         ...(partial.bootstrapOnResume ? { bootstrapOnResume: true } : {}),
+        ...(partial.codexHome !== undefined ? { codexHome: partial.codexHome } : {}),
       };
       fs.writeFileSync(this.metaPath, JSON.stringify(meta, null, 2));
       this.bootstrapped = true;
@@ -101,7 +102,7 @@ export class FileSessionLogger implements SessionLogger {
     }
   }
 
-  updateMeta(update: { pushResumedAt?: number; task?: string }): void {
+  updateMeta(update: { pushResumedAt?: number; task?: string; codexHome?: string }): void {
     if (this.disabled) return;
     try {
       let meta: SessionMeta;
@@ -123,10 +124,12 @@ export class FileSessionLogger implements SessionLogger {
           harnessVersion: this.options.harnessVersion ?? '0.1.0',
           resumedAt: [],
           bootstrapOnResume: true,
+          ...(update.codexHome !== undefined ? { codexHome: update.codexHome } : {}),
         };
       }
       if (update.pushResumedAt !== undefined) meta.resumedAt = [...(meta.resumedAt ?? []), update.pushResumedAt];
       if (update.task !== undefined && !meta.task) meta.task = update.task;
+      if (update.codexHome !== undefined) meta.codexHome = update.codexHome;
       fs.writeFileSync(this.metaPath, JSON.stringify(meta, null, 2));
       this.bootstrapped = true;
       this.cachedStartedAt = meta.startedAt;

--- a/src/phases/gate.ts
+++ b/src/phases/gate.ts
@@ -5,6 +5,7 @@ import { assembleGatePrompt, assembleGateResumePrompt } from '../context/assembl
 import { getPresetById } from '../config.js';
 import { runClaudeGate } from '../runners/claude.js';
 import { runCodexGate } from '../runners/codex.js';
+import { ensureCodexIsolation, CodexIsolationError } from '../runners/codex-isolation.js';
 import { writeState } from '../state.js';
 import { parseVerdict, buildGateResult } from './verdict.js';
 export { parseVerdict, buildGateResult } from './verdict.js';
@@ -264,13 +265,29 @@ export async function runGatePhase(
 
   const promptBytes = Buffer.byteLength(prompt, 'utf8');
 
-  // Step 6: Dispatch to runner
+  // Step 6: Dispatch to runner.
+  // For codex runner, bootstrap the per-run CODEX_HOME isolation (unless
+  // user opted out via --codex-no-isolate). CodexIsolationError aborts the
+  // gate hard (no retry) — surfacing as a gate error is preferable to
+  // silent fallback to the user's real ~/.codex (re-exposes BUG-C).
   const runner = preset.runner;
+  let codexHome: string | null = null;
+  if (runner === 'codex' && !state.codexNoIsolate) {
+    try {
+      codexHome = ensureCodexIsolation(runDir);
+    } catch (err) {
+      if (err instanceof CodexIsolationError) {
+        return { type: 'error', error: err.message, runner: 'codex' };
+      }
+      throw err;
+    }
+  }
   const runStartedAt = Date.now();
   const rawResult = runner === 'claude'
     ? await runClaudeGate(phase, preset, prompt, harnessDir, cwd)
     : await runCodexGate(
         phase, preset, prompt, harnessDir, cwd, resumeSessionId, buildFreshPromptOnFallback,
+        codexHome,
       );
   const durationMs = Date.now() - runStartedAt;
 

--- a/src/phases/interactive.ts
+++ b/src/phases/interactive.ts
@@ -212,8 +212,32 @@ export async function runInteractivePhase(
     return { ...result, attemptId };
   } else {
     const { runCodexInteractive } = await import('../runners/codex.js');
+    const { ensureCodexIsolation, CodexIsolationError } =
+      await import('../runners/codex-isolation.js');
+
+    // Bootstrap per-run CODEX_HOME isolation unless user opted out.
+    // Failure → phase fails with a sidecar error; runner never spawns.
+    let codexHome: string | null = null;
+    if (!updatedState.codexNoIsolate) {
+      try {
+        codexHome = ensureCodexIsolation(runDir);
+      } catch (err) {
+        if (err instanceof CodexIsolationError) {
+          const errorPath = path.join(runDir, `codex-${phase}-error.md`);
+          try {
+            fs.writeFileSync(
+              errorPath,
+              `# Codex Phase ${phase} Error\n\nCODEX_HOME isolation bootstrap failed.\n\n${err.message}\n`,
+            );
+          } catch { /* best-effort */ }
+          return { status: 'failed', attemptId };
+        }
+        throw err;
+      }
+    }
+
     const result = await runCodexInteractive(
-      phase, updatedState, preset, harnessDir, runDir, promptFile, cwd,
+      phase, updatedState, preset, harnessDir, runDir, promptFile, cwd, codexHome,
     );
     if (result.status === 'failed') {
       return { status: 'failed', attemptId };

--- a/src/runners/codex-isolation.ts
+++ b/src/runners/codex-isolation.ts
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+export class CodexIsolationError extends Error {
+  readonly code = 'CODEX_ISOLATION_FAILED';
+  constructor(message: string) {
+    super(message);
+    this.name = 'CodexIsolationError';
+  }
+}
+
+export function codexHomeFor(runDir: string): string {
+  return path.join(runDir, 'codex-home');
+}
+
+function resolveRealCodexHome(): string {
+  return process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+}
+
+export function ensureCodexIsolation(runDir: string): string {
+  const codexHome = codexHomeFor(runDir);
+
+  try {
+    fs.mkdirSync(codexHome, { recursive: true });
+  } catch (err) {
+    throw new CodexIsolationError(
+      `Failed to create isolated codex home at ${codexHome}: ${(err as Error).message}`,
+    );
+  }
+
+  const realHome = resolveRealCodexHome();
+  const authSrc = path.join(realHome, 'auth.json');
+  if (!fs.existsSync(authSrc)) {
+    throw new CodexIsolationError(
+      `Codex auth not found at ${authSrc}. Run 'codex login' first, ` +
+        `or pass --codex-no-isolate to bypass isolation (not recommended).`,
+    );
+  }
+
+  const authDst = path.join(codexHome, 'auth.json');
+  try { fs.unlinkSync(authDst); } catch { /* missing ok */ }
+  try {
+    fs.symlinkSync(authSrc, authDst);
+  } catch (err) {
+    throw new CodexIsolationError(
+      `Failed to symlink codex auth into ${authDst}: ${(err as Error).message}`,
+    );
+  }
+
+  return codexHome;
+}

--- a/src/runners/codex.ts
+++ b/src/runners/codex.ts
@@ -30,6 +30,7 @@ export async function runCodexInteractive(
   runDir: string,
   promptFile: string,
   cwd: string,
+  codexHome: string | null = null,
 ): Promise<CodexInteractiveResult> {
   // Prompt size check
   let promptSize: number;
@@ -63,6 +64,9 @@ export async function runCodexInteractive(
     stdio: ['pipe', 'pipe', 'pipe'],
     detached: true,
     cwd,
+    env: codexHome === null
+      ? process.env
+      : { ...process.env, CODEX_HOME: codexHome },
   });
 
   const childPid = child.pid!;
@@ -168,6 +172,7 @@ interface RawExecInput {
   harnessDir: string;
   cwd: string;
   phase: number;
+  codexHome: string | null;
 }
 
 /**
@@ -198,6 +203,9 @@ async function runCodexExecRaw(input: RawExecInput): Promise<RawExecResult> {
     stdio: ['pipe', 'pipe', 'pipe'],
     detached: true,
     cwd: input.cwd,
+    env: input.codexHome === null
+      ? process.env
+      : { ...process.env, CODEX_HOME: input.codexHome },
   });
   const childPid = child.pid!;
   const startTime = getProcessStartTime(childPid);
@@ -317,6 +325,7 @@ export async function runCodexGate(
   cwd: string,
   resumeSessionId?: string | null,
   buildFreshPromptOnFallback?: () => string | { error: string },
+  codexHome: string | null = null,
 ): Promise<GatePhaseResult> {
   const mode: 'fresh' | 'resume' = resumeSessionId ? 'resume' : 'fresh';
   const first = await runCodexExecRaw({
@@ -327,6 +336,7 @@ export async function runCodexGate(
     harnessDir,
     cwd,
     phase,
+    codexHome,
   });
 
   // §4.5 fallback: only for session_missing, and only when we were actually resuming.
@@ -361,6 +371,7 @@ export async function runCodexGate(
       harnessDir,
       cwd,
       phase,
+      codexHome,
     });
     return rawToResult(fresh, preset, resumeSessionId ?? null, /* resumeFallback */ true);
   }

--- a/src/state.ts
+++ b/src/state.ts
@@ -79,6 +79,7 @@ export function migrateState(raw: any): HarnessState {
     if (raw.phaseReopenFlags[key] === undefined) raw.phaseReopenFlags[key] = false;
   }
   if (raw.loggingEnabled === undefined) raw.loggingEnabled = false;
+  if (raw.codexNoIsolate === undefined) raw.codexNoIsolate = false;
   if (!raw.phaseReopenSource || typeof raw.phaseReopenSource !== 'object') {
     raw.phaseReopenSource = { '1': null, '3': null, '5': null };
   }
@@ -183,6 +184,7 @@ export function createInitialState(
   autoMode: boolean,
   loggingEnabled: boolean = false,
   flow: 'full' | 'light' = 'full',
+  codexNoIsolate: boolean = false,
 ): HarnessState {
   const phasePresets: Record<string, string> = {};
   for (const phase of REQUIRED_PHASE_KEYS) {
@@ -263,5 +265,6 @@ export function createInitialState(
     tmuxControlPane: '',
     loggingEnabled,
     phaseReopenSource: { '1': null, '3': null, '5': null },
+    codexNoIsolate,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,11 @@ export interface HarnessState {
   // Tracks which phase triggered a reopen (for phase_start.reopenFromGate)
   // keys "1","3","5" → number (triggering phase 2/4/6/7) or null
   phaseReopenSource: Record<string, number | null>;
+  // BUG-C root-cause fix (Issue #13): when true, codex subprocesses run with
+  // the user's inherited CODEX_HOME (no isolation). Default false — every
+  // codex-phase spawn runs inside <runDir>/codex-home/ with only auth.json
+  // symlinked in. Persisted so that `harness resume` honors the decision.
+  codexNoIsolate: boolean;
 }
 
 export interface LockData {
@@ -250,12 +255,13 @@ export interface SessionMeta {
   harnessVersion: string;
   resumedAt: number[];
   bootstrapOnResume?: boolean;
+  codexHome?: string;
 }
 
 export interface SessionLogger {
   logEvent(event: DistributiveOmit<LogEvent, 'v' | 'ts' | 'runId'>): void;
   writeMeta(partial: Partial<SessionMeta> & { task: string }): void;
-  updateMeta(update: { pushResumedAt?: number; task?: string }): void;
+  updateMeta(update: { pushResumedAt?: number; task?: string; codexHome?: string }): void;
   finalizeSummary(state: HarnessState): void;
   close(): void;
   hasBootstrapped(): boolean;

--- a/tests/commands/inner.test.ts
+++ b/tests/commands/inner.test.ts
@@ -258,6 +258,7 @@ describe('bootstrapSessionLogger', () => {
       tmuxSession: '', tmuxMode: 'dedicated', tmuxWindows: [],
       tmuxControlWindow: '', tmuxWorkspacePane: '', tmuxControlPane: '',
       loggingEnabled: true,
+      codexNoIsolate: false,
     };
     return { ...base, ...overrides };
   }
@@ -338,6 +339,7 @@ describe('buildConfigCancelHandler — lazy bootstrap', () => {
       tmuxSession: '', tmuxMode: 'dedicated', tmuxWindows: [],
       tmuxControlWindow: '', tmuxWorkspacePane: '', tmuxControlPane: '',
       loggingEnabled: true,
+      codexNoIsolate: false,
     };
     return { ...base, ...overrides };
   }
@@ -439,5 +441,149 @@ describe('buildConfigCancelHandler — lazy bootstrap', () => {
     expect(meta.resumedAt.length).toBeGreaterThan(0);
 
     fs.rmSync(harnessDir, { recursive: true, force: true });
+  });
+
+  it('fresh start persists meta.codexHome=<runDir>/codex-home (BUG-C Issue #13)', () => {
+    const harnessDir = tempHarnessDir();
+    const sessionsRoot = path.join(harnessDir, 'sessions');
+    const runDir = path.join(harnessDir, 'runs', 'cc-iso-1');
+    fs.mkdirSync(runDir, { recursive: true });
+
+    const logger = new FileSessionLogger('cc-iso-1', harnessDir, { sessionsRoot });
+    const state = buildState({ runId: 'cc-iso-1', codexNoIsolate: false });
+    const inputManager = { stop: vi.fn() } as any;
+
+    const handler = buildConfigCancelHandler({
+      state, runDir, harnessDir, runId: 'cc-iso-1', isResume: false, logger, inputManager,
+    });
+    try { handler(); } catch (e) { /* __EXIT_TRAP__ */ }
+
+    const repoKey = computeRepoKey(harnessDir);
+    const meta = JSON.parse(fs.readFileSync(path.join(sessionsRoot, repoKey, 'cc-iso-1', 'meta.json'), 'utf-8'));
+    expect(meta.codexHome).toBe(path.join(runDir, 'codex-home'));
+
+    fs.rmSync(harnessDir, { recursive: true, force: true });
+  });
+
+  it('codexNoIsolate=true: meta.codexHome is absent (no-isolate escape hatch)', () => {
+    const harnessDir = tempHarnessDir();
+    const sessionsRoot = path.join(harnessDir, 'sessions');
+    const runDir = path.join(harnessDir, 'runs', 'cc-iso-2');
+    fs.mkdirSync(runDir, { recursive: true });
+
+    const logger = new FileSessionLogger('cc-iso-2', harnessDir, { sessionsRoot });
+    const state = buildState({ runId: 'cc-iso-2', codexNoIsolate: true });
+    const inputManager = { stop: vi.fn() } as any;
+
+    const handler = buildConfigCancelHandler({
+      state, runDir, harnessDir, runId: 'cc-iso-2', isResume: false, logger, inputManager,
+    });
+    try { handler(); } catch (e) { /* __EXIT_TRAP__ */ }
+
+    const repoKey = computeRepoKey(harnessDir);
+    const meta = JSON.parse(fs.readFileSync(path.join(sessionsRoot, repoKey, 'cc-iso-2', 'meta.json'), 'utf-8'));
+    expect('codexHome' in meta).toBe(false);
+
+    fs.rmSync(harnessDir, { recursive: true, force: true });
+  });
+
+  it('resume branch preserves codexHome through lazy-bootstrap (regression guard for call site #5)', () => {
+    const harnessDir = tempHarnessDir();
+    const sessionsRoot = path.join(harnessDir, 'sessions');
+    const runDir = path.join(harnessDir, 'runs', 'cc-iso-3');
+    fs.mkdirSync(runDir, { recursive: true });
+
+    // Logger hasBootstrapped()=false but isResume=true → updateMeta lazy-creates meta
+    const logger = new FileSessionLogger('cc-iso-3', harnessDir, { sessionsRoot });
+    expect(logger.hasBootstrapped()).toBe(false);
+    const state = buildState({ runId: 'cc-iso-3', codexNoIsolate: false });
+    const inputManager = { stop: vi.fn() } as any;
+
+    const handler = buildConfigCancelHandler({
+      state, runDir, harnessDir, runId: 'cc-iso-3', isResume: true, logger, inputManager,
+    });
+    try { handler(); } catch (e) { /* __EXIT_TRAP__ */ }
+
+    const repoKey = computeRepoKey(harnessDir);
+    const meta = JSON.parse(fs.readFileSync(path.join(sessionsRoot, repoKey, 'cc-iso-3', 'meta.json'), 'utf-8'));
+    expect(meta.codexHome).toBe(path.join(runDir, 'codex-home'));
+    expect(meta.bootstrapOnResume).toBe(true);
+
+    fs.rmSync(harnessDir, { recursive: true, force: true });
+  });
+});
+
+describe('bootstrapSessionLogger — codexHome integration (Issue #13)', () => {
+  function tempHarnessDir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'boot-iso-'));
+  }
+  function buildState(overrides: Partial<HarnessState> = {}): HarnessState {
+    const base: HarnessState = {
+      runId: 'rx', flow: 'full', carryoverFeedback: null,
+      currentPhase: 1, status: 'in_progress', autoMode: false,
+      task: 'test task', baseCommit: '', implRetryBase: '', codexPath: null,
+      externalCommitsDetected: false,
+      artifacts: { spec: 's', plan: 'p', decisionLog: 'd', checklist: 'c', evalReport: 'e' },
+      phases: { '1': 'pending', '2': 'pending', '3': 'pending', '4': 'pending', '5': 'pending', '6': 'pending', '7': 'pending' },
+      gateRetries: { '2': 0, '4': 0, '7': 0 },
+      verifyRetries: 0,
+      pauseReason: null, specCommit: null, planCommit: null, implCommit: null,
+      evalCommit: null, verifiedAtHead: null, pausedAtHead: null, pendingAction: null,
+      phaseOpenedAt: { '1': null, '3': null, '5': null },
+      phaseAttemptId: { '1': null, '3': null, '5': null },
+      phasePresets: {}, phaseReopenFlags: { '1': false, '3': false, '5': false },
+      phaseReopenSource: { '1': null, '3': null, '5': null },
+      phaseCodexSessions: { '2': null, '4': null, '7': null },
+      lastWorkspacePid: null, lastWorkspacePidStartTime: null,
+      tmuxSession: '', tmuxMode: 'dedicated', tmuxWindows: [],
+      tmuxControlWindow: '', tmuxWorkspacePane: '', tmuxControlPane: '',
+      loggingEnabled: true,
+      codexNoIsolate: false,
+    };
+    return { ...base, ...overrides };
+  }
+
+  it('fresh start: meta.codexHome equals <harnessDir>/<runId>/codex-home', async () => {
+    const harnessDir = tempHarnessDir();
+    const sessionsRoot = path.join(harnessDir, 'sessions');
+    const state = buildState();
+    await bootstrapSessionLogger('rx1', harnessDir, state, false, { sessionsRoot });
+    const repoKey = computeRepoKey(harnessDir);
+    const meta = JSON.parse(fs.readFileSync(path.join(sessionsRoot, repoKey, 'rx1', 'meta.json'), 'utf-8'));
+    expect(meta.codexHome).toBe(path.join(harnessDir, 'rx1', 'codex-home'));
+  });
+
+  it('resume (meta missing → lazy-bootstrap): codexHome is persisted', async () => {
+    const harnessDir = tempHarnessDir();
+    const sessionsRoot = path.join(harnessDir, 'sessions');
+    const state = buildState();
+    // isResume=true on a run with no prior meta → updateMeta bootstraps it.
+    await bootstrapSessionLogger('rx2', harnessDir, state, true, { sessionsRoot });
+    const repoKey = computeRepoKey(harnessDir);
+    const meta = JSON.parse(fs.readFileSync(path.join(sessionsRoot, repoKey, 'rx2', 'meta.json'), 'utf-8'));
+    expect(meta.codexHome).toBe(path.join(harnessDir, 'rx2', 'codex-home'));
+    expect(meta.bootstrapOnResume).toBe(true);
+  });
+
+  it('idempotent re-entry (non-resume + meta exists): codexHome preserved', async () => {
+    const harnessDir = tempHarnessDir();
+    const sessionsRoot = path.join(harnessDir, 'sessions');
+    const state = buildState();
+    await bootstrapSessionLogger('rx3', harnessDir, state, false, { sessionsRoot });
+    // Second non-resume call → idempotent branch (L278 updateMeta)
+    await bootstrapSessionLogger('rx3', harnessDir, state, false, { sessionsRoot });
+    const repoKey = computeRepoKey(harnessDir);
+    const meta = JSON.parse(fs.readFileSync(path.join(sessionsRoot, repoKey, 'rx3', 'meta.json'), 'utf-8'));
+    expect(meta.codexHome).toBe(path.join(harnessDir, 'rx3', 'codex-home'));
+  });
+
+  it('codexNoIsolate=true: meta.codexHome absent on fresh start', async () => {
+    const harnessDir = tempHarnessDir();
+    const sessionsRoot = path.join(harnessDir, 'sessions');
+    const state = buildState({ codexNoIsolate: true });
+    await bootstrapSessionLogger('rx4', harnessDir, state, false, { sessionsRoot });
+    const repoKey = computeRepoKey(harnessDir);
+    const meta = JSON.parse(fs.readFileSync(path.join(sessionsRoot, repoKey, 'rx4', 'meta.json'), 'utf-8'));
+    expect('codexHome' in meta).toBe(false);
   });
 });

--- a/tests/commands/run.test.ts
+++ b/tests/commands/run.test.ts
@@ -196,4 +196,25 @@ describe('startCommand', () => {
     expect(state.flow).toBe('light');
     expect(state.autoMode).toBe(true);
   });
+
+  it('state.codexNoIsolate=true AND stderr warning when --codex-no-isolate passed', async () => {
+    await startCommand('test task', { root: repo.path, codexNoIsolate: true });
+    const harnessDir = join(repo.path, '.harness');
+    const runId = readFileSync(join(harnessDir, 'current-run'), 'utf-8').trim();
+    const state = JSON.parse(readFileSync(join(harnessDir, runId, 'state.json'), 'utf-8'));
+    expect(state.codexNoIsolate).toBe(true);
+    const stderr = stderrSpy.mock.calls.map((c: any) => c[0]).join('');
+    expect(stderr).toMatch(/CODEX_HOME isolation disabled/i);
+    expect(stderr).toMatch(/BUG-C risk/);
+  });
+
+  it('state.codexNoIsolate=false (default) and no warning when flag omitted', async () => {
+    await startCommand('test task', { root: repo.path });
+    const harnessDir = join(repo.path, '.harness');
+    const runId = readFileSync(join(harnessDir, 'current-run'), 'utf-8').trim();
+    const state = JSON.parse(readFileSync(join(harnessDir, runId, 'state.json'), 'utf-8'));
+    expect(state.codexNoIsolate).toBe(false);
+    const stderr = stderrSpy.mock.calls.map((c: any) => c[0]).join('');
+    expect(stderr).not.toMatch(/CODEX_HOME isolation disabled/i);
+  });
 });

--- a/tests/integration/logging.test.ts
+++ b/tests/integration/logging.test.ts
@@ -31,6 +31,7 @@ function buildState(overrides: Partial<HarnessState> = {}): HarnessState {
     tmuxSession: '', tmuxMode: 'dedicated', tmuxWindows: [],
     tmuxControlWindow: '', tmuxWorkspacePane: '', tmuxControlPane: '',
     loggingEnabled: true,
+    codexNoIsolate: false,
   };
   return { ...base, ...overrides };
 }

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -344,6 +344,51 @@ describe('FileSessionLogger.finalizeSummary', () => {
   });
 });
 
+describe('SessionMeta.codexHome integration (BUG-C isolation Issue #13)', () => {
+  it('writeMeta persists codexHome when provided', () => {
+    const harnessDir = makeTempHarnessDir();
+    const sessionsRoot = path.join(harnessDir, 'sessions-root');
+    const logger = new FileSessionLogger('run-iso-1', harnessDir, { sessionsRoot });
+    logger.writeMeta({ task: 't', codexHome: '/run/iso/codex-home' });
+    const repoKey = computeRepoKey(harnessDir);
+    const meta = JSON.parse(fs.readFileSync(path.join(sessionsRoot, repoKey, 'run-iso-1', 'meta.json'), 'utf-8'));
+    expect(meta.codexHome).toBe('/run/iso/codex-home');
+  });
+
+  it('writeMeta omits codexHome when undefined (no-isolate path)', () => {
+    const harnessDir = makeTempHarnessDir();
+    const sessionsRoot = path.join(harnessDir, 'sessions-root');
+    const logger = new FileSessionLogger('run-iso-2', harnessDir, { sessionsRoot });
+    logger.writeMeta({ task: 't' });
+    const repoKey = computeRepoKey(harnessDir);
+    const meta = JSON.parse(fs.readFileSync(path.join(sessionsRoot, repoKey, 'run-iso-2', 'meta.json'), 'utf-8'));
+    expect('codexHome' in meta).toBe(false);
+  });
+
+  it('updateMeta lazy-bootstrap (resume w/ missing meta.json) persists codexHome', () => {
+    const harnessDir = makeTempHarnessDir();
+    const sessionsRoot = path.join(harnessDir, 'sessions-root');
+    const logger = new FileSessionLogger('run-iso-3', harnessDir, { sessionsRoot });
+    logger.updateMeta({ pushResumedAt: Date.now(), task: 'recovered', codexHome: '/late/codex-home' });
+    const repoKey = computeRepoKey(harnessDir);
+    const meta = JSON.parse(fs.readFileSync(path.join(sessionsRoot, repoKey, 'run-iso-3', 'meta.json'), 'utf-8'));
+    expect(meta.codexHome).toBe('/late/codex-home');
+    expect(meta.bootstrapOnResume).toBe(true);
+  });
+
+  it('updateMeta merge branch (meta.json exists) writes codexHome', () => {
+    const harnessDir = makeTempHarnessDir();
+    const sessionsRoot = path.join(harnessDir, 'sessions-root');
+    const logger = new FileSessionLogger('run-iso-4', harnessDir, { sessionsRoot });
+    logger.writeMeta({ task: 'first' });
+    logger.updateMeta({ pushResumedAt: Date.now(), codexHome: '/merge/codex-home' });
+    const repoKey = computeRepoKey(harnessDir);
+    const meta = JSON.parse(fs.readFileSync(path.join(sessionsRoot, repoKey, 'run-iso-4', 'meta.json'), 'utf-8'));
+    expect(meta.codexHome).toBe('/merge/codex-home');
+    expect(meta.resumedAt.length).toBe(1);
+  });
+});
+
 describe('createSessionLogger factory', () => {
   it('returns NoopLogger when loggingEnabled=false', () => {
     const harnessDir = makeTempHarnessDir();

--- a/tests/phases/gate-resume.test.ts
+++ b/tests/phases/gate-resume.test.ts
@@ -42,6 +42,7 @@ function makeState(): HarnessState {
     tmuxControlWindow: '', tmuxWorkspacePane: '', tmuxControlPane: '',
     loggingEnabled: false,
     phaseReopenSource: { '1': null, '3': null, '5': null },
+    codexNoIsolate: false,
   };
 }
 

--- a/tests/phases/gate.test.ts
+++ b/tests/phases/gate.test.ts
@@ -9,6 +9,15 @@ import type { GateResult } from '../../src/types.js';
 vi.mock('../../src/runners/codex.js', () => ({ runCodexGate: vi.fn() }));
 vi.mock('../../src/runners/claude.js', () => ({ runClaudeGate: vi.fn() }));
 vi.mock('../../src/context/assembler.js', () => ({ assembleGatePrompt: vi.fn() }));
+vi.mock('../../src/runners/codex-isolation.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/runners/codex-isolation.js')>(
+    '../../src/runners/codex-isolation.js',
+  );
+  return {
+    ...actual,
+    ensureCodexIsolation: vi.fn((runDir: string) => `${runDir}/codex-home`),
+  };
+});
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -415,6 +424,89 @@ describe('runGatePhase — one-shot sidecar replay', () => {
     expect((result as any).recoveredFromSidecar).toBe(true);
     expect(result.type).toBe('verdict');
     void assembleGatePrompt; // silence unused import warning
+  });
+
+  it('ensureCodexIsolation(runDir) is called and codexHome threaded to runCodexGate (positive path, codexNoIsolate=false)', async () => {
+    const { assembleGatePrompt: mockAssembler } = await import('../../src/context/assembler.js');
+    const { runCodexGate: mockCodex } = await import('../../src/runners/codex.js');
+    const { ensureCodexIsolation } = await import('../../src/runners/codex-isolation.js');
+
+    vi.mocked(mockAssembler).mockReturnValue('mock prompt');
+    vi.mocked(mockCodex).mockResolvedValue({
+      type: 'verdict', verdict: 'APPROVE', comments: '', rawOutput: '## Verdict\nAPPROVE\n',
+    } as any);
+
+    const runDir = makeTmpDir();
+    const state = {
+      phasePresets: { '2': 'codex-high' },
+      gateRetries: { '2': 0 },
+      phaseCodexSessions: { '2': null, '4': null, '7': null },
+      currentPhase: 2,
+      codexNoIsolate: false,
+    } as any;
+
+    await runGatePhase(2, state, '/fake-harness', runDir, '/cwd');
+
+    expect(vi.mocked(ensureCodexIsolation)).toHaveBeenCalledWith(runDir);
+    // codexHome is the 8th positional arg of runCodexGate
+    const call = vi.mocked(mockCodex).mock.calls[0];
+    expect(call[7]).toBe(`${runDir}/codex-home`);
+  });
+
+  it('codexNoIsolate=true: ensureCodexIsolation NOT called; runCodexGate receives codexHome=null', async () => {
+    const { assembleGatePrompt: mockAssembler } = await import('../../src/context/assembler.js');
+    const { runCodexGate: mockCodex } = await import('../../src/runners/codex.js');
+    const { ensureCodexIsolation } = await import('../../src/runners/codex-isolation.js');
+
+    vi.mocked(mockAssembler).mockReturnValue('mock prompt');
+    vi.mocked(mockCodex).mockResolvedValue({
+      type: 'verdict', verdict: 'APPROVE', comments: '', rawOutput: '## Verdict\nAPPROVE\n',
+    } as any);
+
+    const runDir = makeTmpDir();
+    const state = {
+      phasePresets: { '2': 'codex-high' },
+      gateRetries: { '2': 0 },
+      phaseCodexSessions: { '2': null, '4': null, '7': null },
+      currentPhase: 2,
+      codexNoIsolate: true,
+    } as any;
+
+    await runGatePhase(2, state, '/fake-harness', runDir, '/cwd');
+
+    expect(vi.mocked(ensureCodexIsolation)).not.toHaveBeenCalled();
+    const call = vi.mocked(mockCodex).mock.calls[0];
+    expect(call[7]).toBeNull();
+  });
+
+  it('CodexIsolationError propagates as gate error (no retry — hard abort)', async () => {
+    const { assembleGatePrompt: mockAssembler } = await import('../../src/context/assembler.js');
+    const { runCodexGate: mockCodex } = await import('../../src/runners/codex.js');
+    const isolationMod = await import('../../src/runners/codex-isolation.js');
+    const { CodexIsolationError } = isolationMod;
+
+    vi.mocked(mockAssembler).mockReturnValue('mock prompt');
+    vi.mocked(isolationMod.ensureCodexIsolation).mockImplementationOnce(() => {
+      throw new CodexIsolationError('fake-fail: auth not found');
+    });
+
+    const runDir = makeTmpDir();
+    const state = {
+      phasePresets: { '2': 'codex-high' },
+      gateRetries: { '2': 0 },
+      phaseCodexSessions: { '2': null, '4': null, '7': null },
+      currentPhase: 2,
+      codexNoIsolate: false,
+    } as any;
+
+    const result = await runGatePhase(2, state, '/fake-harness', runDir, '/cwd');
+
+    expect(result.type).toBe('error');
+    if (result.type === 'error') {
+      expect(result.error).toMatch(/fake-fail.*auth not found/);
+    }
+    // Runner must NOT be called when isolation bootstrap fails.
+    expect(vi.mocked(mockCodex)).not.toHaveBeenCalled();
   });
 
   it('with flag.value=false: skips replay, runs runner (no infinite retry on REJECT sidecar)', async () => {

--- a/tests/phases/interactive.test.ts
+++ b/tests/phases/interactive.test.ts
@@ -13,6 +13,19 @@ import type { HarnessState } from '../../src/types.js';
 
 // ─── Module mocks for runInteractivePhase ordering test ─────────────────────
 
+vi.mock('../../src/runners/codex.js', () => ({
+  runCodexInteractive: vi.fn(async () => ({ status: 'completed', exitCode: 0 })),
+}));
+vi.mock('../../src/runners/codex-isolation.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/runners/codex-isolation.js')>(
+    '../../src/runners/codex-isolation.js',
+  );
+  return {
+    ...actual,
+    ensureCodexIsolation: vi.fn((runDir: string) => `${runDir}/codex-home`),
+  };
+});
+
 vi.mock('../../src/tmux.js', () => ({
   sendKeysToPane: vi.fn(),
   pollForPidFile: vi.fn().mockResolvedValue(12345),
@@ -633,5 +646,99 @@ describe('validatePhaseArtifacts — light + phase 1 extras (ADR-13)', () => {
     fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
     fs.writeFileSync(state.artifacts.checklist, '{"checks":[]}');
     expect(validatePhaseArtifacts(1, state, tmp)).toBe(false);
+  });
+});
+
+// ─── runInteractivePhase — codex branch + CODEX_HOME isolation (Issue #13) ───
+
+describe('runInteractivePhase — codex-interactive branch invokes codex isolation', () => {
+  it('calls ensureCodexIsolation(runDir) and threads codexHomeFor(runDir) into runCodexInteractive (positive path)', async () => {
+    const { runInteractivePhase } = await import('../../src/phases/interactive.js');
+    const { runCodexInteractive } = await import('../../src/runners/codex.js');
+    const { ensureCodexIsolation } = await import('../../src/runners/codex-isolation.js');
+
+    const runDir = makeTmpDir();
+    const harnessDir = makeTmpDir();
+    const repoDir = createTestRepo();
+
+    const state = makeState({
+      tmuxSession: 'test-session',
+      tmuxWorkspacePane: '%1',
+      tmuxControlPane: '%0',
+      phasePresets: { ...createInitialState('r', 't', 'b', false).phasePresets, '1': 'codex-high' },
+      codexNoIsolate: false,
+    });
+
+    vi.mocked(ensureCodexIsolation).mockClear();
+    vi.mocked(runCodexInteractive).mockClear();
+
+    await runInteractivePhase(1, state, harnessDir, runDir, repoDir, 'attempt-1');
+
+    expect(vi.mocked(ensureCodexIsolation)).toHaveBeenCalledWith(runDir);
+    // runCodexInteractive signature: phase, state, preset, harnessDir, runDir, promptFile, cwd, codexHome
+    const call = vi.mocked(runCodexInteractive).mock.calls[0];
+    expect(call).toBeDefined();
+    expect(call[7]).toBe(`${runDir}/codex-home`);
+  });
+
+  it('codexNoIsolate=true: ensureCodexIsolation NOT called; runCodexInteractive receives codexHome=null', async () => {
+    const { runInteractivePhase } = await import('../../src/phases/interactive.js');
+    const { runCodexInteractive } = await import('../../src/runners/codex.js');
+    const { ensureCodexIsolation } = await import('../../src/runners/codex-isolation.js');
+
+    const runDir = makeTmpDir();
+    const harnessDir = makeTmpDir();
+    const repoDir = createTestRepo();
+
+    const state = makeState({
+      tmuxSession: 'test-session',
+      tmuxWorkspacePane: '%1',
+      tmuxControlPane: '%0',
+      phasePresets: { ...createInitialState('r', 't', 'b', false).phasePresets, '1': 'codex-high' },
+      codexNoIsolate: true,
+    });
+
+    vi.mocked(ensureCodexIsolation).mockClear();
+    vi.mocked(runCodexInteractive).mockClear();
+
+    await runInteractivePhase(1, state, harnessDir, runDir, repoDir, 'attempt-2');
+
+    expect(vi.mocked(ensureCodexIsolation)).not.toHaveBeenCalled();
+    const call = vi.mocked(runCodexInteractive).mock.calls[0];
+    expect(call[7]).toBeNull();
+  });
+
+  it('CodexIsolationError → phase fails with isolation error sidecar (no runner call)', async () => {
+    const { runInteractivePhase } = await import('../../src/phases/interactive.js');
+    const { runCodexInteractive } = await import('../../src/runners/codex.js');
+    const isolationMod = await import('../../src/runners/codex-isolation.js');
+    const { CodexIsolationError } = isolationMod;
+
+    const runDir = makeTmpDir();
+    const harnessDir = makeTmpDir();
+    const repoDir = createTestRepo();
+
+    const state = makeState({
+      tmuxSession: 'test-session',
+      tmuxWorkspacePane: '%1',
+      tmuxControlPane: '%0',
+      phasePresets: { ...createInitialState('r', 't', 'b', false).phasePresets, '1': 'codex-high' },
+      codexNoIsolate: false,
+    });
+
+    vi.mocked(runCodexInteractive).mockClear();
+    vi.mocked(isolationMod.ensureCodexIsolation).mockImplementationOnce(() => {
+      throw new CodexIsolationError('fake: auth.json missing');
+    });
+
+    const result = await runInteractivePhase(1, state, harnessDir, runDir, repoDir, 'attempt-3');
+
+    expect(result.status).toBe('failed');
+    // Runner NEVER called once bootstrap fails.
+    expect(vi.mocked(runCodexInteractive)).not.toHaveBeenCalled();
+    // Isolation failure captured as a sidecar for post-mortem debugging.
+    const errorSidecar = path.join(runDir, 'codex-1-error.md');
+    expect(fs.existsSync(errorSidecar)).toBe(true);
+    expect(fs.readFileSync(errorSidecar, 'utf-8')).toMatch(/fake.*auth\.json missing/);
   });
 });

--- a/tests/runners/codex-isolation.test.ts
+++ b/tests/runners/codex-isolation.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  CodexIsolationError,
+  codexHomeFor,
+  ensureCodexIsolation,
+} from '../../src/runners/codex-isolation.js';
+
+let tmpRoot: string;
+let runDir: string;
+let fakeRealHome: string;
+let savedEnv: string | undefined;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-codex-iso-'));
+  runDir = path.join(tmpRoot, 'run');
+  fs.mkdirSync(runDir, { recursive: true });
+
+  fakeRealHome = path.join(tmpRoot, 'fake-codex-home');
+  fs.mkdirSync(fakeRealHome, { recursive: true });
+  fs.writeFileSync(path.join(fakeRealHome, 'auth.json'), '{"fake":"auth"}');
+
+  savedEnv = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = fakeRealHome;
+});
+
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.CODEX_HOME;
+  else process.env.CODEX_HOME = savedEnv;
+  try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+describe('codexHomeFor', () => {
+  it('returns <runDir>/codex-home/ without side effects', () => {
+    const p = codexHomeFor(runDir);
+    expect(p).toBe(path.join(runDir, 'codex-home'));
+    expect(fs.existsSync(p)).toBe(false);
+  });
+});
+
+describe('ensureCodexIsolation', () => {
+  it('creates <runDir>/codex-home/ with auth.json symlink', () => {
+    const returned = ensureCodexIsolation(runDir);
+    const codexHome = path.join(runDir, 'codex-home');
+    expect(returned).toBe(codexHome);
+    expect(fs.existsSync(codexHome)).toBe(true);
+
+    const authDst = path.join(codexHome, 'auth.json');
+    expect(fs.lstatSync(authDst).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(authDst)).toBe(path.join(fakeRealHome, 'auth.json'));
+
+    expect(fs.readFileSync(authDst, 'utf-8')).toBe('{"fake":"auth"}');
+  });
+
+  it('is idempotent on second call', () => {
+    const first = ensureCodexIsolation(runDir);
+    const authDst = path.join(first, 'auth.json');
+    const firstStat = fs.lstatSync(authDst);
+    // Re-run: must succeed and refresh the symlink without throwing.
+    const second = ensureCodexIsolation(runDir);
+    expect(second).toBe(first);
+    expect(fs.lstatSync(authDst).isSymbolicLink()).toBe(true);
+    expect(firstStat.isSymbolicLink()).toBe(true);
+  });
+
+  it('refreshes symlink when real auth.json rotates (unlink+symlink pattern)', () => {
+    ensureCodexIsolation(runDir);
+    const authDst = path.join(runDir, 'codex-home', 'auth.json');
+    // Simulate rotated real auth
+    fs.writeFileSync(path.join(fakeRealHome, 'auth.json'), '{"fake":"rotated"}');
+    ensureCodexIsolation(runDir);
+    expect(fs.readFileSync(authDst, 'utf-8')).toBe('{"fake":"rotated"}');
+  });
+
+  it('falls back to ~/.codex/auth.json when CODEX_HOME env var is unset', () => {
+    delete process.env.CODEX_HOME;
+    // With CODEX_HOME unset, the module resolves to os.homedir()/.codex which
+    // will likely not have the fake auth; assert the error message targets
+    // the homedir path to prove fallback logic is wired.
+    try {
+      ensureCodexIsolation(runDir);
+      // On the off-chance the tester has a real ~/.codex/auth.json, the call
+      // succeeds — that's still a valid fallback demonstration: the symlink
+      // target must be under os.homedir()/.codex.
+      const authDst = path.join(runDir, 'codex-home', 'auth.json');
+      const linkTarget = fs.readlinkSync(authDst);
+      expect(linkTarget).toBe(path.join(os.homedir(), '.codex', 'auth.json'));
+    } catch (err) {
+      expect(err).toBeInstanceOf(CodexIsolationError);
+      expect((err as Error).message).toContain(path.join(os.homedir(), '.codex', 'auth.json'));
+    }
+  });
+
+  it('throws CodexIsolationError when real auth.json is missing', () => {
+    fs.unlinkSync(path.join(fakeRealHome, 'auth.json'));
+    expect(() => ensureCodexIsolation(runDir)).toThrow(CodexIsolationError);
+    try {
+      ensureCodexIsolation(runDir);
+    } catch (err) {
+      expect((err as Error).message).toMatch(/auth.*not found/i);
+      expect((err as Error).message).toMatch(/codex login/i);
+    }
+  });
+
+  it('wraps mkdir EACCES/EEXIST-on-file failures as CodexIsolationError', () => {
+    // Create a FILE at codex-home path so mkdir(recursive:true) errors with EEXIST-not-dir
+    const codexHome = path.join(runDir, 'codex-home');
+    fs.writeFileSync(codexHome, 'not a dir');
+    expect(() => ensureCodexIsolation(runDir)).toThrow(CodexIsolationError);
+    try {
+      ensureCodexIsolation(runDir);
+    } catch (err) {
+      expect(err).toBeInstanceOf(CodexIsolationError);
+      expect((err as CodexIsolationError).code).toBe('CODEX_ISOLATION_FAILED');
+    }
+  });
+
+  it('bootstraps ONLY auth.json — absent: AGENTS.md, config.toml, agents/, prompts/, skills/, rules/, memories/, hooks.json', () => {
+    // Pre-populate the REAL codex home with everything a user might have
+    fs.writeFileSync(path.join(fakeRealHome, 'AGENTS.md'), '# user conventions\n');
+    fs.writeFileSync(path.join(fakeRealHome, 'config.toml'), '[profile]\nname="me"\n');
+    fs.writeFileSync(path.join(fakeRealHome, 'hooks.json'), '{}');
+    for (const d of ['agents', 'prompts', 'skills', 'rules', 'memories']) {
+      fs.mkdirSync(path.join(fakeRealHome, d));
+      fs.writeFileSync(path.join(fakeRealHome, d, 'leak.md'), 'do not leak');
+    }
+
+    const codexHome = ensureCodexIsolation(runDir);
+
+    expect(fs.existsSync(path.join(codexHome, 'auth.json'))).toBe(true);
+    expect(fs.existsSync(path.join(codexHome, 'AGENTS.md'))).toBe(false);
+    expect(fs.existsSync(path.join(codexHome, 'config.toml'))).toBe(false);
+    expect(fs.existsSync(path.join(codexHome, 'hooks.json'))).toBe(false);
+    for (const d of ['agents', 'prompts', 'skills', 'rules', 'memories']) {
+      expect(fs.existsSync(path.join(codexHome, d))).toBe(false);
+    }
+
+    const entries = fs.readdirSync(codexHome);
+    expect(entries).toEqual(['auth.json']);
+  });
+});

--- a/tests/runners/codex-resume.test.ts
+++ b/tests/runners/codex-resume.test.ts
@@ -173,6 +173,30 @@ describe('runCodexGate — resume path', () => {
   });
 });
 
+describe('runCodexGate — CODEX_HOME on resume-fallback (BUG-C isolation §7.2)', () => {
+  it('BOTH spawns (session_missing → fresh fallback) carry CODEX_HOME=<provided>', async () => {
+    const cp = await import('child_process');
+    (cp.spawn as any)
+      .mockImplementationOnce(() =>
+        makeMockChild({ stderr: 'error: session not found\n', exitCode: 1 }),
+      )
+      .mockImplementationOnce(() =>
+        makeMockChild({ stdout: SUCCESS_STDOUT.replace('abc-123-def', 'fallback-sid') }),
+      );
+    const result = await runCodexGate(
+      2, preset, 'resume prompt', '/tmp/h', '/tmp/c', 'dead-sid',
+      () => 'fresh prompt body',
+      '/iso/run',
+    );
+    expect(result.type).toBe('verdict');
+    // Both calls MUST carry CODEX_HOME — a bypass on either path re-exposes BUG-C.
+    const env1 = (cp.spawn as any).mock.calls[0][2].env;
+    const env2 = (cp.spawn as any).mock.calls[1][2].env;
+    expect(env1.CODEX_HOME).toBe('/iso/run');
+    expect(env2.CODEX_HOME).toBe('/iso/run');
+  });
+});
+
 describe('runCodexGate — metadata captured on error paths', () => {
   it('captures sessionId and tokensTotal on nonzero exit', async () => {
     const cp = await import('child_process');

--- a/tests/runners/codex.test.ts
+++ b/tests/runners/codex.test.ts
@@ -1,9 +1,135 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { runCodexGate, runCodexInteractive } from '../../src/runners/codex.js';
+import { type ModelPreset } from '../../src/config.js';
+import type { HarnessState } from '../../src/types.js';
 
-describe('Codex Runner', () => {
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return { ...actual, spawn: vi.fn(), execSync: vi.fn(() => '/usr/local/bin/codex') };
+});
+vi.mock('../../src/lock.js', () => ({
+  updateLockChild: vi.fn(),
+  clearLockChild: vi.fn(),
+}));
+vi.mock('../../src/process.js', () => ({
+  getProcessStartTime: vi.fn(() => 0),
+  killProcessGroup: vi.fn(async () => {}),
+}));
+vi.mock('../../src/state.js', () => ({
+  writeState: vi.fn(),
+}));
+
+function makeMockChild(opts: {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  delayMs?: number;
+}): any {
+  const emitter: any = new EventEmitter();
+  emitter.stdin = { write: vi.fn(), end: vi.fn() };
+  emitter.stdout = new EventEmitter();
+  emitter.stderr = new EventEmitter();
+  emitter.pid = 2222;
+  setTimeout(() => {
+    if (opts.stdout) emitter.stdout.emit('data', Buffer.from(opts.stdout));
+    if (opts.stderr) emitter.stderr.emit('data', Buffer.from(opts.stderr));
+    emitter.emit('close', opts.exitCode ?? 0);
+  }, opts.delayMs ?? 5);
+  return emitter;
+}
+
+const preset: ModelPreset = {
+  id: 'codex-high',
+  runner: 'codex',
+  model: 'gpt-5.4',
+  effort: 'high',
+  label: 'codex-high',
+};
+
+const SUCCESS_STDOUT =
+  'session id: sid-xyz\n## Verdict\nAPPROVE\n\n## Comments\n\n## Summary\nok.\ntokens used\n100\n';
+
+afterEach(() => { vi.clearAllMocks(); });
+
+describe('Codex Runner — module exports', () => {
   it('module exports runCodexInteractive and runCodexGate', async () => {
     const mod = await import('../../src/runners/codex.js');
     expect(typeof mod.runCodexInteractive).toBe('function');
     expect(typeof mod.runCodexGate).toBe('function');
+  });
+});
+
+describe('runCodexGate — CODEX_HOME env plumbing (BUG-C isolation)', () => {
+  it('spawn env.CODEX_HOME matches provided path (fresh mode)', async () => {
+    const cp = await import('child_process');
+    (cp.spawn as any).mockImplementationOnce(() => makeMockChild({ stdout: SUCCESS_STDOUT }));
+    await runCodexGate(2, preset, 'p', '/tmp/h', '/tmp/c', undefined, undefined, '/iso/here');
+    const spawnOpts = (cp.spawn as any).mock.calls[0][2];
+    expect(spawnOpts.env.CODEX_HOME).toBe('/iso/here');
+  });
+
+  it('spawn env.CODEX_HOME matches provided path (resume mode)', async () => {
+    const cp = await import('child_process');
+    (cp.spawn as any).mockImplementationOnce(() =>
+      makeMockChild({ stdout: SUCCESS_STDOUT.replace('sid-xyz', 'prev-sid') })
+    );
+    await runCodexGate(2, preset, 'p', '/tmp/h', '/tmp/c', 'prev-sid', undefined, '/iso/resume');
+    const spawnOpts = (cp.spawn as any).mock.calls[0][2];
+    expect(spawnOpts.env.CODEX_HOME).toBe('/iso/resume');
+  });
+
+  it('spawn env.CODEX_HOME omitted when codexHome is null (escape hatch)', async () => {
+    const cp = await import('child_process');
+    const originalEnvHad = 'CODEX_HOME' in process.env;
+    const originalValue = process.env.CODEX_HOME;
+    delete process.env.CODEX_HOME;
+    try {
+      (cp.spawn as any).mockImplementationOnce(() => makeMockChild({ stdout: SUCCESS_STDOUT }));
+      await runCodexGate(2, preset, 'p', '/tmp/h', '/tmp/c', undefined, undefined, null);
+      const spawnOpts = (cp.spawn as any).mock.calls[0][2];
+      expect(spawnOpts.env.CODEX_HOME).toBeUndefined();
+    } finally {
+      if (originalEnvHad) process.env.CODEX_HOME = originalValue;
+    }
+  });
+
+  it('spawn env.CODEX_HOME omitted when codexHome param omitted (default null — backward compat)', async () => {
+    const cp = await import('child_process');
+    const originalEnvHad = 'CODEX_HOME' in process.env;
+    const originalValue = process.env.CODEX_HOME;
+    delete process.env.CODEX_HOME;
+    try {
+      (cp.spawn as any).mockImplementationOnce(() => makeMockChild({ stdout: SUCCESS_STDOUT }));
+      await runCodexGate(2, preset, 'p', '/tmp/h', '/tmp/c');
+      const spawnOpts = (cp.spawn as any).mock.calls[0][2];
+      expect(spawnOpts.env.CODEX_HOME).toBeUndefined();
+    } finally {
+      if (originalEnvHad) process.env.CODEX_HOME = originalValue;
+    }
+  });
+});
+
+describe('runCodexInteractive — CODEX_HOME env plumbing', () => {
+  it('spawn env.CODEX_HOME matches provided path', async () => {
+    const cp = await import('child_process');
+    (cp.spawn as any).mockImplementationOnce(() => makeMockChild({ stdout: 'ok\n' }));
+
+    const state = { lastWorkspacePid: null, lastWorkspacePidStartTime: null } as unknown as HarnessState;
+
+    const fs = await import('fs');
+    const os = await import('os');
+    const path = await import('path');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-iso-ci-'));
+    const promptPath = path.join(tmp, 'p.txt');
+    fs.writeFileSync(promptPath, 'hi');
+    const runDir = path.join(tmp, 'run');
+    fs.mkdirSync(runDir);
+
+    await runCodexInteractive(1, state, preset, '/tmp/h', runDir, promptPath, '/tmp/c', '/iso/interactive');
+    const spawnOpts = (cp.spawn as any).mock.calls[0][2];
+    expect(spawnOpts.env.CODEX_HOME).toBe('/iso/interactive');
+
+    fs.rmSync(tmp, { recursive: true, force: true });
   });
 });

--- a/tests/state-invalidation.test.ts
+++ b/tests/state-invalidation.test.ts
@@ -34,6 +34,7 @@ function makeState(): HarnessState {
     tmuxControlWindow: '', tmuxWorkspacePane: '', tmuxControlPane: '',
     loggingEnabled: false,
     phaseReopenSource: { '1': null, '3': null, '5': null },
+    codexNoIsolate: false,
   };
 }
 

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -44,6 +44,20 @@ describe('phaseCodexSessions (spec §4.1 / §5)', () => {
     expect(migrated.phaseCodexSessions).toEqual({ '2': null, '4': null, '7': null });
   });
 
+  it('migrateState defaults codexNoIsolate=false when missing (BUG-C isolation)', () => {
+    const legacy = JSON.parse(JSON.stringify(makeState()));
+    delete legacy.codexNoIsolate;
+    const migrated = migrateState(legacy);
+    expect(migrated.codexNoIsolate).toBe(false);
+  });
+
+  it('migrateState preserves existing codexNoIsolate=true (user-opted escape hatch)', () => {
+    const legacy = JSON.parse(JSON.stringify(makeState()));
+    legacy.codexNoIsolate = true;
+    const migrated = migrateState(legacy);
+    expect(migrated.codexNoIsolate).toBe(true);
+  });
+
   it('migrateState discards malformed GateSessionInfo entries', () => {
     const base = makeState();
     (base as any).phaseCodexSessions = {


### PR DESCRIPTION
## Summary

Root-cause fix for BUG-C (Issue #13): codex gate subprocesses inherit the parent `HOME`, let codex load the user's personal `~/.codex/AGENTS.md`, and apply those conventions to the external project under review. PR #11 mitigated via the `REVIEWER_CONTRACT` scope-rules stanza — effective against a cooperative reviewer, brittle in general. This change makes the personal customizations literally unreachable by the subprocess.

**Design**: override `CODEX_HOME` (not `HOME`) to a per-run dir at `<runDir>/codex-home/` that contains only `auth.json` as a symlink to the real codex home. `config.toml`, `AGENTS.md`, `agents/`, `prompts/`, `skills/`, `rules/`, `memories/`, `hooks.json` are all absent by design. Escape hatch: `--codex-no-isolate` persists to `state.codexNoIsolate` and is honored on resume.

- **Spec / plan / eval**: `docs/specs/2026-04-18-codex-home-isolation-design.md` (combined doc per compressed /harness flow)
- **Defense in depth**: PR #11 `REVIEWER_CONTRACT_BASE` scope-rules stanza retained — isolation is primary, stanza survives any future bypass.
- **Out of scope**: Claude runner HOME isolation (separate issue); real `~/.codex/` contents never touched.

## Changes

| Area | File | Change |
|---|---|---|
| New module | `src/runners/codex-isolation.ts` | `ensureCodexIsolation(runDir)` + `CodexIsolationError`. Idempotent. All FS failures wrapped. |
| Runner | `src/runners/codex.ts` | `codexHome: string \| null` param on `runCodexGate` + `runCodexInteractive` + internal `runCodexExecRaw`. Threaded into spawn `env`. |
| Phases | `src/phases/gate.ts`, `src/phases/interactive.ts` | Bootstrap isolation before spawn unless `state.codexNoIsolate`. `CodexIsolationError` → hard abort (gate_error / sidecar-write + phase fail). |
| State | `src/types.ts`, `src/state.ts` | `HarnessState.codexNoIsolate: boolean` + migration default=false. `SessionMeta.codexHome?: string`. |
| CLI | `bin/harness.ts`, `src/commands/start.ts` | `--codex-no-isolate` on `start` + `run`. Stderr warning when engaged. |
| Logger | `src/logger.ts` | `writeMeta` + `updateMeta` handle `codexHome` on literal and lazy-bootstrap branches. |
| Integration | `src/commands/inner.ts` | Five meta call sites thread `codexHome` (`bootstrapSessionLogger` fresh/resume/idempotent + `buildConfigCancelHandler` fresh/resume). |

## Test plan

- [x] `pnpm tsc --noEmit` → exit 0
- [x] `pnpm vitest run` → **566 passed / 1 skipped** (baseline was 531 passed; +35 new tests)
- [x] `pnpm build` → exit 0
- [x] Unit: isolation module (8 tests) — idempotent mkdir, symlink target, missing-auth wrapping, EACCES wrapping, rotation refresh, absence-check for all 8 customization paths, CODEX_HOME env.unset fallback.
- [x] Runner env (5 tests): CODEX_HOME plumbing for fresh / resume / resume-fallback (**both** spawns carry env) / null escape hatch / default-null back-compat.
- [x] Phase integration: gate + interactive positive path (isolation called + codexHome threaded), no-isolate path (not called, codexHome=null), `CodexIsolationError` propagation (gate_error + interactive phase fail + error sidecar, runner NEVER called).
- [x] Logger: writeMeta/updateMeta persist codexHome; meta omits key when `codexNoIsolate=true`. All 5 call sites covered (fresh/resume-lazy-bootstrap/idempotent-re-entry/config-cancel-fresh/config-cancel-resume).
- [x] State: `migrateState` defaults `codexNoIsolate=false`; preserves user-set `true`.
- [x] CLI: `--codex-no-isolate` → `state.codexNoIsolate=true` + stderr warning visible; absence → `false` + no warning.

## Manual smoke (evidence)

Live codex run against the real codex binary, with `CODEX_HOME` pointed at an isolated dir:

```
[smoke2] codexHome: /tmp/harness-smoke-…/run/codex-home
[smoke2] auth.json symlink → /Users/daniel/.codex/auth.json
[smoke2] codex-home contents: [ 'auth.json' ]
[smoke2] absent AGENTS.md|config.toml|agents|prompts|skills|rules|memories|hooks.json: all true
[smoke2] idempotent re-run ok
[smoke2] codex exit: 0
[smoke2] stdout last 300: "codex\nSMOKE_OK\ntokens used\n7,694"
[smoke2] isolated session rollouts: 1
    .../codex-home/sessions/2026/04/18/rollout-2026-04-18T22-20-44-*.jsonl
[smoke2] rollout grep for 'Lore Commit Protocol' | 'AUTONOMY DIRECTIVE' | 'oh-my-codex' |
         'omx:generated' | 'Multi-Agent Orchestration': **0 matches across all keywords**
```

Interpretation:
- `auth.json` symlink works end-to-end (codex replied `SMOKE_OK`).
- Codex respects `CODEX_HOME` (session rollout written under isolated dir, not real `~/.codex/sessions/`).
- `~/.codex/AGENTS.md` did **not** leak: all five personal-convention keywords unique to my `AGENTS.md` return 0 hits in the rollout.

Evidence artifacts preserved at:
- `/tmp/codex-iso-smoke-1776518448508/` (full isolated tree)
- `/tmp/codex-iso-evidence-1776518448508.jsonl` (rollout file)

`--codex-no-isolate` surface is covered by unit tests only (full harness tmux run not re-executed); tests verify `state.codexNoIsolate=true` + stderr warning + runner `env.CODEX_HOME` omitted + `ensureCodexIsolation` never called on the isolated path.

## Process notes

Plan-gate cycle: **4 Codex rejects → APPROVE on submission #5**.

| Round | Concerns raised | Resolution |
|---|---|---|
| R1 | fixture sweep naming, logger integration generalized to "logger.ts", shallow eval checklist, TDD sequencing, warning-line evidence | Resolved (commit `fd567b4`) |
| R2 | `writeMeta` is fixed-literal (not partial-spread), two inner.ts call sites, FS error wrap scope, lazy-bootstrap branch coverage | Resolved (commit `020bd20`) |
| R3 | §4.4 vs §7.3 bootstrap-timing drift, config-cancel checklist, resume-fallback env assertion, `config.toml` explicit absence | Resolved (commit `9ebc839`) |
| R4 | `updateMeta` callers (5 sites, not 2), interactive positive-path test, absence-list full (agents/prompts/skills/rules/memories/hooks.json) | Resolved (commits `fde96d6` + `12c851f`) |
| R5 | (APPROVE) only P3: §5 Modify list should list `src/commands/inner.ts` | **Deferred** per P1-only policy |

## Related

- Issue #13 (open-issues row 13 in `CLAUDE.md`)
- PR #11 (BUG-C prompt-level mitigation — defense-in-depth layer, retained)