### PR TITLE
fix(logger): accumulate gate_error.tokensTotal into summary.json (P3.1)

### DIFF
--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -116,47 +116,6 @@ watchdog: if `phase_start` fired >30s ago without activity, control
 pane prints "No output yet? Check the Claude window (`C-b 1`) — may be
 waiting on folder-trust."
 
-## Open — Priority 3
-
-### P3.1  `summary.json` gate token total does not include `gate_error.tokensTotal`
-
-Carried forward from the control-pane footer PR (P2.1 implementation,
-2026-04-19). The footer aggregator intentionally counts
-`gate_error.tokensTotal` in the displayed live total because users
-care about spend that actually happened, including on gate runs that
-errored. `FileSessionLogger.finalizeSummary` at
-`src/logger.ts:218-220`, however, only increments `gateErrors++` on
-`gate_error` and never adds `e.tokensTotal` to the persisted
-`summary.json.totals.gateTokens`. The result is a known, documented
-divergence between the live footer and the post-run summary on runs
-that experience any gate error.
-
-Reconciliation is out of scope for the footer PR — touching
-`finalizeSummary` would change a persisted artifact shape and needs
-its own spec/plan/gate pass. Spec ref:
-`docs/specs/2026-04-19-control-pane-counters-design.md` §3.6.1
-("Intentional divergence from `summary.json.totals.gateTokens` — NOT
-a consistency guarantee").
-
-Proposed change (separate PR):
-1. Add `tokensTotal` accumulation alongside `gateErrors++` in
-   `src/logger.ts:218-220`, guarded by the same
-   `recoveredFromSidecar` + `authoritativeErrors` dedup as
-   `gate_verdict`.
-2. Update `tests/logger.test.ts` sidecar-replay expectations so the
-   summary total now includes `gate_error.tokensTotal` (single-count).
-3. Once landed, tighten the footer aggregator comment in
-   `src/metrics/footer-aggregator.ts` to drop the "intentional
-   divergence" note, and update spec §3.6.1 accordingly (or supersede
-   with a new ADR).
-
-The sidecar dedup semantics from spec §3.6.1 must remain intact when
-the follow-up lands — the goal is to converge the two totals, not to
-remove the dedup.
-
-Tracking: issue number TBD — open post-merge and link here and in the
-footer PR body once the PR is in the tree.
-
 ## Context / provenance
 
 - All observations were produced by a single dogfood-full run on

--- a/docs/specs/2026-04-19-control-pane-counters-design.md
+++ b/docs/specs/2026-04-19-control-pane-counters-design.md
@@ -83,7 +83,7 @@ Task prescribes polling; polling at 1 Hz is sufficient and simpler. `fs.readFile
    - `authoritativeErrors`: `Set<phase>` for `gate_error`.
 2. Second pass (token accumulation): for a `gate_verdict` with `recoveredFromSidecar === true`, skip if the key is already in `authoritativeVerdicts`. For `gate_error` with `recoveredFromSidecar === true`, skip if `phase` is in `authoritativeErrors`.
 
-**Intentional divergence from `summary.json.totals.gateTokens` — NOT a consistency guarantee.** `src/logger.ts:218–220` currently increments `gateErrors++` on `gate_error` but does **not** add `e.tokensTotal` to `gateTokens`. The footer counts `gate_error.tokensTotal` (it's spend that occurred and users care about live cost tracking) while `finalizeSummary` does not. The two totals will therefore differ on runs that experience a `gate_error`. This is a known pre-existing asymmetry in `finalizeSummary`; reconciling it is **out of scope** for this spec (recorded as a plan TODO per the round-2 gate feedback). The dedup rule above still applies so sidecar replay does not double-count either side.
+**Converges with `summary.json.totals.gateTokens` (as of P3.1 follow-up).** `src/logger.ts` now accumulates `gate_error.tokensTotal` into `summary.json.totals.gateTokens` using the same `authoritativeErrors` sidecar dedup as the footer. The two totals are therefore symmetric on both healthy and error-containing runs.
 
 ### 3.7 Current phase + attempt (hybrid — state.json + events)
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -220,6 +220,7 @@ export class FileSessionLogger implements SessionLogger {
         } else if (e.event === 'gate_error') {
           if (e.recoveredFromSidecar && seenErrorPhases.has(e.phase)) continue;
           gateErrors++;
+          if (e.tokensTotal) gateTokens += e.tokensTotal;
         } else if (e.event === 'escalation') {
           escalations++;
         } else if (e.event === 'force_pass') {

--- a/src/metrics/footer-aggregator.ts
+++ b/src/metrics/footer-aggregator.ts
@@ -243,7 +243,6 @@ function getTokenTotals(events: LogEvent[]): { claudeTokens: number; gateTokens:
       if (event.recoveredFromSidecar === true && authoritativeErrors.has(event.phase)) {
         continue;
       }
-      // Intentional divergence from summary.json.totals.gateTokens — NOT a consistency guarantee.
       if (typeof event.tokensTotal === 'number') {
         gateTokens += event.tokensTotal;
       }

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -313,13 +313,33 @@ describe('FileSessionLogger.finalizeSummary', () => {
     const sessionsRoot = path.join(harnessDir, 'sessions-root');
     const logger = new FileSessionLogger('runK', harnessDir, { sessionsRoot });
     logger.writeMeta({ task: 't' });
-    logger.logEvent({ event: 'gate_error', phase: 2, retryIndex: 0, runner: 'codex', error: 'boom', durationMs: 5000, recoveredFromSidecar: false });
-    logger.logEvent({ event: 'gate_error', phase: 2, retryIndex: 0, runner: 'codex', error: 'boom', durationMs: 5000, recoveredFromSidecar: true });
+    logger.logEvent({ event: 'gate_error', phase: 2, retryIndex: 0, runner: 'codex', error: 'boom', durationMs: 5000, tokensTotal: 12000, recoveredFromSidecar: false });
+    logger.logEvent({ event: 'gate_error', phase: 2, retryIndex: 0, runner: 'codex', error: 'boom', durationMs: 5000, tokensTotal: 12000, recoveredFromSidecar: true });
     const state = { status: 'completed', autoMode: false } as HarnessState;
     logger.finalizeSummary(state);
     const repoKey = computeRepoKey(harnessDir);
     const summary = JSON.parse(fs.readFileSync(path.join(sessionsRoot, repoKey, 'runK', 'summary.json'), 'utf-8'));
     expect(summary.totals.gateErrors).toBe(1);
+    expect(summary.totals.gateTokens).toBe(12000);
+  });
+
+  it('accumulates gate_error.tokensTotal into gateTokens (sidecar-only event still counts when no authoritative exists)', () => {
+    const harnessDir = makeTempHarnessDir();
+    const sessionsRoot = path.join(harnessDir, 'sessions-root');
+    const logger = new FileSessionLogger('runP31', harnessDir, { sessionsRoot });
+    logger.writeMeta({ task: 't' });
+    // Phase 2: authoritative with tokensTotal=12000 → counted once
+    logger.logEvent({ event: 'gate_error', phase: 2, retryIndex: 0, runner: 'codex', error: 'boom', durationMs: 5000, tokensTotal: 12000, recoveredFromSidecar: false });
+    // Phase 4: sidecar-only (no authoritative) with tokensTotal=8000 → counted
+    logger.logEvent({ event: 'gate_error', phase: 4, retryIndex: 0, runner: 'codex', error: 'fail', durationMs: 3000, tokensTotal: 8000, recoveredFromSidecar: true });
+    // Phase 7: authoritative with no tokensTotal field → contributes 0, does not NaN
+    logger.logEvent({ event: 'gate_error', phase: 7, retryIndex: 0, runner: 'codex', error: 'oops', durationMs: 2000, recoveredFromSidecar: false });
+    const state = { status: 'completed', autoMode: false } as HarnessState;
+    logger.finalizeSummary(state);
+    const repoKey = computeRepoKey(harnessDir);
+    const summary = JSON.parse(fs.readFileSync(path.join(sessionsRoot, repoKey, 'runP31', 'summary.json'), 'utf-8'));
+    expect(summary.totals.gateErrors).toBe(3);
+    expect(summary.totals.gateTokens).toBe(20000);
   });
 
   it('renameSync failure warns once but does NOT disable logger (retry on next phase per §6.1)', () => {


### PR DESCRIPTION
## Summary

- `summary.json.totals.gateTokens`가 `gate_error.tokensTotal`을 누락하여 control-pane live footer와 post-run summary가 gate error가 발생한 run에서 수치 차이가 나던 문제 해결.
- `finalizeSummary`의 `gate_error` 분기가 `gate_verdict`와 동일한 `authoritativeErrors` 기반 sidecar dedup을 적용하면서 `e.tokensTotal`을 누적. 양쪽 총합이 수렴.
- 스펙 §3.6.1의 "Intentional divergence — NOT a consistency guarantee" 문단을 "Converges" 선언으로 대체. footer aggregator의 divergence 코멘트도 제거.

## Changes

| 파일 | 변경 |
|---|---|
| `src/logger.ts` | `gate_error` 분기에 `if (e.tokensTotal) gateTokens += e.tokensTotal` 추가 (기존 `gateErrors++` 옆) |
| `src/metrics/footer-aggregator.ts` | "Intentional divergence" 코멘트 1줄 제거 |
| `docs/specs/2026-04-19-control-pane-counters-design.md` §3.6.1 | 수렴 완료 선언으로 재작성 |
| `tests/logger.test.ts` | 기존 sidecar dedup 테스트에 `tokensTotal` 필드 + `gateTokens` assertion 추가; 신규 multi-phase accumulation 테스트 (authoritative + sidecar-only + no-tokensTotal 커버) |
| `FOLLOWUPS.md` | §P3.1 제거 (닫힘) |

Sidecar dedup semantic은 그대로 유지 — goal은 "두 총합 수렴", not "dedup 제거".

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm vitest run tests/logger.test.ts` — 32/32 pass (신규 accumulation 테스트 포함)
- [x] `pnpm vitest run tests/metrics/footer-aggregator.test.ts` — 11/11 pass (footer 코멘트 제거가 로직 영향 없음 확인)
- [x] `pnpm vitest run` 전체 — 788 passed / 1 skipped (baseline 787 + 1 신규)
- [x] `pnpm build` — dist 정상 생성