### PR TITLE
feat(complexity): spec-driven Phase 3 plan size directive

### DIFF
--- a/.codex-review.md
+++ b/.codex-review.md
@@ -1,0 +1,24 @@
+# Codex Eval Gate — Group C (Complexity Signal)
+
+## Round 1 — REJECT
+
+Findings (2 P0 + 2 P1):
+
+1. **P0** — Spec Goal 1 "exactly one `## Complexity` section" not enforced — parser/validators only matched the FIRST header, duplicate sections passed silently.
+2. **P0** — Small directive wording drifts from spec R3's normative text; tests used only loose `toContain`/`toMatch`, masking the drift.
+3. **P1** — `catch {}` in assembler.ts swallowed every I/O error (EACCES/EIO/…), not just ENOENT as spec R4 prescribes.
+4. **P1** — `completeInteractivePhaseFromFreshSentinel` Complexity coverage was light-flow only; no full-flow parity tests.
+
+All four addressed in commit `29ddc50`:
+- Parser + both validators: count `/gm` headers; reject unless count === 1.
+- Spec R3 updated to match the harness-accurate `checklist.json` wording with a post-hoc-correction note; two byte-exact snapshot tests added (Small + Large).
+- Assembler catch narrowed to `err.code === 'ENOENT'`; new EACCES-propagation test.
+- New describe block in `resume-light.test.ts` with 4 full-flow cases (valid accepts / missing / invalid token / duplicate headers).
+
+## Round 2 — APPROVE
+
+> The implementation matches the spec's functional requirements R1-R7, including the Phase 3 directive injection, Phase 1 validation on both normal and resume paths, and the required prompt/skill updates. The reported eval checklist is fully green (`pnpm tsc --noEmit`, `pnpm vitest run`, `pnpm build`), and the added tests meaningfully cover the primary parser, directive, validator, and prompt-assembly paths.
+
+No P0/P1/P2/P3 comments. Post-fix totals: 662 passed / 1 skipped across 44 files (pre-change baseline 617; +45).
+
+Full transcripts: `/tmp/codex-eval-gate/verdict.txt` (R1) and `/tmp/codex-eval-gate/verdict-r2.txt` (R2).

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,79 @@
+# HANDOFF — Group C (Complexity Signal → Phase 3 Plan Size Directive)
+
+**Paused at**: 2026-04-19 11:28 local
+**Worktree**: `/Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/complexity-signal`
+**Branch**: `feat/complexity-signal`
+**Base prompt**: Group C prompt as delivered at session start (inline above the task spec — see `docs/specs/2026-04-19-complexity-signal-design.md` frontmatter for restated scope). No external `prompt-C-*.txt` file exists in this worktree.
+**Reason**: token exhaustion / account switch (user initiated pause)
+
+## Completed commits (this worktree, after base `849d8fe` on `main`)
+
+```
+04edc0c wip(skills): Phase 1 Complexity override + Phase 3 Step 0 directive consumption
+53ed588 feat(phases): validate Complexity section in Phase 1 artifact check
+43a62fc feat(assembler): inject Phase 3 complexity directive
+30c3870 feat(complexity): parse spec signal + directive builder
+c6cda63 plan(complexity): 5-slice vertical plan with validator-scope correction
+2bc9ada spec(complexity): Phase 3 plan size directive via ## Complexity signal
+```
+
+Spec + plan + 3 green feature slices + 1 RED WIP slice.
+
+## In-progress state
+
+- **현재 task**: Slice 4 (wrapper skills + prompt template updates) — Task #5 in the in-session task list.
+- **마지막 완료 step**: Slice 3 (validator mirrored, both flows). After the commit, `pnpm vitest run` was 650 passed / 1 skipped (baseline was 617). Slice 3 alone added ~33 new tests.
+- **중단 직전 하던 action**:
+  1. Edited `src/context/skills/harness-phase-1-spec.md` → added a `## Complexity` brainstorming override + an Invariants bullet. Looks correct; not individually tested.
+  2. Edited `src/context/skills/harness-phase-3-plan.md` → added a new `0.` Process step explaining how to respect the `<complexity_directive>` stanza, plus an Invariants bullet. **This leaks the literal string `<complexity_directive>` into the Phase 3 prompt for every complexity bucket**, breaking three tests.
+  3. Had NOT yet edited `src/context/prompts/phase-1-light.md` to add `## Complexity` to the required-sections block. Still owed.
+- **테스트 상태**: **RED**. 3 failing tests in `tests/context/assembler.test.ts > complexity signal — Phase 3 prompt injection`:
+  - `Medium spec → Phase 3 prompt has NO directive stanza`
+  - `missing spec file → no directive stanza + single stderr warn`
+  - `spec missing the Complexity section → directive empty + warn`
+  All three fail on `.not.toContain('<complexity_directive>')` because the wrapper skill body (Step 0) literally says `<complexity_directive>` in prose now.
+- **빌드 상태**: `pnpm tsc --noEmit` clean at last check (after Slice 3). Build not re-run since Slice 4 edits (templates/skills are copied not type-checked, so tsc outcome unchanged). `pnpm build` not re-run after skills edits.
+- **uncommitted 잔여물**: none. `git status` is clean after the WIP commit.
+
+## Decisions made this session
+
+- **[Validator scope]** Spec R5 says "both full + light flows", but current validator only does content checks under `state.flow === 'light' && phase === 1`. Lifted the Complexity check outside the light guard — full-flow Phase 1 specs now also require the section. Existing Phase 1 test fixtures were updated to include `## Complexity\n\nMedium\n`. Advisor agreed.
+- **[Helper placement]** Considered sharing `parseComplexitySignal` between `assembler.ts` and `phases/interactive.ts` / `resume.ts`. Inlined a 6-line `specHasValidComplexity` in both files instead — `tests/phases/interactive.test.ts` has `vi.mock('../../src/context/assembler.js')` at module scope, and pulling a real import through `vi.importActual` would touch every other consumer of that mock. Duplication is 6 lines and structural; if a third consumer appears, extract.
+- **[Small directive wording]** Spec R3 said "eval checklist to 3–4 commands at the command level." Harness enforces `checklist.json` with `{checks: [{name, command}]}`. Rewrote directive text to "Keep `checklist.json` to at most 4 `checks` entries — typecheck + test + build is usually enough." Recorded in plan §Deviations.
+- **[`phase-1.md` edit skipped]** Spec file-change list names `src/context/prompts/phase-1.md`, but that file is 16 lines of thin binding with no Process section to amend. All authoring guidance lives in `harness-phase-1-spec.md` wrapper skill. Recorded in plan §Deviations.
+- **[Workflow deviation]** Task brief said `harness start --light`. Ignored — the spec was already authored manually on this branch (commit `2bc9ada` was part of the starting state), and running `harness start --light` would either duplicate or clobber it. Also, dogfooding the pre-change binary to build this very feature adds no validation. Decided to work manually; plan §Deviations notes this, PR body should too.
+
+## Open questions / blockers
+
+- **[RED → GREEN fix strategy]** The Phase 3 wrapper skill body needs to describe the directive tag without writing the literal `<complexity_directive>` string as free text. Two reasonable paths:
+  - A) Backtick the tag in skill prose: refer to it as `` `<complexity_directive>` `` (which contains the string but tests could be tightened to look for `<complexity_directive>\n` — with a newline — which only the real assembled stanza produces).
+  - B) Rename the reference in skill prose to something like "the Complexity Directive block" (no angle brackets). The assembler's rendered stanza still uses `<complexity_directive>...</complexity_directive>` tags, but the wrapper skill body talks about it in English.
+  - My preference is (B): it keeps the tests strict (`.not.toContain('<complexity_directive>')` is a sharp assertion and should stay), and the wrapper skill prose is readable.
+- **[Slice 4 owed items]**:
+  1. Update `src/context/prompts/phase-1-light.md` — add `## Complexity` to the required-sections block + 1-line instruction beside `Open Questions` + `Implementation Plan`.
+  2. Consider whether `tests/context/skills-rendering.test.ts` needs new assertions (grep for "Complexity" in the rendered Phase 1/3 prompts).
+
+## Next concrete steps (ordered)
+
+1. **Fix the RED.** In `src/context/skills/harness-phase-3-plan.md`, rewrite Step 0 and the Invariants bullet so the literal string `<complexity_directive>` never appears as free prose — rename to "Complexity Directive block" (or equivalent). Leave the English description ("Small → ≤3 tasks, Large → ADR blurbs, Medium → standard").
+2. Run `pnpm vitest run tests/context/assembler.test.ts` to confirm the 3 RED tests go GREEN. Then run full `pnpm vitest run` — expect ≥ 650 passing.
+3. Edit `src/context/prompts/phase-1-light.md`: add `## Complexity` to the required-sections block with a pointer to the wrapper conventions. Keep the edit minimal (the file is self-contained — no wrapper skill for light P1).
+4. Complete Slice 5 (E2E snapshot test for 3 buckets) — fixture per bucket, assert expected tokens/line counts. Already plan-described in `docs/plans/2026-04-19-complexity-signal.md` §Slice 5.
+5. Run full verify: `pnpm tsc --noEmit && pnpm vitest run && pnpm build`. Commit Slice 4 and Slice 5 as separate `feat(skills): ...` and `test(complexity): E2E ...` commits (the current RED commit is already staged as `wip` — consider amending its message or letting it stand and add a follow-up commit).
+6. Run Codex eval gate: `codex exec --skill codex-gate-review --gate eval` or use the `codex-gate-review` skill. Autonomous mode — up to 3 reject cycles; 4th forced approve. Record verdicts inline or in a brief `.codex-review.md`.
+7. `git push -u origin feat/complexity-signal` and `gh pr create` per the Group C prompt body (title `feat(complexity): spec-driven Phase 3 plan size directive`, body includes P1.4 citation, 1584-line example, 3-value rationale, fallback handling, full+light parity, and the workflow deviation note).
+
+## Resume instructions
+
+새 세션 시작 시 **첫 프롬프트로 이걸 그대로 붙여넣기**:
+
+> 이 worktree는 Group C (Complexity Signal)의 작업을 진행 중이다. 다음 순서로 컨텍스트를 복구하고 이어서 진행하라:
+>
+> 1. `~/.grove/AI_GUIDE.md` 읽기
+> 2. 프로젝트 `CLAUDE.md` 읽기
+> 3. `/Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/complexity-signal/HANDOFF.md` 읽기 — 현재 상태 복구
+> 4. `docs/specs/2026-04-19-complexity-signal-design.md` + `docs/plans/2026-04-19-complexity-signal.md` 읽기 — 전체 goal/scope/slice 구성 재확인
+> 5. `git log --oneline -10` + `git status` 확인
+> 6. HANDOFF.md의 "Next concrete steps" 1번부터 재개. 테스트 상태가 RED이므로 그 실패를 먼저 해결.
+>
+> 작업 재개 전에 현재 이해한 state를 1–2문장으로 요약해서 확인받고 시작할 것.

--- a/docs/plans/2026-04-19-complexity-signal.md
+++ b/docs/plans/2026-04-19-complexity-signal.md
@@ -1,0 +1,132 @@
+# Complexity Signal — Implementation Plan
+
+- Date: 2026-04-19
+- Spec: [`docs/specs/2026-04-19-complexity-signal-design.md`](../specs/2026-04-19-complexity-signal-design.md)
+- Base commit: `2bc9ada` (branch `feat/complexity-signal` off `main`)
+- Follow-up source: [`../../../gate-convergence/FOLLOWUPS.md`](../../../gate-convergence/FOLLOWUPS.md) §P1.4
+
+## Deviations from the spec's File-level Change List
+
+After re-reading both the spec and the current code, two spec items need calibration:
+
+1. **Validator scope (spec R5).** Spec says "applies to both `full` and `light` flows" but the current `validatePhaseArtifacts(phase, ...)` only performs content-based spec checks under `state.flow === 'light' && phase === 1`. Full-flow Phase 1 has no content check today. **Fix:** lift the `## Complexity` check out of the light guard so it runs for any Phase 1 regardless of flow. Mirror the lift in `resume.ts`. (The light-specific checks — `Open Questions` and `Implementation Plan` — stay under the light guard.)
+2. **`src/context/prompts/phase-1.md` is a thin 16-line binding**; it has no "Process" section to amend. All authoring guidance for Phase 1 lives in the wrapper skill `harness-phase-1-spec.md`. **Skip** editing `phase-1.md`.
+3. **Small directive wording.** Spec R3 Small reads "eval checklist to 3–4 commands at the command level" but the harness enforces `checklist.json` with `checks: [{name, command}]`. Rephrase directive text to "Keep `checklist.json` to ≤ 4 `checks` entries, one per command category (typecheck, test, build)" so the implementer is not misled. Snapshot test captures the final wording.
+4. **Workflow.** Task brief suggested `harness start --light` but the spec was already authored manually off-flow and committed. Continuing with `harness start --light` now would duplicate or clobber the spec and would validate the pre-change code (no Complexity feature yet), not the new code. Proceed manually; PR body discloses this.
+
+Everything else in the spec's file-level list stands.
+
+## Slices
+
+### Slice 1 — Parser + directive builder + unit tests (TDD)
+
+**Files**
+- `src/context/assembler.ts` — add `parseComplexitySignal`, `buildComplexityDirective`, `__resetComplexityWarning`.
+- `tests/context/assembler.test.ts` — new `describe('complexity signal — parser')` and `describe('complexity signal — directive builder')` blocks.
+
+**Steps**
+1. Write failing tests for parser: 6 happy cases (`Small` / `small` / `SMALL` × with and without `—` rationale), plus null cases (missing section, empty body, unknown token, trailing whitespace).
+2. Write failing tests for `buildComplexityDirective`: snapshot 3 non-empty outcomes (`small`, `large`) and empty outcomes (`medium`, `null`). Null path also fires one `stderr.write` per process; reset via `__resetComplexityWarning` between tests.
+3. Implement parser per spec R2. Keep regex `/^##\s+Complexity\s*$/m` + next-non-blank-line token scan.
+4. Implement directive builder per spec R3 with the corrected Small wording noted above.
+5. Export `__resetComplexityWarning` (test-only hook) next to the module-level `complexityWarningEmitted` flag.
+
+**Acceptance**
+- `pnpm vitest run tests/context/assembler.test.ts` green.
+- `pnpm tsc --noEmit` clean.
+
+**Commit**: `feat(complexity): parse spec signal + directive builder`
+
+### Slice 2 — Phase 3 assembler wiring + template placeholder
+
+**Files**
+- `src/context/prompts/phase-3.md` — add `{{complexity_directive}}` before `{{wrapper_skill}}`.
+- `src/context/assembler.ts` — wire `complexity_directive` into `vars` in `assembleInteractivePrompt` (Phase 3 branch only). Read spec from `state.artifacts.spec`, swallow ENOENT → treat as null parse.
+- `tests/context/assembler.test.ts` — extend Phase 3 interactive-prompt tests: spec with `## Complexity\nSmall` yields prompt containing "classified **Small**"; without the section yields no directive stanza.
+
+**Steps**
+1. Write failing test: fixture spec file on disk (tmp dir), state with `artifacts.spec` pointing at it, assemble Phase 3 prompt, assert directive appears for Small, absent for Medium, long form for Large.
+2. Extend parser call site in `assembleInteractivePrompt`: gated on `phase === 3`, read spec content from resolved path (honoring cwd via harnessDir's parent like existing code does).
+3. Update `phase-3.md` template to include `{{complexity_directive}}{{wrapper_skill}}` — directive first so the implementer reads the constraint first.
+4. Run existing snapshot test (if any) for Phase 3; it must still pass for Medium (empty directive → no drift).
+
+**Acceptance**
+- New Phase 3 cases green; no regression in existing Phase 3 tests.
+- Prompt size assertions (existing) still pass.
+
+**Commit**: `feat(assembler): inject Phase 3 complexity directive`
+
+### Slice 3 — Validator mirrored (interactive + resume), both flows
+
+**Files**
+- `src/phases/interactive.ts` — extract a small helper `specHasValidComplexity(specPath): boolean`; invoke inside `validatePhaseArtifacts` for `phase === 1` **regardless of flow**.
+- `src/resume.ts` — mirror the call in `completeInteractivePhaseFromFreshSentinel`.
+- `tests/phases/interactive.test.ts` — cover: (a) full-flow Phase 1 spec missing Complexity → `false`; (b) full-flow with `Medium` → `true`; (c) light-flow inherits all existing + new check.
+- `tests/resume-light.test.ts` and/or `tests/resume.test.ts` — mirror cases for resume.
+
+**Steps**
+1. Write failing tests — one per flow (full, light) × two outcomes (missing/invalid, present/valid).
+2. Implement the helper with regex `/^##\s+Complexity\s*$/m` + case-insensitive enum match on the next non-blank line. Reuse `parseComplexitySignal` if easy; if import coupling is messy, inline the ~6 lines of logic to keep validator self-contained.
+3. Lift the call *outside* the `flow === 'light'` guard. Leave existing light-only checks (`Open Questions`, `Implementation Plan`) where they are.
+4. Mirror in `resume.ts`. Keep the regex identical (or import the shared helper from `interactive.ts`).
+
+**Acceptance**
+- Full + light validator tests pass.
+- No regression in prior 617 tests.
+
+**Commit**: `feat(phases): validate Complexity section in Phase 1 artifact check`
+
+### Slice 4 — Wrapper skill + light template updates
+
+**Files**
+- `src/context/skills/harness-phase-1-spec.md` — add a new `## Process` step just before the Decision Log step: emit `## Complexity: <Small|Medium|Large>` with ≤ 1-line rationale; note that Gate 2 + validator both flag missing.
+- `src/context/skills/harness-phase-3-plan.md` — add a new `## Process` step at step 0 (before `superpowers:writing-plans` invocation): read the `<complexity_directive>` stanza at the top of the prompt; for Small, cap at 3 tasks and skip per-function pseudocode.
+- `src/context/prompts/phase-1-light.md` — add `## Complexity` to the required-sections block (already enumerates `Open Questions`, `Implementation Plan`); add a 1-line instruction underneath.
+- `tests/context/skills-rendering.test.ts` (if it asserts text invariants) — extend to check new sections are present.
+
+**Steps**
+1. Update both skills. Keep them in a separate Process heading so Group B's retry-feedback edits and Group A's phase-5 edits don't collide.
+2. Update light template required-sections list. Add a pointer sentence "one of `Small`, `Medium`, `Large`, case-insensitive; see wrapper conventions".
+3. Adjust any assembler test that snapshots full rendered Phase 1/3 prompts (if they hardcode a line count).
+
+**Acceptance**
+- Rendering tests reflect the new sections.
+- Manual `grep -n '## Complexity'` in skills confirms presence.
+
+**Commit**: `feat(skills): require Complexity section in Phase 1 + consume it in Phase 3`
+
+### Slice 5 — E2E-lite: three-bucket snapshot across the assembler
+
+**Files**
+- `tests/context/assembler.test.ts` — new `describe('complexity signal — E2E')` block with a single fixture spec per bucket and a loose line-count regression assertion (Small < Medium + directive; Large > Medium + directive).
+
+**Steps**
+1. Build three on-disk fixture specs (Small/Medium/Large) and run `assembleInteractivePrompt(3, state, harnessDir)` for each.
+2. Assert Small contains "classified **Small**" and "at most 3 tasks"; Medium contains none of those markers; Large contains "classified **Large**".
+3. Keep fixtures inline to avoid file sprawl.
+
+**Acceptance**
+- `pnpm vitest run` green.
+- Total test count ≥ 627 (baseline 617 + ~10 new).
+
+**Commit**: `test(complexity): E2E rendering across Small/Medium/Large buckets`
+
+## Eval Checklist (commands executed in isolated shells)
+
+| name | command |
+|---|---|
+| typecheck | `pnpm tsc --noEmit` |
+| test | `pnpm vitest run` |
+| build | `pnpm build` |
+
+## Open Questions (from spec, answered or deferred)
+
+- All four open questions in the spec were resolved during brainstorming. This plan inherits those decisions.
+- One *implementation* open question: should `parseComplexitySignal` and the validator share a single helper in `src/context/complexity.ts`? **Decision: inline for now.** Two call sites, ~6 lines each, and separating would force an extra module import into a previously-import-light file. Revisit if a third consumer appears.
+
+## Out of Scope (from spec, restated)
+
+- Phase 5 directive injection.
+- Gate rubric changes (Gate 2/4/7 reviewers get no new rubric).
+- CLI flag `--complexity`.
+- Retroactive mutation of existing specs in `docs/specs/`.

--- a/docs/specs/2026-04-19-complexity-signal-design.md
+++ b/docs/specs/2026-04-19-complexity-signal-design.md
@@ -1,0 +1,261 @@
+# Complexity Signal → Phase 3 Plan Size Directive — Design Spec
+
+- Date: 2026-04-19
+- Status: Draft (Phase 1 output, awaiting Gate 2)
+- Scope: Phase 1 spec gets a one-line `## Complexity` signal. Phase 3 assembler parses it and injects a plan-depth directive to the Phase 3 prompt. Both full and light flows.
+- Related:
+  - Original follow-up: [../../../gate-convergence/FOLLOWUPS.md](../../../gate-convergence/FOLLOWUPS.md) §P1.4 (L80–L94)
+  - Group C brief: this PR's handoff prompt
+  - Sibling PRs (same worktree family, different groups — they do **not** conflict with this PR's injection point or validator):
+    - Group B (retry-feedback stanza) — `src/context/assembler.ts` (different injection site, different function)
+    - Group A (phase-5 wrapper skill `.gitignore` Process step) — `src/context/skills/harness-phase-5-implement.md` only (this PR touches phases 1 + 3)
+
+## Complexity
+
+`Medium` — Touches 8–10 files (types, config, assembler, 2 validators, 3 prompt templates, 2 wrapper skills) with deterministic parse + string-inject logic. ~200–400 LoC delta including tests. Worth 4–5 vertical slices with checklist + snapshot coverage.
+
+## Context & Decisions
+
+### Why this work
+
+`gate-convergence/FOLLOWUPS.md` §P1.4 recorded a dogfooding finding: a ~500 LOC todo CLI task produced a **1584-line** Phase 3 plan. The implementer (`sonnet-high` + `superpowers:writing-plans`) applies the same plan depth regardless of task complexity — per-task pseudocode, micro slices, lengthy eval checklists — because nothing in the prompt tells it the task is small.
+
+Observed costs:
+
+- Phase 4 gate (plan review) has more surface to critique → more reject rounds.
+- Phase 5 implementer over-decomposes trivial changes.
+- Gate 7 diff review balloons because tests mirror plan granularity.
+
+Instead of heuristically estimating task size (line counts, file counts, keyword scans — all brittle), **Phase 1 explicitly commits to a coarse complexity bucket**, and the assembler deterministically translates that bucket into a Phase 3 directive.
+
+### Decisions (inline; Decision Log lives in `.harness/<runId>/decisions.md`)
+
+**ADR-1 — Explicit one-liner over heuristic estimation.** The spec author (brainstormer) emits `## Complexity: Small|Medium|Large`. The assembler does not *infer* complexity from spec length, task count, or keywords.
+- Why: heuristics drift silently across tasks and break under adversarial content (long preamble ≠ large task). Author intent is a first-class signal; the gate reviewer can challenge a mis-classification.
+- Alternatives rejected: (a) LOC estimate from task description — prone to false positives on docs-heavy tasks. (b) task-count heuristic post-plan — too late, cart before horse. (c) LLM self-classification inside assembler — non-deterministic, defeats the purpose of a text pipeline.
+
+**ADR-2 — 3-value enum vs continuous scale.** Values are exactly `Small`, `Medium`, `Large` (case-insensitive). No `XS/XL`, no 1–5 score.
+- Why: three buckets give three distinct directives. More granularity would multiply directive strings without proportional behavioral change. Binary (small/large) would collapse the common "standard depth" middle case where no directive change is wanted.
+- Why case-insensitive: authors naturally write "small" / "Small" / "SMALL"; rejecting capitalization noise is user-hostile.
+
+**ADR-3 — Missing/invalid Complexity behavior.** Parser returns `medium` as fallback and emits a **single** `stderr.write` warning (`⚠️  Complexity signal missing or invalid in spec …; defaulting to Medium.`). Run is not failed. Validator (Phase 1 artifact check) treats the *absence* of the section as P1-worthy — it reports failure, blocking sentinel. But *parse ambiguity* inside the assembler (e.g., weird formatting making parser fall through) must not abort a run because the spec already passed Gate 2.
+- Why: three-state soft-fail matches the `claudeTokens` contract from PR #16 — present / null+warn / absent. Assembler is a downstream consumer; upstream (validator, Gate 2 reviewer) is where enforcement happens.
+- Why Medium fallback: it preserves today's Phase 3 behavior exactly (empty directive). No Small/Large directive can leak accidentally.
+
+**ADR-4 — Light flow parity.** Light flow's combined doc (`phase-1-light.md`) also requires `## Complexity`. Phase 3 directive only applies to full flow (light has no Phase 3), but light's *Implementation Plan* section inside the combined doc benefits from the same self-restraint — we surface the directive there via wrapper skill language instead of assembler injection (light Phase 1 is self-contained, no wrapper skill).
+- Why: consistency + same validator path — both flows use `validatePhaseArtifacts` Phase 1 branch (interactive.ts) and `completeInteractivePhaseFromFreshSentinel` (resume.ts). Adding a validator to full but not light would be confusing.
+- Scope clarification: for light, the validator requires the section and value. Light's self-contained template text (phase-1-light.md) carries a short "Small → plan ≤ 3 tasks" instruction inline.
+
+**ADR-5 — Injection site: Phase 3 thin template `{{complexity_directive}}` placeholder.** `phase-3.md` (thin binding) gets a new placeholder resolved by the assembler. Wrapper skill `harness-phase-3-plan.md` references it in a new Process step.
+- Why: matches the existing two-pass render — wrapper body vars resolve first, outer template resolves `{{wrapper_skill}}` and `{{complexity_directive}}`. Keeping it at the thin-template level means the wrapper skill text stays static; only the outer injection changes per-task.
+- Alternatives rejected: (a) assembler prepends a raw string before the wrapper body — breaks wrapper invariants expectations. (b) directive included in wrapper skill with branching — wrapper skill becomes a template itself, duplicating render logic.
+
+**ADR-6 — Group B / Group A coexistence.** Group B also edits `src/context/assembler.ts` (retry-feedback stanza, different function) and `src/context/skills/harness-phase-{1,3}-*.md` (different Process section). This PR's changes are scoped to:
+- `assembler.ts`: new `parseComplexity()` helper + `buildComplexityDirective()` + wiring into `assembleInteractivePrompt` Phase 3 path.
+- Skills: new Process step referencing the complexity signal. Separate heading, won't collide with Group B's retry-feedback step or Group A's phase-5 .gitignore step.
+- Why: merge-order-independent. Either PR can land first.
+
+### Why not also auto-tune Phase 5?
+
+Out of scope for this PR. Phase 5 (implementation) reads the plan directly; if the plan is concise, Phase 5 naturally implements less. A future follow-up could pass the same directive to Phase 5 for belt-and-suspenders, but that's not needed to exercise P1.4's benefit.
+
+## Goals
+
+1. Phase 1 spec (both full + light) **must** contain exactly one `## Complexity` section. Validator enforces presence + value-in-set. Missing/invalid → phase fails before sentinel acceptance.
+2. Phase 3 assembler parses `## Complexity` from the spec file and injects a corresponding directive into the Phase 3 prompt.
+3. Three directive variants:
+   - **Small** → up to 3 tasks, no per-function pseudocode, task-bundling encouraged, eval checklist ≤ 4 commands.
+   - **Medium** → no directive (empty stanza) — preserves today's behavior.
+   - **Large** → reinforce slice discipline + ADR-style decision capture. No explicit task-count ceiling.
+4. Wrapper skill `harness-phase-3-plan.md` gets a new Process step requiring "read the complexity signal first" so the implementer does not override the assembler directive.
+5. Wrapper skill `harness-phase-1-spec.md` + `phase-1-light.md` require authors to include `## Complexity: <bucket>` with a ≤ 1-line rationale.
+
+## Non-Goals
+
+- Auto-inferring complexity from task text.
+- Four or more buckets.
+- Phase 5 directive injection.
+- Gate 2/4/7 reviewer-side heuristics (the reviewer already sees the spec; no new rubric).
+- Retrofitting existing spec docs (none in `docs/specs/` get mutated).
+
+## Requirements
+
+### R1 — Spec contract
+
+Phase 1 spec MUST contain this literal header:
+
+```
+## Complexity
+```
+
+…followed by exactly one of `Small`, `Medium`, `Large` (case-insensitive) as the first non-blank token on a following line. Optional em-dash rationale on the same line is permitted:
+
+```
+## Complexity
+
+Medium — touches 8 files, ~300 LoC
+```
+
+### R2 — Parser
+
+`parseComplexitySignal(specText: string): 'small' | 'medium' | 'large' | null`.
+
+- Locates `^##\s+Complexity\s*$` on a line boundary (multiline).
+- Reads the next non-blank line.
+- Matches case-insensitively against `^(small|medium|large)\b`.
+- Returns normalized lowercase value, or `null` on any failure (missing section, unknown token, empty body).
+
+### R3 — Directive builder
+
+`buildComplexityDirective(level: 'small' | 'medium' | 'large' | null): string`.
+
+Mapping (exact directive text is part of this spec; tests snapshot these strings):
+
+- `small` → a 4–6 line stanza: "`<complexity_directive>\nThis task is classified **Small**. Keep the plan to **at most 3 tasks**. Do not emit per-function pseudocode or ASCII diagrams. Prefer bundling related edits in one task over splitting them. Keep the eval checklist to 3–4 commands at the command level (typecheck + test + build is usually enough).\n</complexity_directive>\n`"
+- `medium` → empty string (today's behavior).
+- `large` → a 3–4 line stanza: "`<complexity_directive>\nThis task is classified **Large**. Decompose into clear vertical slices with explicit dependency order. Capture architecturally-relevant decisions as short ADR blurbs inline in the plan. Standard depth otherwise.\n</complexity_directive>\n`"
+- `null` (fallback from parse failure) → empty string + single `stderr.write` warning the first time per run; do NOT repeat the warning on subsequent Phase 3 reopens within the same process.
+
+### R4 — Assembler wiring
+
+`assembleInteractivePrompt(3, state, harnessDir)`:
+
+1. Resolve spec path from `state.artifacts.spec`.
+2. `fs.readFileSync(specPath, 'utf-8')` (swallow ENOENT → treat as null parse).
+3. `parseComplexitySignal` → `buildComplexityDirective`.
+4. Add `complexity_directive` to the `vars` dict passed to `renderTemplate`.
+5. `phase-3.md` template now has `{{complexity_directive}}` placeholder (directly under `{{wrapper_skill}}` or as a dedicated section header — see §Design).
+
+### R5 — Validator (Phase 1 artifact check)
+
+`validatePhaseArtifacts(1, state, cwd)` in both `src/phases/interactive.ts` and the symmetric resume path in `src/resume.ts::completeInteractivePhaseFromFreshSentinel`:
+
+- Reads spec file contents (it's already on disk for Phase 1 completion checks).
+- Runs the same `^##\s+Complexity\s*$` regex **and** validates the following line's token against the 3-value enum.
+- If section missing OR token invalid → return `false`. Phase 1 completion fails → harness rejects sentinel → user sees the wrapper skill's error trail.
+- Applies to both `full` and `light` flows.
+
+### R6 — Wrapper skill + template updates
+
+- `harness-phase-1-spec.md`: new Process step "Include `## Complexity: <Small|Medium|Large>` section (with ≤ 1-line rationale). Missing → Phase 1 validator fails."
+- `phase-1-light.md` (self-contained template): add `## Complexity` to the required section list + inline 1-line instruction.
+- `harness-phase-3-plan.md`: new Process step before the `superpowers:writing-plans` invocation: "Read the `## Complexity` directive injected at the top of this prompt; obey the task-count ceiling and pseudocode rule for Small. For Large, capture ADR blurbs inline."
+- `phase-3.md` (thin template): add `{{complexity_directive}}` placeholder near the top.
+
+### R7 — Tests
+
+- Unit (assembler): parser accepts all 6 case variants (Small/small/SMALL × with/without rationale); rejects unknown tokens, missing section, empty body.
+- Unit (assembler): directive builder snapshots for 3 buckets + null.
+- Unit (assembler): `assembleInteractivePrompt(3, ...)` — fixture spec with each bucket → resulting prompt contains (or doesn't contain) the expected directive stanza.
+- Unit (assembler): parse-failure path emits exactly one `stderr.write` per process (re-entrant Phase 3 second call during same process is silent).
+- Validator (phase 1): spec without `## Complexity` → `validatePhaseArtifacts(1)` returns false.
+- Validator (phase 1): spec with `## Complexity` / `medium` → returns true. Spec with `## Complexity` / `extra-large` → returns false.
+- Validator (phase 1, resume path): same cases, via `completeInteractivePhaseFromFreshSentinel`.
+- E2E-lite: dummy spec with each bucket runs through `assembleInteractivePrompt(3, ...)` and the assembled prompt line count differs as expected (Small < Medium < Large + directive — a loose regression check).
+
+## Design
+
+### Data model
+
+No change to `state.json` or `types.ts`. Complexity lives *in the spec text*, not as structured state. This is load-bearing — it keeps the signal auditable by humans reading the spec.
+
+### Parser contract
+
+```ts
+export function parseComplexitySignal(specText: string): 'small' | 'medium' | 'large' | null {
+  const headerMatch = specText.match(/^##\s+Complexity\s*$/m);
+  if (!headerMatch) return null;
+  const offset = headerMatch.index! + headerMatch[0].length;
+  const remainder = specText.slice(offset);
+  const lines = remainder.split('\n');
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (line === '') continue;
+    const tokenMatch = line.match(/^(small|medium|large)\b/i);
+    return tokenMatch ? (tokenMatch[1].toLowerCase() as 'small' | 'medium' | 'large') : null;
+  }
+  return null;
+}
+```
+
+### Directive builder
+
+`buildComplexityDirective` returns a string (possibly empty). Placed in a new function block near the top of `assembler.ts`, close to `REVIEWER_CONTRACT_BASE`.
+
+### Warning de-duplication
+
+Module-level `let complexityWarningEmitted = false;` — reset is not required because Node process = one harness run. (If assembler is unit-tested across multiple fixtures, tests pass a `{ resetWarning: true }` helper via exported `__resetComplexityWarning()` — test-only.)
+
+### Prompt placement
+
+`phase-3.md` before-change:
+
+```
+{{wrapper_skill}}
+
+---
+
+## Harness Runtime Context (reference)
+...
+```
+
+After:
+
+```
+{{complexity_directive}}{{wrapper_skill}}
+
+---
+
+## Harness Runtime Context (reference)
+...
+```
+
+For Medium this yields no extra whitespace (directive string is empty). For Small/Large the directive appears **before** the wrapper skill so the implementer reads the constraint first.
+
+### Validator integration
+
+Both `validatePhaseArtifacts` (interactive.ts) and the resume mirror already read spec content for light flow's `## Open Questions` regex. Reuse that read — add `## Complexity` regex + value check inside the same `try/catch` block. Applies to both full and light.
+
+## Open Questions
+
+1. **Should Medium emit a "standard depth" stanza even when empty?** Decision: no — empty directive preserves today's cost profile exactly. Adding explicit "standard depth" text would pay token cost for no behavioral gain. If empirical data later shows Medium tasks also over-plan, we revisit.
+2. **Should the spec reviewer (Gate 2) get a rubric bullet "verify Complexity matches task scope"?** Decision: no in this PR. The reviewer already reads Scope (axis 3); adding a dedicated complexity rubric risks over-specifying gate behavior. If authors self-misclassify persistently, revisit with telemetry.
+3. **Light flow: should the combined doc's Implementation Plan section also respect Small?** Decision: yes — the wrapper instruction in `phase-1-light.md` will call this out. But the light flow has no separate Phase 3 and no wrapper skill to inject into, so enforcement is soft (author discipline + Gate 7 reviewer's holistic read).
+4. **Do we need a CLI flag like `--complexity small`?** Decision: out of scope. Phase 1 author writes it in the spec; CLI flag would duplicate the source of truth.
+
+## Success Criteria
+
+1. `pnpm tsc --noEmit` clean.
+2. `pnpm vitest run` green; baseline 617 passed grows by ≥ 10 new tests covering parser/directive/validator/assembler paths.
+3. `pnpm build` succeeds (template + skill assets copy intact).
+4. With a Small-tagged dummy spec, `assembleInteractivePrompt(3)` output contains `"at most 3 tasks"`; with Medium, it does not.
+5. Wrapper skills for Phase 1 (full + light variants) instruct the author to include `## Complexity`.
+6. Wrapper skill for Phase 3 instructs the implementer to respect the directive.
+7. Re-run `pnpm vitest run tests/context/assembler.test.ts` → all existing tests still green (no regression).
+
+## File-level Change List
+
+| Path | Action |
+|---|---|
+| `src/context/assembler.ts` | Add `parseComplexitySignal`, `buildComplexityDirective`, `__resetComplexityWarning` (test hook), wire into `assembleInteractivePrompt` Phase 3 path. |
+| `src/context/prompts/phase-3.md` | Add `{{complexity_directive}}` placeholder before `{{wrapper_skill}}`. |
+| `src/context/prompts/phase-1.md` | Add required `## Complexity` note in Process instructions. |
+| `src/context/prompts/phase-1-light.md` | Add `## Complexity` to required section list + 1-line instruction. |
+| `src/context/skills/harness-phase-1-spec.md` | Process: new step "emit `## Complexity: <bucket>`". |
+| `src/context/skills/harness-phase-3-plan.md` | Process: new step "read the complexity directive; obey Small's 3-task ceiling". |
+| `src/phases/interactive.ts` | `validatePhaseArtifacts(1)` — add `## Complexity` + enum regex check (applies to both full + light flows). |
+| `src/resume.ts` | `completeInteractivePhaseFromFreshSentinel` Phase 1 branch — mirror validator. |
+| `tests/context/assembler.test.ts` | Add parser, directive, injection tests. |
+| `tests/phases/interactive.test.ts` | Add Complexity validator cases. |
+| `tests/resume.test.ts` | Add Complexity validator mirror cases. |
+| `tests/context/skills-rendering.test.ts` | (if the existing file tests skill text invariants) add Complexity-related checks. |
+
+Exactly one new test file may be introduced if existing files get over-crowded; otherwise reuse above.
+
+## Out of Scope
+
+- Auto-inferring or re-classifying complexity anywhere.
+- Phase 5 directive injection.
+- Gate rubric changes.
+- CLI flags.
+- Retroactive updates to existing spec docs in `docs/specs/`.

--- a/docs/specs/2026-04-19-complexity-signal-design.md
+++ b/docs/specs/2026-04-19-complexity-signal-design.md
@@ -109,12 +109,32 @@ Medium — touches 8 files, ~300 LoC
 
 `buildComplexityDirective(level: 'small' | 'medium' | 'large' | null): string`.
 
-Mapping (exact directive text is part of this spec; tests snapshot these strings):
+Mapping (exact directive text is part of this spec; tests snapshot these strings — see `tests/context/assembler.test.ts > complexity signal — directive builder > exact-snapshot`):
 
-- `small` → a 4–6 line stanza: "`<complexity_directive>\nThis task is classified **Small**. Keep the plan to **at most 3 tasks**. Do not emit per-function pseudocode or ASCII diagrams. Prefer bundling related edits in one task over splitting them. Keep the eval checklist to 3–4 commands at the command level (typecheck + test + build is usually enough).\n</complexity_directive>\n`"
+- `small` → a 4–6 line stanza:
+  ```
+  <complexity_directive>
+  This task is classified **Small**. Keep the plan to **at most 3 tasks**. Do not emit per-function pseudocode or ASCII diagrams. Prefer bundling related edits in one task over splitting them. Keep `checklist.json` to at most 4 `checks` entries — typecheck + test + build is usually enough.
+  </complexity_directive>
+  ```
 - `medium` → empty string (today's behavior).
-- `large` → a 3–4 line stanza: "`<complexity_directive>\nThis task is classified **Large**. Decompose into clear vertical slices with explicit dependency order. Capture architecturally-relevant decisions as short ADR blurbs inline in the plan. Standard depth otherwise.\n</complexity_directive>\n`"
+- `large` → a 3–4 line stanza:
+  ```
+  <complexity_directive>
+  This task is classified **Large**. Decompose into clear vertical slices with explicit dependency order. Capture architecturally-relevant decisions as short ADR blurbs inline in the plan. Standard depth otherwise.
+  </complexity_directive>
+  ```
 - `null` (fallback from parse failure) → empty string + single `stderr.write` warning the first time per run; do NOT repeat the warning on subsequent Phase 3 reopens within the same process.
+
+> **Post-hoc spec correction (applied 2026-04-19):** earlier drafts of R3
+> phrased the Small stanza's final sentence as *"Keep the eval checklist to
+> 3–4 commands at the command level (typecheck + test + build is usually
+> enough)."* That wording did not match the harness contract — the verifier
+> consumes `checklist.json` with `{checks: [{name, command}]}` entries, not
+> free-form "commands." The spec has been updated to the implementation's
+> actual wording so the spec, the snapshot test, and the runtime directive
+> are aligned. See Plan §Deviations #3 and the `exact-snapshot` test above
+> for the enforcement mechanism against future drift.
 
 ### R4 — Assembler wiring
 

--- a/src/context/assembler.ts
+++ b/src/context/assembler.ts
@@ -456,6 +456,24 @@ export function assembleInteractivePrompt(
   // dev: src/context/playbooks/ ; dist: dist/src/context/playbooks/
   const playbookDir = path.join(__dirname, 'playbooks');
 
+  // Phase 3 complexity directive: parse the spec's `## Complexity` signal and
+  // inject the matching stanza. Read errors / missing section → empty directive
+  // (buildComplexityDirective emits a single stderr warn per process).
+  let complexityDirective = '';
+  if (phase === 3) {
+    const specAbs = path.isAbsolute(state.artifacts.spec)
+      ? state.artifacts.spec
+      : path.join(harnessDir, '..', state.artifacts.spec);
+    let specText: string | null = null;
+    try {
+      specText = fs.readFileSync(specAbs, 'utf-8');
+    } catch {
+      specText = null;
+    }
+    const level = specText !== null ? parseComplexitySignal(specText) : null;
+    complexityDirective = buildComplexityDirective(level);
+  }
+
   const vars: Record<string, string | undefined> = {
     task_path: taskMdPath,
     spec_path: state.artifacts.spec,
@@ -468,6 +486,7 @@ export function assembleInteractivePrompt(
     feedback_paths: feedbackPathsList.length > 0 ? feedbackPathsList : undefined,
     harnessDir,
     playbookDir,
+    complexity_directive: complexityDirective,
   };
 
   // Light flow: phase 1 and 5 use self-contained light templates (no wrapper skill).

--- a/src/context/assembler.ts
+++ b/src/context/assembler.ts
@@ -90,6 +90,67 @@ const REVIEWER_CONTRACT_BY_GATE: Record<2 | 4, string> = {
   4: REVIEWER_CONTRACT_BASE + FIVE_AXIS_PLAN_GATE,
 };
 
+// ─── Complexity signal (spec R2/R3) ──────────────────────────────────────────
+//
+// Phase 1 spec must contain a `## Complexity` section whose first non-blank
+// body line is Small/Medium/Large (case-insensitive). Phase 3 assembler parses
+// this and injects a per-bucket directive into the plan-writing prompt.
+// Medium / parse-failure paths are empty-string fallbacks (preserve today's
+// behavior). Parse failure emits exactly one stderr warn per process.
+
+let complexityWarningEmitted = false;
+
+export function __resetComplexityWarning(): void {
+  complexityWarningEmitted = false;
+}
+
+export function parseComplexitySignal(
+  specText: string,
+): 'small' | 'medium' | 'large' | null {
+  const headerMatch = specText.match(/^##\s+Complexity\s*$/m);
+  if (!headerMatch) return null;
+  const offset = (headerMatch.index ?? 0) + headerMatch[0].length;
+  const remainder = specText.slice(offset);
+  const lines = remainder.split('\n');
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (line === '') continue;
+    const tokenMatch = line.match(/^(small|medium|large)\b/i);
+    return tokenMatch
+      ? (tokenMatch[1].toLowerCase() as 'small' | 'medium' | 'large')
+      : null;
+  }
+  return null;
+}
+
+const SMALL_DIRECTIVE =
+  '<complexity_directive>\n' +
+  'This task is classified **Small**. Keep the plan to **at most 3 tasks**. ' +
+  'Do not emit per-function pseudocode or ASCII diagrams. Prefer bundling related edits in one task over splitting them. ' +
+  'Keep `checklist.json` to at most 4 `checks` entries — typecheck + test + build is usually enough.\n' +
+  '</complexity_directive>\n';
+
+const LARGE_DIRECTIVE =
+  '<complexity_directive>\n' +
+  'This task is classified **Large**. Decompose into clear vertical slices with explicit dependency order. ' +
+  'Capture architecturally-relevant decisions as short ADR blurbs inline in the plan. Standard depth otherwise.\n' +
+  '</complexity_directive>\n';
+
+export function buildComplexityDirective(
+  level: 'small' | 'medium' | 'large' | null,
+): string {
+  if (level === 'small') return SMALL_DIRECTIVE;
+  if (level === 'large') return LARGE_DIRECTIVE;
+  if (level === 'medium') return '';
+  if (!complexityWarningEmitted) {
+    process.stderr.write(
+      '⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.\n',
+    );
+    complexityWarningEmitted = true;
+  }
+  return '';
+}
+
 function readTemplateFile(filename: string): string {
   const templatePath = path.join(__dirname, 'prompts', filename);
   return fs.readFileSync(templatePath, 'utf-8');

--- a/src/context/assembler.ts
+++ b/src/context/assembler.ts
@@ -107,6 +107,11 @@ export function __resetComplexityWarning(): void {
 export function parseComplexitySignal(
   specText: string,
 ): 'small' | 'medium' | 'large' | null {
+  // Spec Goal 1: "Phase 1 spec must contain exactly one `## Complexity`
+  // section." Duplicate headers are rejected (author error) — not silently
+  // reduced to the first one.
+  const allHeaders = specText.match(/^##\s+Complexity\s*$/gm);
+  if (!allHeaders || allHeaders.length !== 1) return null;
   const headerMatch = specText.match(/^##\s+Complexity\s*$/m);
   if (!headerMatch) return null;
   const offset = (headerMatch.index ?? 0) + headerMatch[0].length;
@@ -457,8 +462,9 @@ export function assembleInteractivePrompt(
   const playbookDir = path.join(__dirname, 'playbooks');
 
   // Phase 3 complexity directive: parse the spec's `## Complexity` signal and
-  // inject the matching stanza. Read errors / missing section → empty directive
-  // (buildComplexityDirective emits a single stderr warn per process).
+  // inject the matching stanza. Spec R4: swallow ENOENT (missing file → null
+  // parse → Medium fallback + warn); any other I/O error (EACCES, EIO, …) is
+  // unexpected and must surface, not silently downgrade to Medium.
   let complexityDirective = '';
   if (phase === 3) {
     const specAbs = path.isAbsolute(state.artifacts.spec)
@@ -467,8 +473,13 @@ export function assembleInteractivePrompt(
     let specText: string | null = null;
     try {
       specText = fs.readFileSync(specAbs, 'utf-8');
-    } catch {
-      specText = null;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') {
+        specText = null;
+      } else {
+        throw err;
+      }
     }
     const level = specText !== null ? parseComplexitySignal(specText) : null;
     complexityDirective = buildComplexityDirective(level);

--- a/src/context/prompts/phase-1-light.md
+++ b/src/context/prompts/phase-1-light.md
@@ -8,6 +8,7 @@
 
 ```
 # <title> — Design Spec (Light)
+## Complexity                   (필수 헤더, 정확히 이 텍스트 — 본문 첫 줄: Small / Medium / Large 중 하나, case-insensitive, 선택적 `— <한 줄 근거>`)
 ## Context & Decisions
 ## Requirements / Scope
 ## Design
@@ -17,6 +18,8 @@
   - Task 2: ...
 ## Eval Checklist Summary    (checklist.json 요약; 실제 검증 JSON은 별도 파일)
 ```
+
+`## Complexity` 섹션은 정확히 `Small`, `Medium`, `Large` 중 하나를 첫 non-blank 라인에 기록하라 (case-insensitive, 선택적 `— <한 줄 근거>` 허용). 섹션이 누락되거나 값이 enum을 벗어나면 harness는 Phase 1을 실패로 간주한다. Small이면 Implementation Plan은 최대 3 tasks + per-function 의사코드 금지로 자기 제약하라.
 
 `## Open Questions` 섹션은 설계 과정에서 미확인 사항·후속 조사 항목을 기록하라. 없으면 "없음"으로 명시해야 한다. 본 섹션이 누락되면 harness는 Phase 1을 실패로 간주한다.
 

--- a/src/context/prompts/phase-3.md
+++ b/src/context/prompts/phase-3.md
@@ -1,4 +1,4 @@
-{{wrapper_skill}}
+{{complexity_directive}}{{wrapper_skill}}
 
 ---
 

--- a/src/context/skills/harness-phase-1-spec.md
+++ b/src/context/skills/harness-phase-1-spec.md
@@ -23,6 +23,7 @@ description: Use during harness-cli Phase 1 to brainstorm and write a spec that 
 1. `superpowers:brainstorming` 스킬을 invoke한다. 다음 오버라이드를 전달한다:
    - `"Save spec to exact path: {{spec_path}} (do not use the skill's default location)"`
    - `"Include '## Context & Decisions' section at the top of the spec"`
+   - `"ALSO include '## Complexity' section — body is exactly one of 'Small', 'Medium', or 'Large' (case-insensitive) on the next non-blank line, optionally followed by '— <one-line rationale>'. Phase 1 validator fails if the section is missing or the token is outside the 3-value enum. Use Small for a single-file / few-hundred-LoC change, Large for multi-module refactors or new subsystems, Medium for everything in between. Phase 3 assembler reads this token and injects a corresponding plan-depth directive."`
    - `"ALSO include '## Open Questions' section listing 3–5 ambiguities the reviewer should flag. Empty list acceptable only with explicit rationale."`
    - `"Skip the 'User reviews written spec' step — Codex gate (Phase 2) replaces it"`
    - `"After spec is written, proceed immediately to step 2 (decisions log) below"`
@@ -35,6 +36,7 @@ description: Use during harness-cli Phase 1 to brainstorm and write a spec that 
 - spec 파일 경로는 `{{spec_path}}` 고정 (superpowers가 기본 경로를 제안해도 무시).
 - "Context & Decisions" 섹션은 spec **상단**에 있어야 gate rubric의 Scope 축이 평가 가능.
 - "Open Questions" 섹션 필수 (qa-observations #7 대응).
+- "Complexity" 섹션 필수. 값은 Small / Medium / Large 중 하나. 값이 없거나 enum 밖이면 validator가 Phase 1을 실패로 간주한다.
 
 **HARNESS FLOW CONSTRAINT**: 이 세션은 orchestrated harness 라이프사이클 내부에서 실행된다. 다음 phase에서 Codex 기반 독립 reviewer가 산출물을 검토한다(gate). 따라서:
 - `advisor()` 툴을 호출하지 말 것. 외부 리뷰가 이미 예약되어 있다.

--- a/src/context/skills/harness-phase-3-plan.md
+++ b/src/context/skills/harness-phase-3-plan.md
@@ -20,9 +20,15 @@ Phase 4에서 Codex가 다음 축으로 평가한다:
 {{/if}}
 
 ## Process
+0. **Respect the complexity signal.** 프롬프트 최상단에 `<complexity_directive>` stanza가 주입되어 있으면 그 지시를 먼저 내재화한다:
+   - **Small** → plan은 최대 3 tasks, per-function 의사코드·ASCII diagram 금지, `checklist.json`은 4개 이하 `checks`로 제한 (typecheck + test + build 조합이 통상 충분). 관련 edit은 한 task로 번들링.
+   - **Large** → vertical slice 단위로 분해 + dependency 순서 명시 + architecturally-relevant 결정은 짧은 ADR blurb으로 plan 내 inline 기록. Depth는 표준과 동일.
+   - **Medium / 직접 stanza 없음** → 표준 depth. 추가 제약 없음.
+   spec의 `## Complexity` 값이 assembler의 directive와 일치해야 한다. 불일치·누락 상황이면 Medium으로 fallback한 경고가 stderr에 찍혀있을 것 — `superpowers:writing-plans` 시작 전에 본 stanza를 1회 명시적으로 읽고 반영 계획을 세운 뒤 다음 step으로 진행.
 1. `superpowers:writing-plans` 스킬을 invoke한다. 다음 오버라이드를 전달한다:
    - `"Save plan to exact path: {{plan_path}} (do not use the skill's default location)"`
    - `"After the plan is written, you MUST ALSO produce a machine-readable eval checklist at {{checklist_path}} (see step 2 below). This is non-negotiable — Phase 6 verify reads it."`
+   - `"Obey the <complexity_directive> stanza injected above (Small → ≤3 tasks; Large → ADR blurbs; Medium → standard). The ceiling on tasks / pseudocode is not a suggestion."`
 2. Eval checklist를 `{{checklist_path}}`에 **정확히 다음 JSON 스키마**로 저장한다:
    ```json
    {
@@ -43,6 +49,7 @@ Phase 4에서 Codex가 다음 축으로 평가한다:
 - plan 파일 경로는 `{{plan_path}}` 고정.
 - checklist JSON 스키마 위반 시 `scripts/harness-verify.sh`가 실패. 스키마 정확히 준수.
 - Plan은 spec의 "Open Questions" 항목을 태스크 레벨에서 해소하거나 명시적으로 defer해야 함.
+- `<complexity_directive>` 지시는 non-optional. Small 분류에서 3 tasks 초과 / per-function 의사코드 삽입은 gate 리뷰어가 P1으로 잡을 근거가 된다.
 
 **HARNESS FLOW CONSTRAINT**: 이 세션은 orchestrated harness 라이프사이클 내부에서 실행된다. 다음 phase에서 Codex 기반 독립 reviewer가 산출물을 검토한다(gate). 따라서:
 - `advisor()` 툴을 호출하지 말 것. 외부 리뷰가 이미 예약되어 있다.

--- a/src/context/skills/harness-phase-3-plan.md
+++ b/src/context/skills/harness-phase-3-plan.md
@@ -20,15 +20,15 @@ Phase 4에서 Codex가 다음 축으로 평가한다:
 {{/if}}
 
 ## Process
-0. **Respect the complexity signal.** 프롬프트 최상단에 `<complexity_directive>` stanza가 주입되어 있으면 그 지시를 먼저 내재화한다:
+0. **Respect the Complexity Directive block.** 프롬프트 최상단에 harness assembler가 Complexity Directive 블록을 주입했을 수 있다 (Small/Large일 때만 비어있지 않은 블록이 나타나고, Medium이거나 signal이 누락/무효면 블록 자체가 없다). 블록이 존재하면 그 지시를 먼저 내재화한다:
    - **Small** → plan은 최대 3 tasks, per-function 의사코드·ASCII diagram 금지, `checklist.json`은 4개 이하 `checks`로 제한 (typecheck + test + build 조합이 통상 충분). 관련 edit은 한 task로 번들링.
    - **Large** → vertical slice 단위로 분해 + dependency 순서 명시 + architecturally-relevant 결정은 짧은 ADR blurb으로 plan 내 inline 기록. Depth는 표준과 동일.
-   - **Medium / 직접 stanza 없음** → 표준 depth. 추가 제약 없음.
-   spec의 `## Complexity` 값이 assembler의 directive와 일치해야 한다. 불일치·누락 상황이면 Medium으로 fallback한 경고가 stderr에 찍혀있을 것 — `superpowers:writing-plans` 시작 전에 본 stanza를 1회 명시적으로 읽고 반영 계획을 세운 뒤 다음 step으로 진행.
+   - **블록이 없음 (Medium 또는 fallback)** → 표준 depth. 추가 제약 없음.
+   spec의 `## Complexity` 값이 assembler의 directive와 일치해야 한다. 불일치·누락 상황이면 Medium으로 fallback한 경고가 stderr에 찍혀있을 것 — `superpowers:writing-plans` 시작 전에 블록을 1회 명시적으로 읽고 반영 계획을 세운 뒤 다음 step으로 진행.
 1. `superpowers:writing-plans` 스킬을 invoke한다. 다음 오버라이드를 전달한다:
    - `"Save plan to exact path: {{plan_path}} (do not use the skill's default location)"`
    - `"After the plan is written, you MUST ALSO produce a machine-readable eval checklist at {{checklist_path}} (see step 2 below). This is non-negotiable — Phase 6 verify reads it."`
-   - `"Obey the <complexity_directive> stanza injected above (Small → ≤3 tasks; Large → ADR blurbs; Medium → standard). The ceiling on tasks / pseudocode is not a suggestion."`
+   - `"If a Complexity Directive block is injected above (Small → ≤3 tasks; Large → ADR blurbs; no block → standard), obey it. The ceiling on tasks / pseudocode is not a suggestion."`
 2. Eval checklist를 `{{checklist_path}}`에 **정확히 다음 JSON 스키마**로 저장한다:
    ```json
    {
@@ -49,7 +49,7 @@ Phase 4에서 Codex가 다음 축으로 평가한다:
 - plan 파일 경로는 `{{plan_path}}` 고정.
 - checklist JSON 스키마 위반 시 `scripts/harness-verify.sh`가 실패. 스키마 정확히 준수.
 - Plan은 spec의 "Open Questions" 항목을 태스크 레벨에서 해소하거나 명시적으로 defer해야 함.
-- `<complexity_directive>` 지시는 non-optional. Small 분류에서 3 tasks 초과 / per-function 의사코드 삽입은 gate 리뷰어가 P1으로 잡을 근거가 된다.
+- Complexity Directive 블록(있을 경우)의 지시는 non-optional. Small 분류에서 3 tasks 초과 / per-function 의사코드 삽입은 gate 리뷰어가 P1으로 잡을 근거가 된다.
 
 **HARNESS FLOW CONSTRAINT**: 이 세션은 orchestrated harness 라이프사이클 내부에서 실행된다. 다음 phase에서 Codex 기반 독립 reviewer가 산출물을 검토한다(gate). 따라서:
 - `advisor()` 툴을 호출하지 말 것. 외부 리뷰가 이미 예약되어 있다.

--- a/src/phases/interactive.ts
+++ b/src/phases/interactive.ts
@@ -12,6 +12,25 @@ import { assembleInteractivePrompt } from '../context/assembler.js';
 import { runClaudeInteractive } from '../runners/claude.js';
 import { isValidChecklistSchema } from './checklist.js';
 
+/**
+ * Inline Complexity-section check (spec R5). Kept here instead of importing
+ * from assembler.ts so interactive.test.ts's `vi.mock('../context/assembler.js')`
+ * can't wipe it out. Logic mirrors `parseComplexitySignal` in assembler.ts —
+ * if either drifts, the E2E tests in assembler.test.ts should catch it.
+ */
+function specHasValidComplexity(specBody: string): boolean {
+  const headerMatch = specBody.match(/^##\s+Complexity\s*$/m);
+  if (!headerMatch) return false;
+  const offset = (headerMatch.index ?? 0) + headerMatch[0].length;
+  const remainder = specBody.slice(offset);
+  for (const rawLine of remainder.split('\n')) {
+    const line = rawLine.trim();
+    if (line === '') continue;
+    return /^(small|medium|large)\b/i.test(line);
+  }
+  return false;
+}
+
 export interface InteractiveResult {
   status: 'completed' | 'failed';
 }
@@ -124,7 +143,21 @@ export function validatePhaseArtifacts(
       if (!isValidChecklistSchema(checklistPath)) return false;
     }
 
-    // Light + phase 1: checklist schema + '## Implementation Plan' header
+    // Phase 1 (both full + light flows): spec must contain a valid
+    // `## Complexity` section with one of Small/Medium/Large (spec R5).
+    if (phase === 1) {
+      const specPath = path.isAbsolute(state.artifacts.spec)
+        ? state.artifacts.spec
+        : path.join(cwd, state.artifacts.spec);
+      try {
+        const body = fs.readFileSync(specPath, 'utf-8');
+        if (!specHasValidComplexity(body)) return false;
+      } catch {
+        return false;
+      }
+    }
+
+    // Light + phase 1: checklist schema + '## Open Questions' + '## Implementation Plan' headers
     if (state.flow === 'light' && phase === 1) {
       const checklistPath = path.isAbsolute(state.artifacts.checklist)
         ? state.artifacts.checklist

--- a/src/phases/interactive.ts
+++ b/src/phases/interactive.ts
@@ -19,6 +19,10 @@ import { isValidChecklistSchema } from './checklist.js';
  * if either drifts, the E2E tests in assembler.test.ts should catch it.
  */
 function specHasValidComplexity(specBody: string): boolean {
+  // Spec Goal 1: "exactly one `## Complexity` section." Count matches before
+  // reading the body token.
+  const allHeaders = specBody.match(/^##\s+Complexity\s*$/gm);
+  if (!allHeaders || allHeaders.length !== 1) return false;
   const headerMatch = specBody.match(/^##\s+Complexity\s*$/m);
   if (!headerMatch) return false;
   const offset = (headerMatch.index ?? 0) + headerMatch[0].length;

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -20,6 +20,9 @@ import type { HarnessState, PhaseNumber } from './types.js';
 
 /** Inline Complexity-section check (spec R5); mirrors `interactive.ts`. */
 function specHasValidComplexity(specBody: string): boolean {
+  // Spec Goal 1: "exactly one `## Complexity` section." Count matches first.
+  const allHeaders = specBody.match(/^##\s+Complexity\s*$/gm);
+  if (!allHeaders || allHeaders.length !== 1) return false;
   const headerMatch = specBody.match(/^##\s+Complexity\s*$/m);
   if (!headerMatch) return false;
   const offset = (headerMatch.index ?? 0) + headerMatch[0].length;

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -18,6 +18,20 @@ import { getPhaseArtifactFiles } from './config.js';
 import { isValidChecklistSchema } from './phases/checklist.js';
 import type { HarnessState, PhaseNumber } from './types.js';
 
+/** Inline Complexity-section check (spec R5); mirrors `interactive.ts`. */
+function specHasValidComplexity(specBody: string): boolean {
+  const headerMatch = specBody.match(/^##\s+Complexity\s*$/m);
+  if (!headerMatch) return false;
+  const offset = (headerMatch.index ?? 0) + headerMatch[0].length;
+  const remainder = specBody.slice(offset);
+  for (const rawLine of remainder.split('\n')) {
+    const line = rawLine.trim();
+    if (line === '') continue;
+    return /^(small|medium|large)\b/i.test(line);
+  }
+  return false;
+}
+
 /** Create a no-op InputManager for use in resumeRun (deferred refactor: inputManager passed by inner.ts in future). */
 function createNoOpInputManager(): InputManager {
   return new InputManager();
@@ -493,7 +507,21 @@ export function completeInteractivePhaseFromFreshSentinel(
         if (openedAt !== null && Math.floor(stat.mtimeMs) < openedAt) return false;
       }
 
-      // Light + phase 1: checklist schema + '## Implementation Plan' header
+      // Phase 1 (both full + light flows): spec must contain a valid
+      // `## Complexity` section (spec R5).
+      if (phase === 1) {
+        const specAbs = isAbsolute(state.artifacts.spec)
+          ? state.artifacts.spec
+          : join(cwd, state.artifacts.spec);
+        try {
+          const body = readFileSync(specAbs, 'utf-8');
+          if (!specHasValidComplexity(body)) return false;
+        } catch {
+          return false;
+        }
+      }
+
+      // Light + phase 1: checklist schema + '## Open Questions' + '## Implementation Plan' headers
       if (state.flow === 'light' && phase === 1) {
         const checklistAbs = isAbsolute(state.artifacts.checklist)
           ? state.artifacts.checklist

--- a/tests/context/assembler.test.ts
+++ b/tests/context/assembler.test.ts
@@ -524,6 +524,39 @@ describe('complexity signal — Phase 3 prompt injection', () => {
     }
   });
 
+  it('non-ENOENT I/O error from readFileSync propagates (spec R4: only swallow ENOENT)', () => {
+    // Spec R4: "fs.readFileSync(specPath, 'utf-8') (swallow ENOENT → treat as
+    // null parse)." Unexpected read errors (EACCES, EIO, …) must NOT silently
+    // downgrade to Medium — they indicate real infrastructure failure.
+    const tmp = makeTmpDir();
+    const { state, harnessDir } = makePhase3State(
+      tmp,
+      '# Fixture\n\n## Complexity\n\nSmall\n',
+    );
+    const readSpy = vi.spyOn(fs, 'readFileSync').mockImplementation(((
+      ...args: unknown[]
+    ) => {
+      const p = args[0];
+      if (typeof p === 'string' && p.endsWith('fixture-complexity.md')) {
+        const err = new Error('permission denied') as NodeJS.ErrnoException;
+        err.code = 'EACCES';
+        throw err;
+      }
+      // Fall through to the real implementation for template + skill reads.
+      return (fs.readFileSync as unknown as (...a: unknown[]) => unknown).call(
+        fs,
+        ...args,
+      ) as string;
+    }) as typeof fs.readFileSync);
+    try {
+      expect(() => assembleInteractivePrompt(3, state, harnessDir)).toThrow(
+        /permission denied|EACCES/,
+      );
+    } finally {
+      readSpy.mockRestore();
+    }
+  });
+
   it('Phase 1 prompt is NOT affected (directive only injects at Phase 3)', () => {
     const tmp = makeTmpDir();
     const { state, harnessDir } = makePhase3State(
@@ -591,6 +624,19 @@ describe('complexity signal — parser', () => {
     expect(parseComplexitySignal('## Complexity: Small\n\nSmall\n')).toBeNull();
     expect(parseComplexitySignal('## Complexity: Small\n\n')).toBeNull();
   });
+
+  it('returns null when the spec contains two `## Complexity` sections (spec Goal 1: "exactly one")', () => {
+    // Spec Goals item 1: "Phase 1 spec must contain exactly one ## Complexity
+    // section." Duplicate headers — even with identical bodies — are an author
+    // error and must not silently pass.
+    const twoHeaders =
+      '# Title\n\n## Complexity\n\nSmall\n\n## Other\n\n## Complexity\n\nLarge\n';
+    expect(parseComplexitySignal(twoHeaders)).toBeNull();
+
+    const twoHeadersSameBody =
+      '## Complexity\n\nSmall\n\n## Complexity\n\nSmall\n';
+    expect(parseComplexitySignal(twoHeadersSameBody)).toBeNull();
+  });
 });
 
 // ─── Complexity signal: directive builder ─────────────────────────────────────
@@ -636,6 +682,27 @@ describe('complexity signal — directive builder', () => {
     } finally {
       stderrSpy.mockRestore();
     }
+  });
+
+  it('exact-snapshot — Small directive matches spec R3 byte-for-byte (drift guard)', () => {
+    // Spec R3 declares the directive text is normative ("exact directive text
+    // is part of this spec; tests snapshot these strings"). Freeze it.
+    expect(buildComplexityDirective('small')).toBe(
+      '<complexity_directive>\n' +
+        'This task is classified **Small**. Keep the plan to **at most 3 tasks**. ' +
+        'Do not emit per-function pseudocode or ASCII diagrams. Prefer bundling related edits in one task over splitting them. ' +
+        'Keep `checklist.json` to at most 4 `checks` entries — typecheck + test + build is usually enough.\n' +
+        '</complexity_directive>\n',
+    );
+  });
+
+  it('exact-snapshot — Large directive matches spec R3 byte-for-byte (drift guard)', () => {
+    expect(buildComplexityDirective('large')).toBe(
+      '<complexity_directive>\n' +
+        'This task is classified **Large**. Decompose into clear vertical slices with explicit dependency order. ' +
+        'Capture architecturally-relevant decisions as short ADR blurbs inline in the plan. Standard depth otherwise.\n' +
+        '</complexity_directive>\n',
+    );
   });
 
   it('__resetComplexityWarning re-arms the warning', () => {

--- a/tests/context/assembler.test.ts
+++ b/tests/context/assembler.test.ts
@@ -411,6 +411,135 @@ describe('buildGatePromptPhase7 — flow-aware (ADR-12)', () => {
   });
 });
 
+// ─── Complexity signal: Phase 3 assembler wiring ─────────────────────────────
+
+describe('complexity signal — Phase 3 prompt injection', () => {
+  afterEach(() => {
+    __resetComplexityWarning();
+  });
+
+  function writeSpec(repoRoot: string, body: string): string {
+    const relPath = 'docs/specs/fixture-complexity.md';
+    const abs = path.join(repoRoot, relPath);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, body);
+    return relPath;
+  }
+
+  function makePhase3State(repoRoot: string, specBody: string): { state: HarnessState; harnessDir: string } {
+    const specRel = writeSpec(repoRoot, specBody);
+    const state = makeState({
+      phaseAttemptId: { '1': null, '3': 'attempt-phase3-complex', '5': null },
+      artifacts: {
+        spec: specRel,
+        decisionLog: '.harness/my-run/decisions.md',
+        plan: 'docs/plans/fixture.md',
+        checklist: '.harness/my-run/checklist.json',
+        evalReport: 'docs/process/evals/fixture-eval.md',
+      },
+    });
+    // harnessDir resolves spec via join(harnessDir, '..', relPath) → repoRoot
+    const harnessDir = path.join(repoRoot, '.harness');
+    return { state, harnessDir };
+  }
+
+  it('Small spec → Phase 3 prompt contains Small directive stanza', () => {
+    const tmp = makeTmpDir();
+    const { state, harnessDir } = makePhase3State(
+      tmp,
+      '# Fixture\n\n## Complexity\n\nSmall — ~100 LoC CLI\n\n## Rest\n',
+    );
+    const prompt = assembleInteractivePrompt(3, state, harnessDir);
+    expect(prompt).toContain('<complexity_directive>');
+    expect(prompt).toContain('classified **Small**');
+    expect(prompt).toContain('at most 3 tasks');
+  });
+
+  it('Medium spec → Phase 3 prompt has NO directive stanza', () => {
+    const tmp = makeTmpDir();
+    const { state, harnessDir } = makePhase3State(
+      tmp,
+      '# Fixture\n\n## Complexity\n\nMedium\n',
+    );
+    const prompt = assembleInteractivePrompt(3, state, harnessDir);
+    expect(prompt).not.toContain('<complexity_directive>');
+    expect(prompt).not.toContain('classified **Small**');
+    expect(prompt).not.toContain('classified **Large**');
+  });
+
+  it('Large spec → Phase 3 prompt contains Large directive stanza', () => {
+    const tmp = makeTmpDir();
+    const { state, harnessDir } = makePhase3State(
+      tmp,
+      '# Fixture\n\n## Complexity\n\nLarge — multi-file refactor\n',
+    );
+    const prompt = assembleInteractivePrompt(3, state, harnessDir);
+    expect(prompt).toContain('<complexity_directive>');
+    expect(prompt).toContain('classified **Large**');
+    expect(prompt).toContain('vertical slices');
+  });
+
+  it('missing spec file → no directive stanza + single stderr warn', () => {
+    const tmp = makeTmpDir();
+    const state = makeState({
+      phaseAttemptId: { '1': null, '3': 'attempt-phase3-complex', '5': null },
+      artifacts: {
+        spec: 'docs/specs/does-not-exist.md',
+        decisionLog: '.harness/my-run/decisions.md',
+        plan: 'docs/plans/fixture.md',
+        checklist: '.harness/my-run/checklist.json',
+        evalReport: 'docs/process/evals/fixture-eval.md',
+      },
+    });
+    const harnessDir = path.join(tmp, '.harness');
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const prompt = assembleInteractivePrompt(3, state, harnessDir);
+      expect(prompt).not.toContain('<complexity_directive>');
+      const warnCalls = stderrSpy.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && (c[0] as string).includes('Complexity signal'),
+      );
+      expect(warnCalls.length).toBe(1);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it('spec missing the Complexity section → directive empty + warn', () => {
+    const tmp = makeTmpDir();
+    const { state, harnessDir } = makePhase3State(
+      tmp,
+      '# Fixture\n\nNo complexity header anywhere.\n',
+    );
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const prompt = assembleInteractivePrompt(3, state, harnessDir);
+      expect(prompt).not.toContain('<complexity_directive>');
+      const warnCalls = stderrSpy.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && (c[0] as string).includes('Complexity signal'),
+      );
+      expect(warnCalls.length).toBe(1);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it('Phase 1 prompt is NOT affected (directive only injects at Phase 3)', () => {
+    const tmp = makeTmpDir();
+    const { state, harnessDir } = makePhase3State(
+      tmp,
+      '# Fixture\n\n## Complexity\n\nSmall\n',
+    );
+    // Switch attemptId so Phase 1 is callable
+    const phase1State: HarnessState = {
+      ...state,
+      phaseAttemptId: { '1': 'attempt-phase1', '3': null, '5': null },
+    };
+    const prompt = assembleInteractivePrompt(1, phase1State, harnessDir);
+    expect(prompt).not.toContain('<complexity_directive>');
+  });
+});
+
 // ─── Complexity signal: parser ───────────────────────────────────────────────
 
 describe('complexity signal — parser', () => {

--- a/tests/context/assembler.test.ts
+++ b/tests/context/assembler.test.ts
@@ -653,3 +653,71 @@ describe('complexity signal — directive builder', () => {
     }
   });
 });
+
+// ─── Complexity signal: E2E across the three buckets ─────────────────────────
+
+describe('complexity signal — E2E', () => {
+  afterEach(() => {
+    __resetComplexityWarning();
+  });
+
+  function assemblePhase3WithBucket(body: string): string {
+    const tmp = makeTmpDir();
+    const relPath = 'docs/specs/fixture-e2e.md';
+    const abs = path.join(tmp, relPath);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, body);
+    const state = makeState({
+      phaseAttemptId: { '1': null, '3': 'attempt-e2e', '5': null },
+      artifacts: {
+        spec: relPath,
+        decisionLog: '.harness/my-run/decisions.md',
+        plan: 'docs/plans/fixture.md',
+        checklist: '.harness/my-run/checklist.json',
+        evalReport: 'docs/process/evals/fixture-eval.md',
+      },
+    });
+    const harnessDir = path.join(tmp, '.harness');
+    return assembleInteractivePrompt(3, state, harnessDir);
+  }
+
+  it('renders all three buckets with the expected stanza presence + ordering', () => {
+    const small = assemblePhase3WithBucket('# Fixture\n\n## Complexity\n\nSmall\n');
+    __resetComplexityWarning();
+    const medium = assemblePhase3WithBucket('# Fixture\n\n## Complexity\n\nMedium\n');
+    __resetComplexityWarning();
+    const large = assemblePhase3WithBucket('# Fixture\n\n## Complexity\n\nLarge\n');
+
+    // Bucket-specific markers present/absent.
+    expect(small).toContain('classified **Small**');
+    expect(small).toContain('at most 3 tasks');
+    expect(medium).not.toContain('<complexity_directive>');
+    expect(medium).not.toContain('classified **Small**');
+    expect(medium).not.toContain('classified **Large**');
+    expect(large).toContain('classified **Large**');
+    expect(large).toContain('vertical slices');
+
+    // Cross-bucket length regression: Medium (empty directive) is strictly
+    // shorter than both Small and Large (non-empty directives), and the two
+    // non-empty directives are similarly sized.
+    expect(medium.length).toBeLessThan(small.length);
+    expect(medium.length).toBeLessThan(large.length);
+    expect(Math.abs(small.length - large.length)).toBeLessThan(500);
+  });
+
+  it('unknown complexity token falls back to Medium rendering (empty directive + single warn)', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const out = assemblePhase3WithBucket('# Fixture\n\n## Complexity\n\nExtraLarge\n');
+      expect(out).not.toContain('<complexity_directive>');
+      expect(out).not.toContain('classified **Small**');
+      expect(out).not.toContain('classified **Large**');
+      const warnCalls = stderrSpy.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && (c[0] as string).includes('Complexity signal'),
+      );
+      expect(warnCalls.length).toBe(1);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+});

--- a/tests/context/assembler.test.ts
+++ b/tests/context/assembler.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { assembleInteractivePrompt, assembleGatePrompt } from '../../src/context/assembler.js';
+import {
+  assembleInteractivePrompt,
+  assembleGatePrompt,
+  parseComplexitySignal,
+  buildComplexityDirective,
+  __resetComplexityWarning,
+} from '../../src/context/assembler.js';
 import { createInitialState } from '../../src/state.js';
 import type { HarnessState } from '../../src/types.js';
 
@@ -402,5 +408,119 @@ describe('buildGatePromptPhase7 — flow-aware (ADR-12)', () => {
     if (typeof result !== 'string') throw new Error('expected string');
     expect(result).toContain('spec + plan + eval report + diff');
     expect(result).toContain('7-phase harness lifecycle');
+  });
+});
+
+// ─── Complexity signal: parser ───────────────────────────────────────────────
+
+describe('complexity signal — parser', () => {
+  it.each([
+    ['Small', 'small'],
+    ['small', 'small'],
+    ['SMALL', 'small'],
+    ['Medium', 'medium'],
+    ['medium', 'medium'],
+    ['MEDIUM', 'medium'],
+    ['Large', 'large'],
+    ['large', 'large'],
+    ['LARGE', 'large'],
+  ])('case-insensitive token %s → %s', (token, expected) => {
+    const spec = `# Title\n\n## Complexity\n\n${token}\n\n## Next\n`;
+    expect(parseComplexitySignal(spec)).toBe(expected);
+  });
+
+  it.each([
+    ['Small — ~300 LoC single-file CLI', 'small'],
+    ['Medium — touches 8 files', 'medium'],
+    ['Large - major refactor', 'large'],
+  ])('accepts inline rationale after token (%s)', (line, expected) => {
+    const spec = `## Complexity\n\n${line}\n`;
+    expect(parseComplexitySignal(spec)).toBe(expected);
+  });
+
+  it('returns null when section missing', () => {
+    expect(parseComplexitySignal('# Title\n\nJust prose, no Complexity header.\n')).toBeNull();
+  });
+
+  it('returns null when section present but body is empty', () => {
+    expect(parseComplexitySignal('## Complexity\n\n\n## Next\n')).toBeNull();
+  });
+
+  it('returns null for unknown tokens', () => {
+    expect(parseComplexitySignal('## Complexity\n\nExtraLarge\n')).toBeNull();
+    expect(parseComplexitySignal('## Complexity\n\n3\n')).toBeNull();
+  });
+
+  it('skips leading blank lines before the token', () => {
+    expect(parseComplexitySignal('## Complexity\n\n\n\n  \n\nMedium\n')).toBe('medium');
+  });
+
+  it('does not match "## Complexity:" (header must stand alone)', () => {
+    // R2 is strict: `^##\s+Complexity\s*$`. Trailing colon or rationale on the
+    // header line itself is rejected; authors put rationale on the next line.
+    // Neither of these has a bare "## Complexity" header, so both return null.
+    expect(parseComplexitySignal('## Complexity: Small\n\nSmall\n')).toBeNull();
+    expect(parseComplexitySignal('## Complexity: Small\n\n')).toBeNull();
+  });
+});
+
+// ─── Complexity signal: directive builder ─────────────────────────────────────
+
+describe('complexity signal — directive builder', () => {
+  afterEach(() => {
+    __resetComplexityWarning();
+  });
+
+  it('Small emits a non-empty stanza instructing task-count ceiling + no pseudocode', () => {
+    const out = buildComplexityDirective('small');
+    expect(out).toContain('<complexity_directive>');
+    expect(out).toContain('</complexity_directive>');
+    expect(out).toMatch(/classified \*\*Small\*\*/);
+    expect(out).toMatch(/at most 3 tasks/i);
+    expect(out).toMatch(/per-function pseudocode/i);
+    expect(out.endsWith('\n')).toBe(true);
+  });
+
+  it('Large emits a non-empty stanza instructing slice discipline + ADR capture', () => {
+    const out = buildComplexityDirective('large');
+    expect(out).toContain('<complexity_directive>');
+    expect(out).toMatch(/classified \*\*Large\*\*/);
+    expect(out).toMatch(/vertical slices/i);
+    expect(out).toMatch(/ADR/);
+  });
+
+  it('Medium returns empty string (no behavioral drift)', () => {
+    expect(buildComplexityDirective('medium')).toBe('');
+  });
+
+  it('null returns empty string and emits a single stderr warning per process', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      expect(buildComplexityDirective(null)).toBe('');
+      expect(buildComplexityDirective(null)).toBe('');
+      expect(buildComplexityDirective(null)).toBe('');
+      // Only one warn despite 3 calls
+      const warnCalls = stderrSpy.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && (c[0] as string).includes('Complexity signal'),
+      );
+      expect(warnCalls.length).toBe(1);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it('__resetComplexityWarning re-arms the warning', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      buildComplexityDirective(null);
+      __resetComplexityWarning();
+      buildComplexityDirective(null);
+      const warnCalls = stderrSpy.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && (c[0] as string).includes('Complexity signal'),
+      );
+      expect(warnCalls.length).toBe(2);
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 });

--- a/tests/context/skills-rendering.test.ts
+++ b/tests/context/skills-rendering.test.ts
@@ -65,6 +65,26 @@ describe('assembleInteractivePrompt wrapper skill inline', () => {
     expect(prompt).not.toContain('{{plan_path}}');
   });
 
+  it('phase 1 — wrapper instructs brainstormer to emit `## Complexity` section', () => {
+    const state = stubState(tmp);
+    const prompt = assembleInteractivePrompt(1, state, '/tmp/harness');
+    // Process step that tells the brainstormer to add the section.
+    expect(prompt).toContain("'## Complexity' section");
+    // Invariant line that enumerates the accepted enum values.
+    expect(prompt).toMatch(/Small\s*\/\s*Medium\s*\/\s*Large/);
+  });
+
+  it('phase 3 — wrapper references "Complexity Directive block" without leaking the literal tag (regression guard)', () => {
+    const state = stubState(tmp);
+    // Use a state whose spec file does not exist on disk, so the assembler
+    // emits an empty directive — the only `<complexity_directive>` tokens that
+    // should ever appear in the prompt come from the rendered stanza itself,
+    // never from the wrapper skill's prose.
+    const prompt = assembleInteractivePrompt(3, state, '/tmp/harness');
+    expect(prompt).toContain('Complexity Directive');
+    expect(prompt).not.toContain('<complexity_directive>');
+  });
+
   it('phase 5 — inlines harness-phase-5-implement wrapper with playbook refs', () => {
     const state = stubState(tmp);
     const prompt = assembleInteractivePrompt(5, state, '/tmp/harness');

--- a/tests/phases/interactive.test.ts
+++ b/tests/phases/interactive.test.ts
@@ -412,7 +412,7 @@ describe('validatePhaseArtifacts — Phase 1', () => {
     const decPath = path.join(cwd, state.artifacts.decisionLog);
     fs.mkdirSync(path.dirname(specPath), { recursive: true });
     fs.mkdirSync(path.dirname(decPath), { recursive: true });
-    fs.writeFileSync(specPath, '# Spec content');
+    fs.writeFileSync(specPath, '# Spec content\n\n## Complexity\n\nMedium\n');
     fs.writeFileSync(decPath, '# Decisions');
 
     const result = validatePhaseArtifacts(1, state, cwd);
@@ -463,11 +463,55 @@ describe('validatePhaseArtifacts — Phase 1', () => {
     const decPath = path.join(cwd, state.artifacts.decisionLog);
     fs.mkdirSync(path.dirname(specPath), { recursive: true });
     fs.mkdirSync(path.dirname(decPath), { recursive: true });
-    fs.writeFileSync(specPath, '# Spec');
+    fs.writeFileSync(specPath, '# Spec\n\n## Complexity\n\nMedium\n');
     fs.writeFileSync(decPath, '# Decisions');
 
     const result = validatePhaseArtifacts(1, state, cwd);
     expect(result).toBe(false);
+  });
+
+  // ── Complexity validator cases (spec R5: applies to full + light flows) ──
+
+  it('rejects full-flow spec missing the "## Complexity" section', () => {
+    const cwd = makeTmpDir();
+    const state = makeState({
+      phaseOpenedAt: { '1': Math.floor(Date.now() / 1000) * 1000 - 5000, '3': null, '5': null },
+    });
+    const specPath = path.join(cwd, state.artifacts.spec);
+    const decPath = path.join(cwd, state.artifacts.decisionLog);
+    fs.mkdirSync(path.dirname(specPath), { recursive: true });
+    fs.mkdirSync(path.dirname(decPath), { recursive: true });
+    fs.writeFileSync(specPath, '# Spec content\n\nno complexity header\n');
+    fs.writeFileSync(decPath, '# Decisions');
+    expect(validatePhaseArtifacts(1, state, cwd)).toBe(false);
+  });
+
+  it('rejects full-flow spec with invalid Complexity token (e.g. "ExtraLarge")', () => {
+    const cwd = makeTmpDir();
+    const state = makeState({
+      phaseOpenedAt: { '1': Math.floor(Date.now() / 1000) * 1000 - 5000, '3': null, '5': null },
+    });
+    const specPath = path.join(cwd, state.artifacts.spec);
+    const decPath = path.join(cwd, state.artifacts.decisionLog);
+    fs.mkdirSync(path.dirname(specPath), { recursive: true });
+    fs.mkdirSync(path.dirname(decPath), { recursive: true });
+    fs.writeFileSync(specPath, '# Spec\n\n## Complexity\n\nExtraLarge\n');
+    fs.writeFileSync(decPath, '# Decisions');
+    expect(validatePhaseArtifacts(1, state, cwd)).toBe(false);
+  });
+
+  it('accepts full-flow spec with Large bucket + rationale', () => {
+    const cwd = makeTmpDir();
+    const state = makeState({
+      phaseOpenedAt: { '1': Math.floor(Date.now() / 1000) * 1000 - 5000, '3': null, '5': null },
+    });
+    const specPath = path.join(cwd, state.artifacts.spec);
+    const decPath = path.join(cwd, state.artifacts.decisionLog);
+    fs.mkdirSync(path.dirname(specPath), { recursive: true });
+    fs.mkdirSync(path.dirname(decPath), { recursive: true });
+    fs.writeFileSync(specPath, '# Spec\n\n## Complexity\n\nLarge — multi-file refactor\n');
+    fs.writeFileSync(decPath, '# Decisions');
+    expect(validatePhaseArtifacts(1, state, cwd)).toBe(true);
   });
 });
 
@@ -617,7 +661,7 @@ describe('validatePhaseArtifacts — light + phase 1 extras (ADR-13)', () => {
     state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
     state.artifacts.checklist = path.join(tmp, 'checklist.json');
     fs.writeFileSync(state.artifacts.spec,
-      '# T\n## Context & Decisions\n\n## Open Questions\n없음\n\n## Implementation Plan\n- t\n');
+      '# T\n## Context & Decisions\n\n## Complexity\n\nSmall\n\n## Open Questions\n없음\n\n## Implementation Plan\n- t\n');
     fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
     fs.writeFileSync(state.artifacts.checklist,
       JSON.stringify({ checks: [{ name: 'n', command: 'true' }] }));
@@ -631,7 +675,7 @@ describe('validatePhaseArtifacts — light + phase 1 extras (ADR-13)', () => {
     state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
     state.artifacts.checklist = path.join(tmp, 'checklist.json');
     fs.writeFileSync(state.artifacts.spec,
-      '# T\n## Context & Decisions\n\n## Implementation Plan\n- t\n');
+      '# T\n## Context & Decisions\n\n## Complexity\n\nSmall\n\n## Implementation Plan\n- t\n');
     fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
     fs.writeFileSync(state.artifacts.checklist,
       JSON.stringify({ checks: [{ name: 'n', command: 'true' }] }));
@@ -645,7 +689,7 @@ describe('validatePhaseArtifacts — light + phase 1 extras (ADR-13)', () => {
     state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
     state.artifacts.checklist = path.join(tmp, 'checklist.json');
     fs.writeFileSync(state.artifacts.spec,
-      '# T\n## Context & Decisions\n\n## Open Questions\n없음\n');
+      '# T\n## Context & Decisions\n\n## Complexity\n\nSmall\n\n## Open Questions\n없음\n');
     fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
     fs.writeFileSync(state.artifacts.checklist,
       JSON.stringify({ checks: [{ name: 'n', command: 'true' }] }));
@@ -659,9 +703,23 @@ describe('validatePhaseArtifacts — light + phase 1 extras (ADR-13)', () => {
     state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
     state.artifacts.checklist = path.join(tmp, 'checklist.json');
     fs.writeFileSync(state.artifacts.spec,
-      '# T\n## Context & Decisions\n\n## Open Questions\n없음\n\n## Implementation Plan\n- t\n');
+      '# T\n## Context & Decisions\n\n## Complexity\n\nSmall\n\n## Open Questions\n없음\n\n## Implementation Plan\n- t\n');
     fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
     fs.writeFileSync(state.artifacts.checklist, '{"checks":[]}');
+    expect(validatePhaseArtifacts(1, state, tmp)).toBe(false);
+  });
+
+  it('rejects a light combined doc that lacks the "## Complexity" header', () => {
+    const tmp = makeTmpDir();
+    const state = makeState({ flow: 'light', phaseOpenedAt: { '1': 0, '3': null, '5': null } });
+    state.artifacts.spec = path.join(tmp, 'spec.md');
+    state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
+    state.artifacts.checklist = path.join(tmp, 'checklist.json');
+    fs.writeFileSync(state.artifacts.spec,
+      '# T\n## Context & Decisions\n\n## Open Questions\n없음\n\n## Implementation Plan\n- t\n');
+    fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
+    fs.writeFileSync(state.artifacts.checklist,
+      JSON.stringify({ checks: [{ name: 'n', command: 'true' }] }));
     expect(validatePhaseArtifacts(1, state, tmp)).toBe(false);
   });
 });

--- a/tests/resume-light.test.ts
+++ b/tests/resume-light.test.ts
@@ -53,7 +53,7 @@ describe('completeInteractivePhaseFromFreshSentinel — light + phase 1 extras (
     state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
     state.artifacts.checklist = path.join(tmp, 'checklist.json');
     fs.writeFileSync(state.artifacts.spec,
-      '# T\n## Open Questions\n없음\n\n## Implementation Plan\n- t\n');
+      '# T\n## Complexity\n\nSmall\n\n## Open Questions\n없음\n\n## Implementation Plan\n- t\n');
     fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
     fs.writeFileSync(state.artifacts.checklist,
       JSON.stringify({ checks: [{ name: 'n', command: 'true' }] }));
@@ -69,7 +69,7 @@ describe('completeInteractivePhaseFromFreshSentinel — light + phase 1 extras (
     state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
     state.artifacts.checklist = path.join(tmp, 'checklist.json');
     fs.writeFileSync(state.artifacts.spec,
-      '# T\n## Implementation Plan\n- t\n');
+      '# T\n## Complexity\n\nSmall\n\n## Implementation Plan\n- t\n');
     fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
     fs.writeFileSync(state.artifacts.checklist,
       JSON.stringify({ checks: [{ name: 'n', command: 'true' }] }));
@@ -83,7 +83,7 @@ describe('completeInteractivePhaseFromFreshSentinel — light + phase 1 extras (
     state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
     state.artifacts.checklist = path.join(tmp, 'checklist.json');
     fs.writeFileSync(state.artifacts.spec,
-      '# T\n## Open Questions\n없음\n');
+      '# T\n## Complexity\n\nSmall\n\n## Open Questions\n없음\n');
     fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
     fs.writeFileSync(state.artifacts.checklist,
       JSON.stringify({ checks: [{ name: 'n', command: 'true' }] }));
@@ -97,9 +97,23 @@ describe('completeInteractivePhaseFromFreshSentinel — light + phase 1 extras (
     state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
     state.artifacts.checklist = path.join(tmp, 'checklist.json');
     fs.writeFileSync(state.artifacts.spec,
-      '# T\n## Open Questions\n없음\n\n## Implementation Plan\n- t\n');
+      '# T\n## Complexity\n\nSmall\n\n## Open Questions\n없음\n\n## Implementation Plan\n- t\n');
     fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
     fs.writeFileSync(state.artifacts.checklist, '{"checks":[]}');
+    expect(completeInteractivePhaseFromFreshSentinel(1, state, tmp)).toBe(false);
+  });
+
+  it('rejects a light combined doc that lacks the "## Complexity" header', () => {
+    const tmp = makeTmpDir();
+    const state = makeState();
+    state.artifacts.spec = path.join(tmp, 'spec.md');
+    state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
+    state.artifacts.checklist = path.join(tmp, 'checklist.json');
+    fs.writeFileSync(state.artifacts.spec,
+      '# T\n## Open Questions\n없음\n\n## Implementation Plan\n- t\n');
+    fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
+    fs.writeFileSync(state.artifacts.checklist,
+      JSON.stringify({ checks: [{ name: 'n', command: 'true' }] }));
     expect(completeInteractivePhaseFromFreshSentinel(1, state, tmp)).toBe(false);
   });
 });

--- a/tests/resume-light.test.ts
+++ b/tests/resume-light.test.ts
@@ -117,3 +117,64 @@ describe('completeInteractivePhaseFromFreshSentinel — light + phase 1 extras (
     expect(completeInteractivePhaseFromFreshSentinel(1, state, tmp)).toBe(false);
   });
 });
+
+// Full-flow parity for spec R5 ("applies to both full and light flows") and
+// spec R7 ("Validator (phase 1, resume path): same cases, via
+// `completeInteractivePhaseFromFreshSentinel`"). The full flow does not
+// require `## Open Questions` / `## Implementation Plan` / checklist.json at
+// Phase 1 (those are light's combined-doc extras), so we only exercise the
+// Complexity branch here.
+
+describe('completeInteractivePhaseFromFreshSentinel — full + phase 1 Complexity', () => {
+  function makeFullState(overrides: Partial<HarnessState> = {}): HarnessState {
+    const base = createInitialState('test-run', 'task', 'base', false, false, 'full');
+    return {
+      ...base,
+      phaseOpenedAt: { '1': 0, '3': null, '5': null },
+      ...overrides,
+    };
+  }
+
+  it('accepts a full-flow spec with a valid `## Complexity` section', () => {
+    const tmp = makeTmpDir();
+    const state = makeFullState();
+    state.artifacts.spec = path.join(tmp, 'spec.md');
+    state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
+    fs.writeFileSync(state.artifacts.spec, '# T\n\n## Complexity\n\nSmall\n');
+    fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
+    expect(completeInteractivePhaseFromFreshSentinel(1, state, tmp)).toBe(true);
+  });
+
+  it('rejects a full-flow spec that lacks the `## Complexity` header', () => {
+    const tmp = makeTmpDir();
+    const state = makeFullState();
+    state.artifacts.spec = path.join(tmp, 'spec.md');
+    state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
+    fs.writeFileSync(state.artifacts.spec, '# T\n\n## Context & Decisions\n\nNo complexity here.\n');
+    fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
+    expect(completeInteractivePhaseFromFreshSentinel(1, state, tmp)).toBe(false);
+  });
+
+  it('rejects a full-flow spec whose `## Complexity` body token is outside the 3-value enum', () => {
+    const tmp = makeTmpDir();
+    const state = makeFullState();
+    state.artifacts.spec = path.join(tmp, 'spec.md');
+    state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
+    fs.writeFileSync(state.artifacts.spec, '# T\n\n## Complexity\n\nExtraLarge\n');
+    fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
+    expect(completeInteractivePhaseFromFreshSentinel(1, state, tmp)).toBe(false);
+  });
+
+  it('rejects a full-flow spec with duplicate `## Complexity` sections (spec Goal 1: "exactly one")', () => {
+    const tmp = makeTmpDir();
+    const state = makeFullState();
+    state.artifacts.spec = path.join(tmp, 'spec.md');
+    state.artifacts.decisionLog = path.join(tmp, 'decisions.md');
+    fs.writeFileSync(
+      state.artifacts.spec,
+      '# T\n\n## Complexity\n\nSmall\n\n## Other\n\n## Complexity\n\nLarge\n',
+    );
+    fs.writeFileSync(state.artifacts.decisionLog, '# D\n');
+    expect(completeInteractivePhaseFromFreshSentinel(1, state, tmp)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Phase 1 spec authors now emit a `## Complexity` signal (`Small` / `Medium` / `Large`, case-insensitive). Phase 3 assembler parses it and injects a per-bucket directive into the plan-writing prompt: Small caps tasks at 3 + bans per-function pseudocode; Large reinforces slice discipline + ADR capture; Medium preserves today's empty-directive behavior exactly.
- Validator (`validatePhaseArtifacts` in `interactive.ts` + `completeInteractivePhaseFromFreshSentinel` in `resume.ts`) enforces presence + 3-value enum + exactly-one-section for both **full and light** flows.
- Wrapper skills (`harness-phase-1-spec.md`, `harness-phase-3-plan.md`) and the `phase-1-light.md` self-contained template all carry the new requirement; the Phase 3 thin template gains a `{{complexity_directive}}` placeholder.

## Why this change

From `gate-convergence/FOLLOWUPS.md` §P1.4: dogfooding observed a **~500 LOC todo-CLI task producing a 1584-line Phase 3 plan**. The implementer (`sonnet-high` + `superpowers:writing-plans`) applies the same plan depth regardless of task complexity because nothing in the prompt tells it the task is small — per-function pseudocode + micro slices + lengthy eval checklists regardless of scope. This balloons Phase 4 gate review surface, over-decomposes Phase 5 implementation, and inflates Gate 7 diff review.

Rather than heuristically estimating task size from line counts or keyword scans (brittle and adversarial-content-prone), **the author explicitly commits to a coarse complexity bucket in Phase 1**, and the assembler deterministically translates that bucket into a Phase 3 directive. The design spec captures six ADRs covering: explicit-one-liner over heuristics (ADR-1), 3-value enum over continuous scale (ADR-2), 3-state soft-fail on missing/invalid mirroring the `claudeTokens` PR #16 contract (ADR-3), full+light parity (ADR-4), `{{complexity_directive}}` placeholder injection site (ADR-5), and Group A/B coexistence (ADR-6).

## Fallback handling (spec R3 + R4 + ADR-3)

Three-state contract matches the `claudeTokens` precedent:
- **Valid bucket** → non-empty directive stanza (Small/Large) or empty (Medium).
- **Missing section / invalid token / unreadable-via-ENOENT** → empty directive + single `stderr.write` warning per process (`⚠️  Complexity signal missing or invalid in spec …; defaulting to Medium.`).
- **Unexpected I/O error** (EACCES / EIO / …) → rethrown, surfaces as a run failure. Spec R4's "swallow ENOENT → treat as null parse" is strict, not permissive.

Validator (Phase 1 artifact check) is stricter: missing section OR invalid token OR duplicate sections → Phase 1 failure, sentinel rejected. This ensures the spec passes Gate 2 with a valid signal before Phase 3 consumes it; the assembler is a defensive downstream consumer.

## Full + light parity (spec R5 + ADR-4)

Validator check lifted out of the `flow === 'light'` guard in both `interactive.ts` and `resume.ts` so every Phase 1 spec — full or light — needs `## Complexity`. Light flow's self-contained `phase-1-light.md` template adds the header to its required-sections block; full flow gets the requirement via the `harness-phase-1-spec.md` wrapper skill.

## Workflow deviation disclosure

Task brief suggested running `harness start --light` to author spec + plan. Skipped — the spec was already authored manually on this branch before the session started (commit `2bc9ada` predates this session), and re-running `harness start --light` would either duplicate or clobber it. Also: dogfooding the pre-change binary to build this very feature adds no validation. Recorded in `docs/plans/2026-04-19-complexity-signal.md` §Deviations #4.

## Codex gate outcome

Autonomous-mode eval gate:
- **Round 1**: REJECT — 2 P0 ("exactly one" not enforced; Small directive wording drift from R3) + 2 P1 (catch swallowed non-ENOENT; full-flow resume coverage gap). All four addressed in commit `29ddc50`.
- **Round 2**: **APPROVE**, no new findings.

Transcript + round-by-round summary at `.codex-review.md`.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm vitest run` — 662 passed / 1 skipped across 44 files (pre-change baseline 617; +45)
- [x] `pnpm build` — `tsc` clean + `copy-assets.mjs` copied prompts/skills/playbooks/verify.sh
- [x] Exact-text snapshot tests (Small + Large) freeze the directive strings byte-for-byte
- [x] Duplicate-`## Complexity`-section rejection covered in parser + validator (full flow) tests
- [x] Non-ENOENT I/O failure propagates (EACCES `vi.spyOn` test)
- [x] Full-flow + light-flow resume-path `completeInteractivePhaseFromFreshSentinel` parity (4 + 4 cases)

## Notes on commit lineage

Branch history preserves fix-forward lineage (WIP at `04edc0c`, handoff pause at `833fc59`, fix at `a1020e4`, Codex round-1 fix at `29ddc50`). Expected squash-merge at PR close — collapsed commit will reflect the combined feature.