### PR TITLE
feat(config): register full Opus 4.7 + Sonnet 4.6 effort tiers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ Session meta: `~/.harness/sessions/<hash>/<runId>/{events.jsonl, meta.json, summ
 
 | # | 요지 | 심각도 | 상태 |
 |---|---|---|---|
-| 8 | Phase 1 default preset 과중 — 간단한 CLI 한 번에 5.4M 토큰 (2026-04-18 dogfood-full 재측정) | P1 | **부분 해결**: (1) `opus-max` preset id를 `opus-xhigh`로 rename (effort 명시적). (2) PHASE_DEFAULTS[1]·LIGHT_PHASE_DEFAULTS[1]을 `opus-high`로 완화 — xHigh가 기본으로 돌지 않음. `opus-xhigh` preset은 MODEL_PRESETS에 유지되어 수동 선택 가능. `--heavy` CLI flag / 자동 난이도 힌트는 별도 follow-up (FOLLOWUPS.md P1.4). |
+| 8 | Phase 1 default preset 과중 — 간단한 CLI 한 번에 5.4M 토큰 (2026-04-18 dogfood-full 재측정) | P1 | **부분 해결**: (1) PR #22로 legacy `opus-max`(effort=xHigh) id를 `opus-xhigh`로 rename하고, 2026-04-19 PR로 `opus-max`(effort=max)·`sonnet-max`(effort=max) 두 preset을 카탈로그에 **신규 등록** — Opus 4.7의 3-tier(high/xHigh/max) + Sonnet 4.6의 2-tier(high/max) 축을 모두 노출. (2) PHASE_DEFAULTS[1]·LIGHT_PHASE_DEFAULTS[1]은 `opus-high`로 완화된 상태 유지 — max/xHigh는 `promptModelConfig`에서 수동 선택. `--heavy` CLI flag / 자동 난이도 힌트는 별도 follow-up (FOLLOWUPS.md P1.4). |
 | 9 | `printAdvisorReminder` orphan text (control-pane tip이 Claude로 전달 안 됨) | P2 UX | PR #11 `HARNESS FLOW CONSTRAINT`가 `advisor()` 금지로 실질 무효화. **제거 PR 진행 중** (`fix/remove-advisor-reminder`, Group C). |
 | 13 | Codex `HOME` 격리 미도입 — BUG-C alternative fix | P3 | PR #11 `REVIEWER_CONTRACT` scope-rules로 일단 해결. **영구 격리 PR 진행 중** (`feat/codex-home-isolation`, Group D). |
 

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -241,7 +241,19 @@ Focus review on changes within the harness ranges above.
 
 Each interactive phase (1, 3, 5) and each gate phase (2, 4, 7) has a configurable model preset. Phase 6 (automated shell verification) has no AI model. At the start of every `harness run` or `harness resume`, the CLI presents a model-selection UI (via `promptModelConfig()` in `src/ui.ts`) that lets the user assign a preset to each remaining phase before any phase work begins.
 
-Available presets are defined in `MODEL_PRESETS` in `src/config.ts`: `opus-xhigh` (Claude Opus 4.7 / xHigh effort — kept as an opt-in for deliberately heavy specs; renamed from legacy `opus-max`), `opus-high` (Claude Opus 4.7 / high — the default for Phase 1 as of 2026-04-18), `sonnet-high`, `codex-high` (Codex gpt-5.4 / high effort), and `codex-medium`. Default per-phase assignments come from `PHASE_DEFAULTS` in the same file (phase 1 defaults to `opus-high`, phases 3 and 5 to `sonnet-high`, gates 2/4/7 to `codex-high`). The model shown in each phase table above is the default preset; users can override per-phase at run start — select `opus-xhigh` when the task genuinely warrants xHigh reasoning. Selections are persisted in `state.phasePresets` and survive resume; `migrateState()` in `src/state.ts` backfills defaults for older state files that predate the preset system (legacy `opus-max` entries are renamed to `opus-xhigh` on load).
+Available presets are defined in `MODEL_PRESETS` in `src/config.ts`. They cover the full Anthropic 2026-04 effort axes plus a Codex axis:
+
+| id | runner | model | effort |
+|---|---|---|---|
+| `opus-max` | claude | `claude-opus-4-7` | `max` |
+| `opus-xhigh` | claude | `claude-opus-4-7` | `xHigh` |
+| `opus-high` | claude | `claude-opus-4-7` | `high` |
+| `sonnet-max` | claude | `claude-sonnet-4-6` | `max` |
+| `sonnet-high` | claude | `claude-sonnet-4-6` | `high` |
+| `codex-high` | codex | `gpt-5.4` | `high` |
+| `codex-medium` | codex | `gpt-5.4` | `medium` |
+
+Opus 4.7 exposes three distinct tiers (`high < xHigh < max`); Sonnet 4.6 exposes two (`high < max` — there is no xHigh on that axis). Default per-phase assignments come from `PHASE_DEFAULTS` (phase 1 → `opus-high`, phases 3 and 5 → `sonnet-high`, gates 2/4/7 → `codex-high`). The model shown in each phase table above is the default preset; users can override per-phase at run start — pick `opus-xhigh`, `opus-max`, or `sonnet-max` when the task genuinely warrants the extra reasoning. Selections are persisted in `state.phasePresets` and survive resume; `migrateState()` in `src/state.ts` backfills defaults for older state files that predate the preset system. The legacy `opus-max` → `opus-xhigh` rewrite (PR #22) was dropped on 2026-04-19 when `opus-max` became a real max-effort preset — older state.json from before PR #22 that still holds `opus-max` now resumes at the real max tier.
 
 ---
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,11 +8,19 @@ export interface ModelPreset {
   effort: string;
 }
 
+// Model effort axes (per Anthropic 2026-04 guidance):
+//   - Opus 4.7: high < xHigh < max (three distinct tiers)
+//   - Sonnet 4.6: high < max (two tiers; no xHigh)
+// The catalog registers every tier on each axis so users can make explicit
+// cost/quality tradeoffs via `promptModelConfig`. PHASE_DEFAULTS still points
+// at the conservative tier; `max` variants are opt-in.
 export const MODEL_PRESETS: ModelPreset[] = [
-  { id: 'opus-xhigh',   label: 'Claude Opus 4.7 / xHigh',  runner: 'claude', model: 'claude-opus-4-7',   effort: 'xHigh' },
-  { id: 'opus-high',    label: 'Claude Opus 4.7 / high',   runner: 'claude', model: 'claude-opus-4-7',   effort: 'high' },
-  { id: 'sonnet-high',  label: 'Claude Sonnet 4.6 / high', runner: 'claude', model: 'claude-sonnet-4-6', effort: 'high' },
-  { id: 'codex-high',   label: 'Codex / high',             runner: 'codex',  model: 'gpt-5.4',           effort: 'high' },
+  { id: 'opus-max',     label: 'Claude Opus 4.7 / max',    runner: 'claude', model: 'claude-opus-4-7',   effort: 'max'    },
+  { id: 'opus-xhigh',   label: 'Claude Opus 4.7 / xHigh',  runner: 'claude', model: 'claude-opus-4-7',   effort: 'xHigh'  },
+  { id: 'opus-high',    label: 'Claude Opus 4.7 / high',   runner: 'claude', model: 'claude-opus-4-7',   effort: 'high'   },
+  { id: 'sonnet-max',   label: 'Claude Sonnet 4.6 / max',  runner: 'claude', model: 'claude-sonnet-4-6', effort: 'max'    },
+  { id: 'sonnet-high',  label: 'Claude Sonnet 4.6 / high', runner: 'claude', model: 'claude-sonnet-4-6', effort: 'high'   },
+  { id: 'codex-high',   label: 'Codex / high',             runner: 'codex',  model: 'gpt-5.4',           effort: 'high'   },
   { id: 'codex-medium', label: 'Codex / medium',           runner: 'codex',  model: 'gpt-5.4',           effort: 'medium' },
 ];
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -63,13 +63,12 @@ export function migrateState(raw: any): HarnessState {
   if (!raw.phasePresets || typeof raw.phasePresets !== 'object') {
     raw.phasePresets = {};
   }
-  // Legacy rename: 'opus-max' → 'opus-xhigh' (same lineage; id only). Apply
-  // before the unknown-id reset below so existing runs retain user intent.
-  for (const phaseKey of Object.keys(raw.phasePresets)) {
-    if (raw.phasePresets[phaseKey] === 'opus-max') {
-      raw.phasePresets[phaseKey] = 'opus-xhigh';
-    }
-  }
+  // Note: the legacy `opus-max` → `opus-xhigh` migration (PR #22) was dropped
+  // when the catalog re-introduced a real `opus-max` preset pinned to Opus 4.7
+  // effort=`max`. Any state.json from before PR #22 that stored `opus-max`
+  // now resolves to that real max-effort preset (i.e. resume cost may increase
+  // vs. the PR #22 intent of xHigh). Users who want the old xHigh behavior on
+  // resume must explicitly re-select `opus-xhigh` via `promptModelConfig`.
   for (const phase of REQUIRED_PHASE_KEYS) {
     const presetId = raw.phasePresets[phase];
     if (!presetId || !MODEL_PRESETS.find(p => p.id === presetId)) {

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -254,12 +254,23 @@ describe('migrateState', () => {
     expect(migrated.phasePresets['2']).toBe('codex-high');
   });
 
-  it('renames legacy opus-max to opus-xhigh on any phase (same lineage)', () => {
-    const raw = { phasePresets: { '1': 'opus-max', '3': 'sonnet-high', '5': 'opus-max' } };
+  it('preserves opus-max (now a real max-effort preset) across migration', () => {
+    // Post-2026-04-19: 'opus-max' is the Opus 4.7 effort=max preset. Legacy
+    // rewrite-to-opus-xhigh was dropped because it would silently downgrade
+    // new users' explicit `opus-max` selections on resume.
+    const raw = { phasePresets: { '1': 'opus-max', '3': 'sonnet-high', '5': 'opus-xhigh' } };
     const migrated = migrateState(raw);
-    expect(migrated.phasePresets['1']).toBe('opus-xhigh');
+    expect(migrated.phasePresets['1']).toBe('opus-max');
     expect(migrated.phasePresets['3']).toBe('sonnet-high');
     expect(migrated.phasePresets['5']).toBe('opus-xhigh');
+  });
+
+  it('preserves sonnet-max and opus-xhigh as distinct effort tiers', () => {
+    const raw = { phasePresets: { '1': 'opus-xhigh', '3': 'sonnet-max', '5': 'sonnet-max' } };
+    const migrated = migrateState(raw);
+    expect(migrated.phasePresets['1']).toBe('opus-xhigh');
+    expect(migrated.phasePresets['3']).toBe('sonnet-max');
+    expect(migrated.phasePresets['5']).toBe('sonnet-max');
   });
 
   it('backfills lastWorkspacePid and phaseReopenFlags', () => {


### PR DESCRIPTION
## Summary

- Opus 4.7 exposes **three** effort tiers (`high < xHigh < max`) and Sonnet 4.6 exposes **two** (`high < max`). Prior to this PR the catalog only registered `opus-high`/`opus-xhigh`/`sonnet-high`, so `max` on either axis was unreachable and PR #22's `opus-max → opus-xhigh` rename blurred the id-to-effort mapping.
- Add `opus-max` (effort=`max`) and `sonnet-max` (effort=`max`) presets. Catalog now fully covers both Anthropic axes plus the existing Codex axis.
- Drop the legacy `opus-max` → `opus-xhigh` migration from `migrateState`. Re-introducing `opus-max` as a real max-effort preset meant the shim would silently downgrade explicit user selections on resume. Pre-#22 state.json resumes now land on the real max tier (more expensive — dogfood context, acceptable tradeoff).
- `PHASE_DEFAULTS` / `LIGHT_PHASE_DEFAULTS` unchanged — max variants stay opt-in via `promptModelConfig`.

## Preset catalog (post-PR)

| id | runner | model | effort |
|---|---|---|---|
| `opus-max` | claude | `claude-opus-4-7` | `max` |
| `opus-xhigh` | claude | `claude-opus-4-7` | `xHigh` |
| `opus-high` | claude | `claude-opus-4-7` | `high` |
| `sonnet-max` | claude | `claude-sonnet-4-6` | `max` |
| `sonnet-high` | claude | `claude-sonnet-4-6` | `high` |
| `codex-high` | codex | `gpt-5.4` | `high` |
| `codex-medium` | codex | `gpt-5.4` | `medium` |

## Docs updated

- `docs/HOW-IT-WORKS.md` — Model Selection section gets full catalog table + axis explanation.
- `CLAUDE.md` — issue #8 row reflects the new tier registration.

## Test plan

- [x] `pnpm tsc --noEmit` — clean.
- [x] `pnpm vitest run` — **618 passed / 1 skipped** (baseline 617 → +1 for the new `sonnet-max` preservation test).
- [x] `pnpm build` — dist regenerated (copy-assets step included).
- [x] `tests/state.test.ts` migration coverage — legacy-rename case replaced by two preservation cases (`opus-max` as real max, `sonnet-max` round-trip).