### PR TITLE
feat(config): relax Phase 1 default preset opus-max xHigh → opus-high

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ Session meta: `~/.harness/sessions/<hash>/<runId>/{events.jsonl, meta.json, summ
 
 | # | 요지 | 심각도 | 상태 |
 |---|---|---|---|
-| 8 | Phase 1 default preset 과중 (`opus-max` xHigh) — 간단한 CLI에 4분+ 사용 | P1 | **미처리** (PR #11 §5 deferred). `--simple`/`--complex` 힌트 또는 `opus-high` 기본값 검토 필요. |
+| 8 | Phase 1 default preset 과중 — 간단한 CLI 한 번에 5.4M 토큰 (2026-04-18 dogfood-full 재측정) | P1 | **부분 해결**: PHASE_DEFAULTS[1]·LIGHT_PHASE_DEFAULTS[1]을 `opus-high`로 완화. `opus-max` preset 자체는 MODEL_PRESETS에 유지되어 수동 선택 가능. `--heavy` CLI flag / 자동 난이도 힌트는 별도 follow-up. |
 | 9 | `printAdvisorReminder` orphan text (control-pane tip이 Claude로 전달 안 됨) | P2 UX | PR #11 `HARNESS FLOW CONSTRAINT`가 `advisor()` 금지로 실질 무효화. **제거 PR 진행 중** (`fix/remove-advisor-reminder`, Group C). |
 | 13 | Codex `HOME` 격리 미도입 — BUG-C alternative fix | P3 | PR #11 `REVIEWER_CONTRACT` scope-rules로 일단 해결. **영구 격리 PR 진행 중** (`feat/codex-home-isolation`, Group D). |
 

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,0 +1,129 @@
+# Dogfood follow-ups — 2026-04-18
+
+Observations captured by the dogfood-full session (see
+`observations.md` on branch `dogfood/full-flow`, commit `e9caee1`) that
+are **not** addressed by the Phase 1 preset-relaxation PR.
+
+Severity key: P0 = blocking / data loss · P1 = big throughput or quality
+hit · P2 = UX or audit gap · P3 = nitpick.
+
+## Open — Priority 1
+
+### P1.1  Phase 5 "failed" on pytest-left-behind artifacts, no auto-recovery
+
+Root cause:
+- `validatePhaseArtifacts` (src/phases/interactive.ts:148) rejects any
+  non-empty `git status --porcelain` at phase-5 end.
+- Wrapper skill `src/context/skills/harness-phase-5-implement.md` does
+  not require Claude to add language-standard `.gitignore` entries in
+  the scaffolding commit, or to commit every tracked-file edit before
+  sentinel.
+- `runPhaseLoop` (src/phases/runner.ts:196) returns on
+  `phases[N] === 'failed'` with no retry, no resume hint, no diagnosis.
+
+Proposed change (one PR):
+1. Wrapper-skill Process step 0 — "If scaffolding a new language
+   project, add that language's canonical `.gitignore` patterns
+   (`__pycache__/`, `.pytest_cache/`, `.venv/`, `node_modules/`, …) in
+   the scaffolding commit. Before sentinel, run
+   `git status --porcelain` and commit any tracked-file edits with a
+   follow-up `chore: gitignore` commit; stage nothing else."
+2. On validation failure, print blocking-path list + actionable resume
+   command (`hc-full resume` / `hc-full jump 5`).
+3. Optional: allow `validatePhaseArtifacts` to auto-add strictly-ignorable
+   paths (`**/__pycache__/**`, `**/*.pyc`, `node_modules/`, etc.) to
+   `.gitignore`, commit as `chore: auto-ignore`, re-validate once.
+   Behind a `--strict-tree` flag if you want the old behavior back.
+
+Evidence: run at
+`~/.harness/sessions/0f7dd70d1f23/2026-04-18-build-a-terminal-based/`,
+phase 5 failed at 1411.9s / 6.4M Claude tokens; actual impl landed in git
+and `pytest tests/` passes 48/48.
+
+### P1.2  Wrapper-skill self-audit before sentinel (gate-loop efficiency)
+
+Root cause: every gate reject on the dogfood run was legitimate, and in
+most cases re-caught internal contradictions that the implementer itself
+*could* have detected by grepping the artifact it just wrote against the
+spec's own success-criteria section. E.g., gate 4 rejected because the
+plan had `except Exception` in `commands.py` — the spec's own §10
+success-criterion 8 said to grep for that string. The implementer never
+ran its own acceptance grep.
+
+Proposed change:
+- `harness-phase-{1,3,5}-*.md` Process, second-to-last step:
+  "Before writing the sentinel, re-read the artifact you just authored
+  and grep it against every machine-checkable invariant in the spec
+  (or plan) you're implementing. If any hit, fix in this pass — do not
+  hand to the gate. This step is load-bearing: each gate round costs
+  ~40× a local grep."
+
+Expected impact: from this run's data, 2 of 5 gate rejects would have
+been caught pre-sentinel.
+
+### P1.3  P1-only policy not surfaced to the runtime implementer
+
+Repo `CLAUDE.md` and the user's global memory both say "gate에서 P1만
+처리하고 P2는 plan 내 TODO로 기록." But the wrapper-skill prompt only
+says "반드시 반영" for feedback — which Claude takes as "address all
+P1 + P2 comments, blocking." On the dogfood run, gate-2 round 2 said
+"addressing all four issues" (2 P1 + 2 P2); the P2-driven spec
+restructuring exposed a new P1 inconsistency.
+
+Proposed change:
+- `harness-phase-{1,3}-*.md` retry Process step: "Address every P1
+  comment. For each P2: fix inline only if it's a ≤2-line edit; else
+  note in the artifact's `## Deferred` section for follow-up. Do not let
+  P2 drive structural changes — they aren't blocking this gate."
+
+### P1.4  Plan size explosion for trivial tasks
+
+Final plan for a ~500 LOC todo CLI was 1584 lines. Phase 3 with
+`sonnet-high` + `superpowers:writing-plans` default produces the same
+depth regardless of task complexity.
+
+Proposed change:
+- Phase 1 spec adds a `## Complexity` one-liner (Small / Medium / Large).
+- `src/context/assembler.ts` reads that line and injects a corresponding
+  directive into the Phase 3 prompt:
+  - Small → ≤3 tasks, no per-function pseudocode.
+  - Medium → current behavior.
+  - Large → same as Medium today.
+- `harness-phase-3-plan.md` Process adds: "Respect the complexity
+  signal from the spec; don't over-engineer a Small task into a detailed
+  plan."
+
+## Open — Priority 2
+
+### P2.1  Control-pane footer has no running elapsed / token counter
+
+Today the user sees phase ticks only. On the dogfood run, 60 min / 9M
+tokens were spent before anyone noticed. Propose: tail `events.jsonl`
+from the control pane and render a footer line
+`P5 attempt 1 · 23m elapsed · 9.1M tokens so far`.
+
+### P2.2  Post-APPROVE gate feedback file not cleaned up
+
+After gate N approves, `.harness/<runId>/gate-N-feedback.md` still
+contains the last *reject* feedback. Post-hoc "what did the approving
+round actually say?" requires a missing raw file. Low severity.
+
+### P2.3  Folder-trust first-run discoverability
+
+README L248 has the hint. But on first run, the control pane sits at
+"Phase 1 ▶" silently while Claude hangs on the dialog. Propose a
+watchdog: if `phase_start` fired >30s ago without activity, control
+pane prints "No output yet? Check the Claude window (`C-b 1`) — may be
+waiting on folder-trust."
+
+## Context / provenance
+
+- All observations were produced by a single dogfood-full run on
+  `~/Desktop/projects/harness/experimental-todo-full`, captured in
+  `~/.harness/sessions/0f7dd70d1f23/2026-04-18-build-a-terminal-based/`.
+- Shipped fixes #7/#9/#10/#11/#12/#13 all verified in-run; no regression
+  hits.
+- Round 2 was **not** executed — Round 1 alone consumed the budget.
+  Re-validating these follow-ups will want a Round 2 run after PR #22
+  (preset-id rename) and this PR both land, to measure the cost delta
+  without a naming-churn variable in the mix.

--- a/docs/HOW-IT-WORKS.ko.md
+++ b/docs/HOW-IT-WORKS.ko.md
@@ -52,7 +52,7 @@ P1 design(=brainstorm+plan) → [P2/P3/P4 skipped] → P5 impl → P6 verify →
 - **skipped phases**: `phases['2'|'3'|'4']`가 신규 `'skipped'` status로 초기화되고 `runPhaseLoop`가 핸들러 호출 없이 건너뜁니다. `renderControlPanel`은 em-dash 아이콘과 `(skipped)` 라벨로 표시합니다.
 - **Phase 1 산출물**: `docs/specs/<runId>-design.md` 하나의 결합 문서에 필수 `## Implementation Plan` 섹션을 포함합니다. `checklist.json`은 `scripts/harness-verify.sh`가 파싱해야 하므로 별도 파일로 유지.
 - **Phase 7 REJECT**: Phase 1으로 되돌립니다(Phase 5가 아니라 결합 문서 자체를 다시 쓰기 위함). `state.carryoverFeedback`이 Phase 1 완료 시 `pendingAction`이 비워져도 살아남아 Phase 5 재진입 시 소비됩니다.
-- **기본 preset**: P1 = `opus-max`, P5 = `sonnet-high`, P7 = `codex-high` (P2/P3/P4만 빠진 풀 플로우와 동일).
+- **기본 preset**: P1 = `opus-high`, P5 = `sonnet-high`, P7 = `codex-high` (P2/P3/P4만 빠진 풀 플로우와 동일).
 - **활성화**: `harness start --light "태스크"` (또는 `harness run --light …`). `--light`는 `--auto`와 직교.
 - **풀 플로우가 더 나은 경우**: 마이그레이션/보안/계약 변경처럼 pre-impl 독립 리뷰 가치가 큰 작업.
 

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -53,7 +53,7 @@ P1 design(=brainstorm+plan) → [P2/P3/P4 skipped] → P5 impl → P6 verify →
 - **skipped phases**: `phases['2'|'3'|'4']` initialize to the new `'skipped'` `PhaseStatus`. `runPhaseLoop` short-circuits past them; `renderControlPanel` shows them with an em-dash glyph and `(skipped)` label.
 - **Phase 1 output**: single combined doc at `docs/specs/<runId>-design.md` containing a mandatory `## Implementation Plan` section. `checklist.json` stays a separate file so `scripts/harness-verify.sh` still parses it.
 - **Phase 7 REJECT**: routed back to Phase 1 (not Phase 5 — the combined doc is re-authored). `state.carryoverFeedback` survives the Phase 1 completion that clears `pendingAction` and is consumed by Phase 5 on re-entry.
-- **Defaults**: P1 = `opus-max`, P5 = `sonnet-high`, P7 = `codex-high` (same presets as full flow, minus P2/P3/P4).
+- **Defaults**: P1 = `opus-high`, P5 = `sonnet-high`, P7 = `codex-high` (same presets as full flow, minus P2/P3/P4).
 - **Activation**: `harness start --light "task"` (or `harness run --light …`). `--light` composes with `--auto`.
 - **When full flow is still right**: migration/security/contract work, or any task where an independent pre-impl review adds real value.
 
@@ -241,7 +241,7 @@ Focus review on changes within the harness ranges above.
 
 Each interactive phase (1, 3, 5) and each gate phase (2, 4, 7) has a configurable model preset. Phase 6 (automated shell verification) has no AI model. At the start of every `harness run` or `harness resume`, the CLI presents a model-selection UI (via `promptModelConfig()` in `src/ui.ts`) that lets the user assign a preset to each remaining phase before any phase work begins.
 
-Available presets are defined in `MODEL_PRESETS` in `src/config.ts`: `opus-max` (Claude Opus 4.6 / max effort), `opus-high`, `sonnet-high`, `codex-high` (Codex gpt-5.4 / high effort), and `codex-medium`. Default per-phase assignments come from `PHASE_DEFAULTS` in the same file (e.g., phase 1 defaults to `opus-max`, phases 3 and 5 to `sonnet-high`, gates 2/4/7 to `codex-high`). The model shown in each phase table above is the default preset; users can override per-phase at run start. Selections are persisted in `state.phasePresets` and survive resume; `migrateState()` in `src/state.ts` backfills defaults for older state files that predate the preset system.
+Available presets are defined in `MODEL_PRESETS` in `src/config.ts`: `opus-max` (Claude Opus 4.7 / xHigh effort — kept as an opt-in for deliberately heavy specs), `opus-high` (Claude Opus 4.7 / high — the default for Phase 1 as of 2026-04-18), `sonnet-high`, `codex-high` (Codex gpt-5.4 / high effort), and `codex-medium`. Default per-phase assignments come from `PHASE_DEFAULTS` in the same file (phase 1 defaults to `opus-high`, phases 3 and 5 to `sonnet-high`, gates 2/4/7 to `codex-high`). The model shown in each phase table above is the default preset; users can override per-phase at run start — select `opus-max` when the task genuinely warrants xHigh reasoning. Selections are persisted in `state.phasePresets` and survive resume; `migrateState()` in `src/state.ts` backfills defaults for older state files that predate the preset system.
 
 ---
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,7 @@ export const MODEL_PRESETS: ModelPreset[] = [
 ];
 
 export const PHASE_DEFAULTS: Record<number, string> = {
-  1: 'opus-max',
+  1: 'opus-high',
   2: 'codex-high',
   3: 'sonnet-high',
   4: 'codex-high',
@@ -65,7 +65,7 @@ export const PHASE_ARTIFACT_FILES: Record<number, string[]> = {
 export const LIGHT_REQUIRED_PHASE_KEYS = ['1', '5', '7'] as const;
 
 export const LIGHT_PHASE_DEFAULTS: Record<number, string> = {
-  1: 'opus-max',
+  1: 'opus-high',
   5: 'sonnet-high',
   7: 'codex-high',
 };

--- a/tests/phases/interactive.test.ts
+++ b/tests/phases/interactive.test.ts
@@ -603,7 +603,9 @@ describe('runInteractivePhase — Claude dispatch command shape', () => {
 
     expect(command).toContain('--dangerously-skip-permissions');
     expect(command).toContain('--effort');
-    expect(command).toContain('xHigh');
+    // Phase 1 default preset is opus-high (effort=high). Pin the exact effort
+    // here so a future preset change trips this test on purpose.
+    expect(command).toContain('--effort high');
   });
 });
 

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -216,7 +216,7 @@ describe('createInitialState (updated)', () => {
 
   it('initializes phasePresets from PHASE_DEFAULTS', () => {
     const state = createInitialState('run-1', 'task', 'abc123', false);
-    expect(state.phasePresets['1']).toBe('opus-max');
+    expect(state.phasePresets['1']).toBe('opus-high');
     expect(state.phasePresets['5']).toBe('sonnet-high');
   });
 
@@ -250,7 +250,7 @@ describe('migrateState', () => {
   it('replaces invalid preset IDs with defaults', () => {
     const raw = { phasePresets: { '1': 'nonexistent', '2': 'codex-high' } };
     const migrated = migrateState(raw);
-    expect(migrated.phasePresets['1']).toBe('opus-max');
+    expect(migrated.phasePresets['1']).toBe('opus-high');
     expect(migrated.phasePresets['2']).toBe('codex-high');
   });
 


### PR DESCRIPTION
## Summary

- `PHASE_DEFAULTS[1]` and `LIGHT_PHASE_DEFAULTS[1]` flip from `opus-max` (xHigh) → `opus-high`. The `opus-max` preset itself stays in `MODEL_PRESETS` for manual opt-in when a task genuinely wants max-effort reasoning.
- Doc updates (`CLAUDE.md`, `docs/HOW-IT-WORKS.{md,ko.md}`) reflect the new default and explain when to still reach for `opus-max`.
- `FOLLOWUPS.md` captures the six other P1/P2 observations from the same dogfood run that are out of scope here, each with file paths + line numbers so they can be picked up independently.

## Why

2026-04-18 dogfood-full run against a vague `"Build a terminal-based todo manager…"` prompt:

- **Phase 1 burned 5.4M Claude tokens across 3 attempts** before the spec passed gate 2. On `opus-max` / `xHigh`, each retry roughly doubled token cost (710k → 1.6M → 3.1M) while the spec revisions were modest edits, not full rewrites.
- Post-run spec was a clean, middle-complexity CRUD spec. Nothing in the output justified xHigh reasoning. The default was wrong, not the gate.
- For realistic 1–2 hour tasks with the harness at "100% trust," this single-phase blowup makes the 60-minute / 500k-token budget unreachable.

Full breakdown lives in `observations.md` on `dogfood/full-flow` (commit `e9caee1`): session `~/.harness/sessions/0f7dd70d1f23/2026-04-18-build-a-terminal-based/`, 63 min wall clock, ~15M total Claude tokens, 211k gate tokens, all shipped fixes (#7/#9/#10/#11/#12/#13) verified, every gate reject was legitimate.

## What this does NOT do

This PR is intentionally narrow — one identifier per file. Out of scope:

- Automatic difficulty hint (Small / Medium / Large) from Phase 1 → Phase 3 — tracked as **P1.4** in `FOLLOWUPS.md`.
- `--heavy` CLI flag that forces `opus-max` for Phase 1 — deferred; today users can pick `opus-max` from the preset UI at run start.
- Phase 5 unclean-tree failure auto-recovery (the actual most expensive failure mode on the dogfood run, but it needs a proper design — see **P1.1**).
- Wrapper-skill self-audit step before sentinel (**P1.2**) and P1-only gate-feedback policy (**P1.3**).

## Interaction with #22

PR #22 (`refactor/rename-opus-max`) renames the preset id `opus-max` → `opus-xhigh`. That's orthogonal to this change — we're flipping which preset is the *default*, #22 is renaming the *id*. Whichever lands first, the second will need a 1-line rebase (either `'opus-high'` or `'opus-xhigh'` on the same line). No design conflict.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm vitest run` — **609 passed / 1 skipped** (baseline; updated 2 assertions in `tests/state.test.ts` to expect the new default, and pinned `--effort high` in the interactive dispatch test so a future preset flip trips on purpose)
- [x] `pnpm build` — clean, assets copied
- [ ] Reviewer: run a light-flow task (`hc-full start --light "small task"`) and confirm Phase 1 uses `opus-high`; token cost should drop noticeably vs the prior default