### PR TITLE
Support multiline paste in the control-panel task prompt

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,37 +1,111 @@
 # harness-cli
 
-AI 에이전트 개발 프로세스의 7단계 라이프사이클을 오케스트레이션하는 TypeScript CLI입니다: 브레인스토밍 → spec gate → plan → plan gate → 구현 → verify → eval gate.
+`harness-cli`는 AI 기반 개발 작업을 **재현 가능하고 재개 가능한 tmux 워크플로우**로 실행하는 TypeScript CLI입니다.
 
-각 phase는 **tmux 세션** 안의 독립된 서브프로세스에서 실행됩니다. Interactive phase(Claude Code)는 각각 별도의 tmux window에서 실행되고, gate review(Codex companion)와 verify(shell script)는 control window에서 실행됩니다. tmux window 0의 control panel이 실시간으로 phase 상태를 보여주면서 Claude는 인접 window에서 작업합니다. Phase 간 컨텍스트는 파일로 전달되고 세션은 공유하지 않으므로, 컨텍스트 팽창 문제와 self-review bias가 원천적으로 해결됩니다.
+지원 기능:
+- **7단계 full flow**: spec → spec gate → plan → plan gate → implement → verify → eval gate
+- 작은 작업을 위한 **4단계 light flow**: design+plan → implement → verify → eval gate
+- 시작/재개 시점의 **phase별 모델 preset 선택**
+- `resume`, `status`, `list`, `skip`, `jump`를 통한 **tmux 기반 복구/제어**
+- **선택적 세션 로깅**과 경과 시간·토큰 수를 보여주는 live footer
 
-CLI가 세션 바깥에서 phase lifecycle을 관리합니다. Atomic `state.json` 쓰기로 crash-safe 상태를 보장하고, atomic handoff(outer → inner 프로세스)가 포함된 두 단계 파일 락으로 동시 실행을 방지합니다. `resume` / `jump` / `skip` 명령으로 중단 지점에서 재개할 수 있습니다.
+하나의 긴 채팅 세션을 계속 끌고 가는 대신, harness는 파일과 상태를 통해 phase 간 컨텍스트를 넘깁니다. 그래서 각 phase를 깨끗하게 다시 시작할 수 있고, 독립 리뷰 단계도 구현 세션의 문맥을 그대로 물려받지 않습니다.
+
+---
+
+## 각 phase에서 실제로 무엇이 실행되나
+
+기본값은 다음과 같습니다:
+- interactive phase(1 / 3 / 5) → **Claude** preset
+- review gate(2 / 4 / 7) → **Codex** preset
+- phase 6 → 번들된 **`harness-verify.sh`** 스크립트
+
+이 기본값은 런타임에 바꿀 수 있습니다. `harness start` / `harness resume`를 실행할 때마다, 남아 있는 non-verify phase들에 대해 모델 preset 선택 UI가 먼저 뜹니다.
+
+현재 내장 preset:
+- `opus-max`, `opus-xhigh`, `opus-high`
+- `sonnet-max`, `sonnet-high`
+- `codex-high`, `codex-medium`
+
+기본 phase 매핑:
+- Phase 1 → `opus-high`
+- Phase 2 → `codex-high`
+- Phase 3 → `sonnet-high`
+- Phase 4 → `codex-high`
+- Phase 5 → `sonnet-high`
+- Phase 7 → `codex-high`
+
+---
+
+## Full flow와 light flow
+
+### Full flow (`harness start "task"`)
+
+```text
+P1 spec → P2 spec gate → P3 plan → P4 plan gate → P5 implement → P6 verify → P7 eval gate
+```
+
+마이그레이션, API/contract 변경, 보안 민감 작업처럼 **구현 전에 독립 리뷰가 중요한 경우** full flow가 적합합니다.
+
+### Light flow (`harness start --light "task"`)
+
+```text
+P1 design+plan → P5 implement → P6 verify → P7 eval gate
+```
+
+light flow에서는:
+- **2 / 3 / 4 phase**가 `skipped` 상태로 처리됩니다
+- phase 1이 `## Complexity`, `## Open Questions`, `## Implementation Plan`이 들어간 결합 문서를 만들어야 합니다
+- phase 7 피드백이 구현 범위면 **phase 5**, 설계/혼합 범위면 **phase 1**을 다시 엽니다
+- light flow의 gate retry 한도는 **5**이고, full flow는 **3**입니다
+- flow는 run 생성 시점에 고정되므로 `harness resume --light`는 거부됩니다
+
+---
+
+## tmux 안에서의 실행 구조
+
+Harness는 tmux 안에 **pane 기반 control surface**를 만듭니다:
+- **control pane**: 현재 phase, retry, gate/verify 출력, escalation 메뉴
+- **workspace pane**: 현재 interactive agent 세션
+
+실행 위치에 따라 동작이 달라집니다:
+- **tmux 밖에서 시작**: `harness-<runId>` 이름의 dedicated session 생성
+- **tmux 안에서 시작**: 현재 tmux session을 재사용하고 `harness-ctrl` window 생성
+
+macOS에서는 가능한 경우 **iTerm2 → Terminal.app** 순서로 세션을 자동으로 엽니다.
+Linux이거나 AppleScript 실행이 실패하면, 아래처럼 수동 attach 명령만 출력합니다:
+
+```bash
+tmux attach -t harness-<runId>
+```
 
 ---
 
 ## 사전 요구사항
 
-CLI 사용 전에 아래 의존성을 설치해야 합니다 (preflight에서 모두 검사합니다):
+Harness는 git working tree를 기준으로 동작하며, phase 경계에서 artifact를 자동 커밋합니다.
+먼저 아래를 준비하세요:
 
-| 의존성 | 용도 | 설치 방법 |
-|--------|------|-----------|
-| **Node.js ≥ 18** | CLI와 Codex companion 실행 | [nodejs.org](https://nodejs.org) |
-| **pnpm** | 패키지 매니저 | `npm install -g pnpm` |
-| **git** | 필수. 대상 프로젝트는 최소 1개 commit이 있는 git repo여야 함 | macOS/Linux 기본 제공 |
-| **Claude Code CLI** (`claude`) | Phase 1/3/5 interactive 실행 | [claude.ai/code](https://claude.ai/code) |
-| **Codex companion** | Phase 2/4/7 gate review 실행. `~/.claude/plugins/cache/openai-codex/codex/*/scripts/codex-companion.mjs` 경로를 자동 탐색 | `openai-codex` Claude 플러그인 설치 |
-| **harness-verify.sh** | Phase 6 자동 검증. `~/.claude/scripts/harness-verify.sh`에 위치해야 함 | skill 배포판에서 복사 |
-| **jq** | `harness-verify.sh`가 `checklist.json` 파싱에 사용 | `brew install jq` / `apt install jq` |
-| **tmux** | Control panel과 Claude window 호스팅 | `brew install tmux` / `apt install tmux` |
+| 의존성 | 필요한 이유 |
+|---|---|
+| Node.js 18+ | CLI 런타임 |
+| tmux | 세션 / pane 오케스트레이션 |
+| Claude Code CLI (`claude`) | 기본 interactive runner |
+| Codex CLI (`codex`) | 기본 gate runner, 그리고 선택 가능한 interactive runner |
+| `jq` | phase 6 verify의 checklist 파싱 |
+| Git | commit anchor, diff, artifact commit |
+| Interactive TTY | start/resume 시 모델 선택 UI와 escalation UI |
 
-**플랫폼**: macOS 전용. iTerm2를 우선 사용하며 Terminal.app으로 폴백합니다. Linux 지원은 scope 밖입니다.
-
-**터미널**: CLI가 tmux 세션을 위한 새 iTerm2(또는 Terminal.app) 창을 엽니다. 원래 터미널은 즉시 반환됩니다. 에스컬레이션 메뉴는 tmux control window 안에서 실행되므로 TTY가 항상 보장됩니다.
+참고:
+- 지원 플랫폼은 **macOS와 Linux**입니다.
+- verify script는 먼저 설치된 패키지 내부 경로에서 찾고, 없으면 `~/.claude/scripts/harness-verify.sh`를 레거시 fallback으로 사용합니다.
+- interactive phase를 Codex preset으로 바꾸면, 해당 phase도 Codex CLI로 실행됩니다.
 
 ---
 
 ## 설치
 
-Repo를 클론하고 전역으로 link합니다:
+로컬 개발 기준 설치:
 
 ```bash
 git clone <repo-url> harness-cli
@@ -41,15 +115,15 @@ pnpm run build
 pnpm link --global
 ```
 
-Link 이후에는 어느 디렉토리에서나 `harness` 명령을 사용할 수 있습니다.
+이후 `harness` 명령을 전역에서 사용할 수 있습니다.
 
-소스 코드를 수정한 뒤에는 rebuild만 하면 전역 명령에 즉시 반영됩니다:
+소스 변경 후 재빌드:
 
 ```bash
 pnpm run build
 ```
 
-제거할 때:
+전역 링크 제거:
 
 ```bash
 pnpm unlink --global harness-cli
@@ -57,211 +131,184 @@ pnpm unlink --global harness-cli
 
 ---
 
-## 사용법
+## 빠른 시작
 
-모든 명령은 **대상 git 프로젝트**에서 실행합니다 (`harness-cli` repo 자체에서 실행하지 않음):
+대상 프로젝트 루트에서 실행하세요. `.harness/` 위치를 따로 두고 싶으면 `--root`를 사용하면 됩니다.
 
 ```bash
 cd /path/to/your/project
 harness --help
 ```
 
-### 새 run 시작
+새 run 시작:
 
 ```bash
-harness run "사용자 인증 기능이 포함된 GraphQL API 추가"
+harness start "사용자 인증 기능이 포함된 GraphQL API 추가"
+# 동일: harness run "사용자 인증 기능이 포함된 GraphQL API 추가"
 ```
 
-이 명령은 **tmux 세션**을 생성하고 새 iTerm2 창에서 엽니다. 원래 터미널은 즉시 반환됩니다.
+task를 생략하면 control pane 안에서 직접 입력받습니다.
+이 control pane 입력은 일반 `Enter=제출` 동작을 유지하면서도 **멀티라인 붙여넣기**를 지원합니다.
 
-tmux 세션 내부:
-- **Window 0 (control panel)**: 실시간 phase 상태, gate/verify 스트리밍 로그, 에스컬레이션 메뉴 표시
-- **Window N (phase-N)**: Claude가 phase별로 별도 window에서 interactive 실행
-
-Control panel에 현재 활성 phase가 표시됩니다. `Ctrl-B 0`(control)과 `Ctrl-B 1`(Claude) 으로 window를 전환합니다.
-
-Phase 1(브레인스토밍)이 자동 시작됩니다. Claude가 질문을 주고받으며 아래 파일을 작성합니다:
-
-- `docs/specs/<runId>-design.md` — 설계 스펙 문서
-- `.harness/<runId>/decisions.md` — Decision Log
-
-Phase 1 완료 시 Claude window가 자동으로 닫히고, control panel로 포커스가 이동하며, CLI가 다음 단계를 순차 실행합니다:
-
-- **Phase 2**: Codex가 spec을 리뷰 (진행 상황이 control panel에 스트리밍) → `APPROVE` 또는 `REJECT`
-- **Phase 3**: Claude가 새 tmux window에서 구현 계획 작성 → `docs/plans/<runId>.md` + `.harness/<runId>/checklist.json`
-- **Phase 4**: Codex가 spec + plan 리뷰
-- **Phase 5**: Claude가 새 tmux window에서 구현 (종료 전 반드시 git commit)
-- **Phase 6**: `harness-verify.sh`가 checklist 실행 (출력이 control panel에 스트리밍) → `docs/process/evals/<runId>-eval.md`
-- **Phase 7**: Codex가 전체 리뷰 (spec + plan + eval report + diff)
-
-### `harness run` 플래그
-
-```bash
-harness run "태스크" --allow-dirty   # 시작 시 unstaged/untracked 변경 허용 (staged는 여전히 차단)
-harness run "태스크" --auto          # 자율 모드: 에스컬레이션 메뉴 없이 한도 초과 시 강제 통과
-harness run "태스크" --root <dir>    # git root 대신 <dir>/.harness/ 사용
-```
-
-**이미 tmux 안에서 실행 중인 경우?** CLI가 `$TMUX` 환경변수를 감지하여 새 터미널을 열지 않고 현재 세션에 window를 생성합니다. tmux-in-tmux 문제가 발생하지 않습니다.
-
-```bash
-# 기존 tmux 세션 안에서:
-harness run "태스크"   # 현재 세션에 'harness-ctrl' window 생성
-```
-
-### Run 재개
-
-터미널 창을 닫아도 tmux 세션은 살아있습니다. 다시 연결하세요:
-
-```bash
-harness resume                       # 현재 run 재개 (.harness/current-run 포인터 기준)
-harness resume 2026-04-12-graphql-api   # 특정 runId 재개
-```
-
-Resume은 세 가지 경우를 자동으로 처리합니다:
-1. **세션 + inner 모두 살아있음** — 기존 tmux 세션에 재연결 (iTerm2 창 열기)
-2. **세션은 살아있지만 inner가 죽음** — 기존 tmux 세션 안에서 phase loop 재시작
-3. **세션 없음** — 새 tmux 세션을 생성하고 저장된 체크포인트에서 phase loop 시작
-
-Pending action(`skip`/`jump`)은 재시작 시 자동으로 소비됩니다.
-
-### 상태 확인
-
-```bash
-harness status     # 현재 phase, artifact, retry 횟수, pendingAction 출력
-harness list       # 이 repo의 모든 run과 상태를 나열
-```
-
-`status`와 `list`는 read-only 명령이며 TTY 없이도 동작하므로 CI/pipeline에서도 사용 가능합니다.
-
-### 진행 강제
-
-```bash
-harness skip                  # 현재 phase를 강제 통과 (예: 재리뷰 사이클 건너뛰기)
-harness jump 3                # 역방향 jump — Phase 3로 되돌아가서 재실행
-```
-
-이들은 **control-plane 명령**입니다 — lock을 획득하지 않습니다. 대신:
-- Inner 프로세스가 실행 중인 경우: `pending-action.json` 파일을 기록하고 inner 프로세스에 `SIGUSR1`을 전송합니다. 활성 Claude window가 종료되고 phase loop가 새 phase에서 재진입합니다.
-- Inner 프로세스가 없는 경우: `pending-action.json`에 action을 저장하고 다음 `harness resume`에서 소비합니다.
-
-`jump`는 **backward 전용**입니다 (N이 현재 phase보다 작아야 하거나, run이 completed 상태여야 함).
+일반적인 순서:
+1. `.harness/`를 찾거나 생성
+2. tmux control surface 생성
+3. 남은 phase에 대한 모델 preset 선택
+4. phase 1(또는 resume 시 저장된 phase) 시작
 
 ---
 
-## 일반적인 워크플로우
+## 명령어 레퍼런스
+
+### `harness start [task]`
+
+새 run을 시작합니다.
 
 ```bash
-# 1. Clean git repo에서 시작
-cd ~/projects/my-app
-git status   # clean해야 함
-
-# 2. Run 시작 — tmux 세션이 담긴 새 iTerm2 창이 열림
-harness run "설정 페이지에 다크모드 토글 추가"
-# 원래 터미널은 즉시 반환됨. 작업은 새 창에서 진행.
-
-# 3. tmux 세션 안에서:
-#    - Ctrl-B 0 → control panel (phase 상태, gate 로그)
-#    - Ctrl-B 1 → 활성 Claude window
-#    Codex가 spec을 reject하면 Claude가 피드백과 함께 자동 재오픈.
-#    3회 reject되면 control panel에 에스컬레이션 메뉴 표시.
-
-# 4. iTerm2 창을 닫아도 tmux 세션은 살아있음
-harness status   # 현재 위치 확인 (read-only, 아무 터미널에서 가능)
-harness resume   # 실행 중인 tmux 세션에 재연결
-
-# 5. 세션이 실행 중인 동안 다른 터미널에서 skip/jump 가능:
-harness skip     # SIGUSR1 전송 → 현재 phase 강제 통과
-harness jump 3   # SIGUSR1 전송 → Phase 3로 리셋
+harness start "task"
+harness run "task"                  # alias
+harness start --light "task"
+harness start --require-clean "task"
+harness start --enable-logging "task"
+harness start --root /tmp/demo "task"
 ```
+
+플래그:
+- `--require-clean` — working tree에 uncommitted change가 하나라도 있으면 차단
+- `--auto` — escalation 처리 시 autonomous mode 사용
+- `--enable-logging` — `~/.harness/sessions/...` 아래에 세션 로그 저장
+- `--light` — 4단계 light flow 사용
+- `--codex-no-isolate` — Codex subprocess의 per-run `CODEX_HOME` isolation 비활성화; 권장하지 않음
+- `--strict-tree` — phase 5 dirty-tree auto-recovery를 끄고 diagnostic만 남김
+- 전역 `--root <dir>` — harness root를 `<dir>/.harness`로 강제
+
+중요 동작:
+- 기본적으로 unstaged/untracked 변경은 허용됩니다
+- staged 변경은 기본적으로 경고만 합니다
+- `--require-clean`을 주면 staged/unstaged 둘 다 차단됩니다
+- 첫 실행 시 `.gitignore`에 `.harness/`가 없으면 자동으로 추가합니다
+
+### `harness resume [runId]`
+
+현재 run 또는 특정 run을 재개합니다.
+
+```bash
+harness resume
+harness resume 2026-04-19-graphql-api
+```
+
+resume은 세 경우를 자동 처리합니다:
+1. tmux session alive + inner alive → 재연결만 수행
+2. tmux session alive + inner dead → 기존 세션 안에서 inner loop 재시작
+3. tmux session 없음 → tmux를 다시 만들고 저장된 상태부터 계속 진행
+
+resume 때도 남아 있는 phase들에 대해 모델 preset 선택 UI가 다시 뜹니다.
+
+### `harness status`
+
+현재 run 상태를 출력합니다:
+- run/task/status
+- current phase
+- artifact 경로
+- retry 카운터
+- commit anchor
+- pending action
+
+### `harness list`
+
+현재 harness root 아래의 모든 run을 나열합니다.
+
+### `harness skip`
+
+현재 phase를 강제로 통과시킵니다.
+
+inner process가 살아 있으면 pending action을 기록하고 즉시 signal을 보냅니다.
+inner가 없으면 action만 저장해 두었다가 다음 `harness resume`에서 소비합니다.
+
+### `harness jump <phase>`
+
+이전 phase로 되돌립니다.
+
+```bash
+harness jump 3
+```
+
+규칙:
+- completed run이 아닌 경우 backward jump만 허용
+- light flow에서 `skipped` phase로는 jump 불가
+- 적용 방식은 `skip`과 동일
 
 ---
 
-## 동작 원리
+## Artifact와 상태 파일
 
-### 아키텍처: outer/inner 분리
+Harness는 run 상태를 `.harness/<runId>/` 아래에 저장합니다.
 
-`harness run`은 두 프로세스로 분리됩니다:
+주요 파일:
+- `.harness/<runId>/state.json` — atomic run state
+- `.harness/<runId>/task.md` — 정규화된 task 텍스트
+- `.harness/current-run` — `resume`, `status`, `skip`, `jump`가 쓰는 현재 run 포인터
+- `docs/specs/<runId>-design.md` — spec 또는 결합 design 문서
+- `docs/plans/<runId>.md` — full flow용 plan 문서
+- `.harness/<runId>/checklist.json` — verify checklist
+- `docs/process/evals/<runId>-eval.md` — phase 6 평가 리포트
 
-```
-[사용자 터미널]                            [iTerm2 — tmux 세션]
-$ harness run "태스크"                     Window 0 (control):
-  ├── preflight 검사                         harness __inner <runId>
-  ├── state 초기화                           ├── Phase 1: tmux new-window "claude ..."
-  ├── tmux new-session                       │   ├── control에 "Phase 1 ▶" 표시
-  ├── tmux send-keys "__inner"               │   ├── sentinel 감지 → window kill
-  ├── handoff 완료 대기                      │   └── control: "Phase 1 ✓"
-  ├── iTerm2 창 열기                         ├── Phase 2: codex가 control에서 실행
-  └── exit(0) ← 터미널 반환                 │   └── stderr 실시간 스트리밍
-                                             ├── Phase 3: tmux new-window "claude ..."
-                                             └── ... Phase 7까지
-```
+선택적 세션 로깅(`--enable-logging`)을 켜면 아래에도 기록됩니다:
 
-**Outer** (사용자 터미널): preflight → state 초기화 → tmux 세션 생성 → lock을 inner에게 handoff → iTerm2 열기 → exit.
-
-**Inner** (`__inner`, 숨겨진 명령어): lock ownership 획득 → tmux window 0 안에서 phase loop 실행. Claude 세션은 별도 tmux window로 spawn. Gate/verify 출력은 control panel에 스트리밍.
-
-### Phase 실행
-
-```
-tmux 세션 "harness-<runId>"
-  ├── Window 0 (control panel)
-  │     harness __inner — phase loop + 상태 표시
-  │     Gate/verify stderr 스트리밍
-  │
-  ├── Window "phase-1" (Claude 브레인스토밍)   ← 자동 생성, 자동 종료
-  ├── Window "phase-3" (Claude 계획 작성)      ← 자동 생성, 자동 종료
-  └── Window "phase-5" (Claude 구현)           ← 자동 생성, 자동 종료
+```text
+~/.harness/sessions/<repoKey>/<runId>/
+  meta.json
+  events.jsonl
+  summary.json
 ```
 
-| Phase | 실행 위치 | 동작 |
-|-------|----------|------|
-| 1 | tmux window `phase-1` | Claude 브레인스토밍 → spec doc |
-| 2 | control window | Codex가 spec 리뷰 (stderr 스트리밍) |
-| 3 | tmux window `phase-3` | Claude가 plan + checklist 작성 |
-| 4 | control window | Codex가 plan 리뷰 |
-| 5 | tmux window `phase-5` | Claude가 구현 (반드시 git commit) |
-| 6 | control window | `harness-verify.sh`가 checklist 실행 (출력 스트리밍) |
-| 7 | control window | Codex가 전체 리뷰 |
+logging이 켜져 있으면 control pane footer에 다음 정보가 표시됩니다:
+- 현재 phase / attempt
+- phase 경과 시간
+- 현재 세션 경과 시간
+- 누적 Claude + gate token 총량
 
-### Lock handoff
+---
 
-Outer 프로세스가 lock을 획득하고 자신의 PID와 함께 `handoff: true`를 설정합니다. Inner 프로세스가 `cliPid`를 자신의 PID로 갱신하고 `handoff: false`로 전환하여 ownership을 가져갑니다. Outer는 이 전환이 완료될 때까지 polling합니다 (최대 5초). Inner가 시작되지 않으면 outer가 tmux 세션을 kill하고 lock을 해제합니다.
+## 운영 메모
 
-### 실행 모드
-
-- **Dedicated 모드** (기본, tmux 바깥에서 실행): `harness-<runId>` 이름의 새 tmux 세션을 생성합니다. 완료 시 세션 전체가 kill됩니다.
-- **Reused 모드** (기존 tmux 세션 안에서 실행): 현재 세션에 window를 생성합니다. 완료 시 harness가 생성한 window만 kill하고 부모 세션은 유지됩니다.
-
-상태는 `.harness/<runId>/state.json`에 atomic write로 영속화됩니다. 모든 artifact(`spec`, `plan`, `eval report`)는 phase 경계에서 자동 커밋되므로 eval gate(Phase 7)가 전체 diff를 리뷰할 수 있습니다.
-
-**Phase별 상세 (각 단계에서 쓰는 AI 에이전트, 모델, 출력 위치, 세션 클리어 시점, 상태 관리, signal 처리)** 는 [`docs/HOW-IT-WORKS.ko.md`](docs/HOW-IT-WORKS.ko.md)를 참조하세요.
-
-**tmux 재아키텍처 설계 (outer/inner 분리, lock handoff, reused-session 모드, control-plane 시그널 관련 ADR)** 는 [`docs/specs/2026-04-14-tmux-rearchitecture-design.md`](docs/specs/2026-04-14-tmux-rearchitecture-design.md)를 참조하세요.
-
-**원래 CLI 설계 배경 (ADR, 엣지 케이스)** 은 [`docs/specs/2026-04-12-harness-cli-design.md`](docs/specs/2026-04-12-harness-cli-design.md)를 참조하세요.
+- Harness는 **atomic state write**와 **outer/inner lock handoff**를 사용합니다.
+- interactive phase 완료는 `.harness/<runId>/phase-1.done` 같은 sentinel 파일로 검증합니다.
+- phase 5는 기본적으로 clean tree와 `implRetryBase` 이후 최소 1개 commit이 필요합니다. 단, reopen 경로에서 commit 없는 artifact 수정만 필요한 경우는 예외가 있습니다.
+- `skip`과 `jump`는 control-plane 연산이므로 main run lock을 직접 잡지 않습니다.
+- 모델 preset을 다시 고르면 effective runner/model lineage가 바뀐 gate replay sidecar는 무효화될 수 있습니다.
 
 ---
 
 ## 문제 해결
 
-**`tmux is required. Install with: brew install tmux`** — CLI의 multi-window 아키텍처에 tmux가 필요합니다. 설치 후 재시도하세요.
+**처음 실행했는데 Phase 1에서 멈춘 것처럼 보일 때**  
+workspace pane 쪽에서 Claude가 디렉터리 trust / proceed 확인을 기다리는 경우가 있습니다. workspace pane으로 이동해서 승인하세요.
 
-**`harness requires a git repository`** — 최소 1개 commit이 있는 git repo 안에서 실행해야 합니다.
+**`Codex CLI not found in PATH`**  
+Codex CLI를 설치한 뒤 다시 시도하세요. 이제는 예전 companion 경로가 아니라 실제 `codex` 바이너리를 검사합니다.
 
-**`harness is already running (PID: ...)`** — 다른 CLI 인스턴스가 lock을 점유 중입니다. 실제로 죽은 프로세스면 `.harness/repo.lock`을 수동 확인하세요.
+**`Could not open a terminal window automatically.`**  
+Linux에서는 정상 동작일 수 있고, macOS에서도 자동 실행이 실패할 수 있습니다. 출력된 `tmux attach -t ...` 명령으로 수동 attach 하세요.
 
-**`Cannot start harness run: staged changes exist`** — Harness가 artifact를 auto-commit하므로 staged changes가 있으면 시작할 수 없습니다. `git restore --staged .`로 unstage하거나 먼저 커밋하세요.
+**`No active run.`**  
+`harness list`로 기존 run을 확인하거나 새 run을 시작하세요.
 
-**`Inner process failed to start within 5 seconds.`** — `__inner` 프로세스가 제한 시간 내에 lock ownership을 가져오지 못했습니다. tmux 세션은 자동으로 정리됩니다. `tmux list-sessions`로 오류를 확인하고 재시도하세요.
+**`flow is frozen at run creation`**  
+`--light`는 start 시점에만 고를 수 있습니다. 기존 run은 그대로 resume하고, light flow가 필요하면 새 run을 시작하세요.
 
-**`Could not open a terminal window automatically.`** — iTerm2와 Terminal.app 모두 AppleScript로 실행할 수 없었습니다. tmux 세션은 살아있으므로 출력된 `tmux attach -t harness-<runId>` 명령으로 수동 연결하세요.
+**phase 5 dirty tree 오류가 날 때**  
+우선 일반 resume/retry를 해보세요. 허용 가능한 잔여 파일도 자동 복구하지 않고 즉시 실패시키고 싶다면 `--strict-tree`로 시작하세요.
 
-**`claude @file syntax is required but not supported`** — Claude Code CLI를 최신 버전으로 업그레이드하세요.
+**다른 터미널에서 현재 진행 상황을 보고 싶을 때**  
+`harness status`, `harness skip`, `harness jump <phase>`를 사용하세요.
 
-**실수로 iTerm2 창을 닫았을 때** — tmux 세션은 살아있습니다. `harness resume`으로 재연결하거나, 직접 `tmux attach -t harness-<runId>`를 실행하세요.
+---
 
-**Phase에서 멈춘 것 같을 때** — `harness status`로 현재 위치를 확인하세요. `harness resume`으로 실행 중인 세션에 재연결합니다. `harness skip` / `harness jump N`은 세션이 실행 중인 동안에도 아무 터미널에서 사용 가능합니다.
+## 관련 문서
+
+- [`docs/HOW-IT-WORKS.ko.md`](docs/HOW-IT-WORKS.ko.md)
+- [`README.md`](README.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,111 @@
 # harness-cli
 
-A TypeScript CLI that orchestrates a 7-phase AI agent development lifecycle: brainstorm → spec gate → plan → plan gate → implement → verify → eval gate.
+`harness-cli` is a TypeScript CLI for running AI-assisted engineering work as a reproducible, resumable tmux workflow.
 
-Each phase runs in its own isolated subprocess inside a **tmux session** — Claude Code for interactive phases (each in a separate tmux window), Codex companion for independent gate review, and a shell script for automated verification. A control panel in tmux window 0 provides real-time phase status while Claude works in adjacent windows. Context is passed between phases through files, not shared sessions, so context bloat and self-review bias are eliminated.
+It supports:
+- a **full 7-phase flow**: spec → spec gate → plan → plan gate → implement → verify → eval gate
+- a **light 4-phase flow** for smaller tasks: design+plan → implement → verify → eval gate
+- **per-phase model preset selection** at start/resume
+- **tmux-based crash recovery** with `resume`, `status`, `list`, `skip`, and `jump`
+- **optional session logging** and a live footer with elapsed time and token totals
 
-The CLI manages phase lifecycle externally: crash-safe state via atomic `state.json` writes, two-level file locking with atomic handoff (outer → inner process), and full crash recovery through `resume` / `jump` / `skip` commands.
+Unlike a single long-lived chat session, harness passes context through files and state, so each phase can restart cleanly and independent review phases do not inherit the implementation session's context.
+
+---
+
+## What actually runs in each phase
+
+By default, harness uses:
+- **Claude** presets for interactive phases (1 / 3 / 5)
+- **Codex** presets for review gates (2 / 4 / 7)
+- the bundled **`harness-verify.sh`** script for phase 6
+
+Those defaults are configurable at runtime. On every `harness start` / `harness resume`, harness prompts for the model preset of every remaining non-verify phase.
+
+Current built-in presets:
+- `opus-max`, `opus-xhigh`, `opus-high`
+- `sonnet-max`, `sonnet-high`
+- `codex-high`, `codex-medium`
+
+Default phase assignments:
+- Phase 1 → `opus-high`
+- Phase 2 → `codex-high`
+- Phase 3 → `sonnet-high`
+- Phase 4 → `codex-high`
+- Phase 5 → `sonnet-high`
+- Phase 7 → `codex-high`
+
+---
+
+## Full flow vs light flow
+
+### Full flow (`harness start "task"`)
+
+```text
+P1 spec → P2 spec gate → P3 plan → P4 plan gate → P5 implement → P6 verify → P7 eval gate
+```
+
+Use the full flow when independent pre-implementation review matters: migrations, API/contract work, security-sensitive changes, or anything where the extra gate cost is worth it.
+
+### Light flow (`harness start --light "task"`)
+
+```text
+P1 design+plan → P5 implement → P6 verify → P7 eval gate
+```
+
+In light flow:
+- phases **2 / 3 / 4** are marked as `skipped`
+- phase 1 must produce a combined design document with `## Complexity`, `## Open Questions`, and `## Implementation Plan`
+- phase 7 can reopen **phase 5** for impl-only feedback, or **phase 1** for design/mixed feedback
+- light-flow gate retry limit is **5** (full flow stays at **3**)
+- the flow is frozen when the run is created, so `harness resume --light` is rejected
+
+---
+
+## Runtime layout inside tmux
+
+Harness runs the workflow inside tmux with a split-pane control surface:
+- **control pane**: current phase, retries, gate/verify output, escalation menus
+- **workspace pane**: the active interactive agent session
+
+Behavior depends on where you launch it:
+- **outside tmux**: creates a dedicated session named `harness-<runId>`
+- **inside tmux**: reuses the current tmux session and creates a `harness-ctrl` window
+
+On macOS, harness tries to open the tmux session automatically in **iTerm2** first, then **Terminal.app**.
+On Linux, or when AppleScript launch fails, harness prints a manual attach command instead:
+
+```bash
+tmux attach -t harness-<runId>
+```
 
 ---
 
 ## Prerequisites
 
-Before using the CLI, install these dependencies (all are checked by preflight):
+Harness is designed for a git working tree and will auto-commit artifacts between phases.
+Install these first:
 
-| Dependency | Purpose | Install |
-|------------|---------|---------|
-| **Node.js ≥ 18** | Runtime for the CLI and Codex companion | [nodejs.org](https://nodejs.org) |
-| **pnpm** | Package manager (for this repo) | `npm install -g pnpm` |
-| **git** | Required; target project must be a git repo with ≥1 commit | built-in on macOS/Linux |
-| **Claude Code CLI** (`claude`) | Used for interactive phases 1/3/5 | [claude.ai/code](https://claude.ai/code) |
-| **Codex companion** | Used for gate phases 2/4/7. Path is auto-detected at `~/.claude/plugins/cache/openai-codex/codex/*/scripts/codex-companion.mjs` | Install the `openai-codex` Claude plugin |
-| **harness-verify.sh** | Used for Phase 6 auto-verification. Expected at `~/.claude/scripts/harness-verify.sh` | Copy from this repo's skill distribution |
-| **jq** | Used by `harness-verify.sh` to parse `checklist.json` | `brew install jq` / `apt install jq` |
-| **tmux** | Hosts the control panel and Claude windows | `brew install tmux` / `apt install tmux` |
+| Dependency | Why it is needed |
+|---|---|
+| Node.js 18+ | CLI runtime |
+| tmux | session / pane orchestration |
+| Claude Code CLI (`claude`) | default interactive runner |
+| Codex CLI (`codex`) | default gate runner and optional interactive runner |
+| `jq` | checklist parsing in phase 6 verify |
+| Git | commit anchors, diffs, artifact commits |
+| Interactive TTY | start/resume model selection and escalation UI |
 
-**Platform**: macOS only. iTerm2 is preferred for automatic window opening; Terminal.app is used as fallback. Linux support is out of scope.
-
-**Terminal**: The CLI opens a new iTerm2 (or Terminal.app) window for the tmux session. Your original terminal is returned immediately. Escalation menus run inside the tmux control window, so a TTY is always available.
+Notes:
+- Supported platforms are **macOS and Linux**.
+- The verify script is resolved from the installed package first, with legacy fallback to `~/.claude/scripts/harness-verify.sh`.
+- If you switch an interactive phase to a Codex preset, harness will use the Codex CLI for that phase too.
 
 ---
 
 ## Installation
 
-Clone the repo and link globally for development:
+For local development:
 
 ```bash
 git clone <repo-url> harness-cli
@@ -41,15 +115,15 @@ pnpm run build
 pnpm link --global
 ```
 
-After linking, the `harness` command is available in any directory.
+After linking, `harness` is available globally.
 
-When you modify source code, rebuild to propagate changes to the global command:
+Rebuild after source changes:
 
 ```bash
 pnpm run build
 ```
 
-To uninstall:
+Remove the global link:
 
 ```bash
 pnpm unlink --global harness-cli
@@ -57,213 +131,184 @@ pnpm unlink --global harness-cli
 
 ---
 
-## Usage
+## Quick start
 
-Run all commands from a target git project (NOT from `harness-cli` itself):
+Run harness from the target project root (or pass `--root` to place `.harness/` elsewhere):
 
 ```bash
 cd /path/to/your/project
 harness --help
 ```
 
-### Start a new run
+Start a run:
 
 ```bash
-harness run "Add GraphQL API with user authentication"
+harness start "Add GraphQL API with user authentication"
+# same as: harness run "Add GraphQL API with user authentication"
 ```
 
-This creates a **tmux session** and opens it in a new iTerm2 window. Your original terminal is returned immediately.
+If you omit the task, harness asks for it inside the control pane.
+That control-pane prompt supports **multiline paste** while still treating a normal `Enter` as submit.
 
-Inside the tmux session:
-- **Window 0 (control panel)**: Shows real-time phase status, gate/verify streaming logs, and escalation menus
-- **Window N (phase-N)**: Claude runs interactively in a separate window per phase
+Typical sequence:
+1. harness creates or finds `.harness/`
+2. it creates the tmux control surface
+3. it prompts for model presets for the remaining phases
+4. it starts phase 1 (or the saved phase on resume)
 
-The control panel displays which phase is active. Switch between windows with `Ctrl-B 0` (control) and `Ctrl-B 1` (Claude).
+---
 
-Phase 1 (brainstorming) starts automatically. Claude asks clarifying questions and writes:
+## Command reference
 
-- `docs/specs/<runId>-design.md` — spec document
-- `.harness/<runId>/decisions.md` — decision log
+### `harness start [task]`
 
-When Phase 1 finishes, the Claude window closes automatically, focus returns to the control panel, and the CLI advances through:
-
-- **Phase 2**: Codex reviews the spec (progress streamed to control panel) → `APPROVE` or `REJECT`
-- **Phase 3**: Claude opens in a new tmux window for planning → `docs/plans/<runId>.md` + `.harness/<runId>/checklist.json`
-- **Phase 4**: Codex reviews spec + plan
-- **Phase 5**: Claude opens in a new tmux window for implementation (must git commit before exit)
-- **Phase 6**: `harness-verify.sh` runs the checklist (output streamed to control panel) → `docs/process/evals/<runId>-eval.md`
-- **Phase 7**: Codex reviews everything (spec + plan + eval report + diff)
-
-### Flags for `harness run`
+Starts a new run.
 
 ```bash
-harness run "task" --allow-dirty   # allow unstaged/untracked changes at start (staged still blocked)
-harness run "task" --auto          # autonomous mode: no escalation menus, limit-exceeded → force-pass
-harness run "task" --root <dir>    # use <dir>/.harness/ instead of the git root
+harness start "task"
+harness run "task"                  # alias
+harness start --light "task"
+harness start --require-clean "task"
+harness start --enable-logging "task"
+harness start --root /tmp/demo "task"
 ```
 
-**Already inside tmux?** The CLI detects `$TMUX` and creates a new window in your current session instead of launching a new terminal — no tmux-in-tmux nesting.
+Flags:
+- `--require-clean` — block if the working tree has any uncommitted changes
+- `--auto` — autonomous mode for escalation handling
+- `--enable-logging` — write session logs under `~/.harness/sessions/...`
+- `--light` — use the 4-phase light flow
+- `--codex-no-isolate` — disable per-run `CODEX_HOME` isolation for Codex subprocesses; not recommended
+- `--strict-tree` — disable phase-5 dirty-tree auto-recovery and write diagnostics instead
+- global `--root <dir>` — use `<dir>/.harness` as the harness root
+
+Important behavior:
+- unstaged/untracked changes are allowed by default
+- staged changes are warned about by default
+- if `--require-clean` is set, both staged and unstaged changes are blocked
+- on first run, harness ensures `.harness/` is present in `.gitignore`
+
+### `harness resume [runId]`
+
+Resumes the current run or a specific run.
 
 ```bash
-# Inside an existing tmux session:
-harness run "task"   # creates a 'harness-ctrl' window in the current session
-```
-
-### Resume a run
-
-If the terminal closes, the tmux session stays alive. Re-attach:
-
-```bash
-harness resume                       # resumes the current run (.harness/current-run pointer)
-harness resume 2026-04-12-graphql-api   # resume a specific runId
+harness resume
+harness resume 2026-04-19-graphql-api
 ```
 
 Resume handles three cases automatically:
-1. **Session + inner alive** — re-attaches to the existing tmux session (opens iTerm2 window)
-2. **Session alive, inner dead** — restarts the phase loop inside the existing tmux session
-3. **No session** — creates a fresh tmux session and starts the phase loop from the saved checkpoint
+1. tmux session alive + inner process alive → reattach only
+2. tmux session alive + inner process dead → restart the inner loop in place
+3. no tmux session → recreate tmux and continue from saved state
 
-Pending actions (from `skip`/`jump`) are consumed on restart.
+On resume, harness again prompts for presets for the remaining phases.
 
-### Inspect state
+### `harness status`
+
+Prints the current run state:
+- run/task/status
+- current phase
+- artifact paths
+- retry counters
+- commit anchors
+- pending action
+
+### `harness list`
+
+Lists all runs under the harness root.
+
+### `harness skip`
+
+Force-passes the current phase.
+
+If the inner process is alive, harness writes a pending action and signals the running session immediately.
+If not, the skip is saved and consumed by the next `harness resume`.
+
+### `harness jump <phase>`
+
+Jumps backward to an earlier phase.
 
 ```bash
-harness status     # print current phase, artifacts, retries, pending action
-harness list       # show all runs in this repo with their status
+harness jump 3
 ```
 
-`status` and `list` are read-only and work without a TTY, so they're safe to use in CI or pipelines.
-
-### Force progression
-
-```bash
-harness skip                  # force-pass the current phase (e.g., skip a re-review cycle)
-harness jump 3                # backward jump — reset to Phase 3 and restart from there
-```
-
-These are **control-plane commands** — they don't acquire the lock. Instead:
-- If the inner process is running: writes a `pending-action.json` file and sends `SIGUSR1` to the inner process. The active Claude window is killed and the phase loop re-enters at the new phase.
-- If no inner process is running: saves the action to `pending-action.json` for the next `harness resume` to pick up.
-
-`jump` is **backward-only** (N must be less than the current phase, or the run must be completed).
+Rules:
+- backward only unless the run is already completed
+- cannot jump into a `skipped` phase in light flow
+- saved/applied the same way as `skip`
 
 ---
 
-## Typical workflow
+## Artifacts and state
 
-```bash
-# 1. Start in a clean git repo
-cd ~/projects/my-app
-git status   # should be clean
+Harness stores run state under `.harness/<runId>/`.
 
-# 2. Kick off a run — a new iTerm2 window opens with the tmux session
-harness run "Add dark mode toggle to the settings page"
-# Your terminal is returned immediately. Work happens in the new window.
+Common artifacts:
+- `.harness/<runId>/state.json` — atomic run state
+- `.harness/<runId>/task.md` — normalized task text
+- `.harness/current-run` — pointer used by `resume`, `status`, `skip`, and `jump`
+- `docs/specs/<runId>-design.md` — spec or combined design doc
+- `docs/plans/<runId>.md` — full-flow implementation plan
+- `.harness/<runId>/checklist.json` — verify checklist
+- `docs/process/evals/<runId>-eval.md` — phase 6 evaluation report
 
-# 3. In the tmux session:
-#    - Ctrl-B 0 → control panel (phase status, gate logs)
-#    - Ctrl-B 1 → active Claude window
-#    If Codex rejects the spec, Claude reopens automatically with the feedback.
-#    If it rejects 3 times, the control panel shows an escalation menu.
+Optional session logging (`--enable-logging`) writes to:
 
-# 4. Close the iTerm2 window — the tmux session survives
-harness status   # see where you are (read-only, works from any terminal)
-harness resume   # re-attach to the running tmux session
-
-# 5. Skip or jump while the session is running (from another terminal):
-harness skip     # sends SIGUSR1 → current phase force-passed
-harness jump 3   # sends SIGUSR1 → resets to Phase 3
+```text
+~/.harness/sessions/<repoKey>/<runId>/
+  meta.json
+  events.jsonl
+  summary.json
 ```
+
+When logging is enabled, the control pane footer shows:
+- current phase / attempt
+- phase elapsed time
+- current session elapsed time
+- cumulative Claude + gate token totals
 
 ---
 
-## How it works
+## Operational notes
 
-### Architecture: outer/inner split
-
-`harness run` is split into two processes:
-
-```
-[Your terminal]                          [iTerm2 — tmux session]
-$ harness run "task"                     Window 0 (control):
-  ├── preflight checks                     harness __inner <runId>
-  ├── state init                           ├── Phase 1: tmux new-window "claude ..."
-  ├── tmux new-session                     │   ├── control shows "Phase 1 ▶"
-  ├── tmux send-keys "__inner"             │   ├── sentinel detected → kill window
-  ├── poll for handoff complete            │   └── control: "Phase 1 ✓"
-  ├── open iTerm2 window                   ├── Phase 2: codex runs in control
-  └── exit(0) ← terminal returned         │   └── stderr streamed live
-                                           ├── Phase 3: tmux new-window "claude ..."
-                                           └── ... through Phase 7
-```
-
-**Outer** (your terminal): preflight → state init → create tmux session → handoff lock to inner → open iTerm2 → exit.
-
-**Inner** (`__inner`, hidden command): claims lock ownership → runs the phase loop inside tmux window 0. Claude sessions spawn as separate tmux windows. Gate/verify output streams to the control panel.
-
-### Phase execution
-
-```
-tmux session "harness-<runId>"
-  ├── Window 0 (control panel)
-  │     harness __inner — phase loop + status display
-  │     Gate/verify stderr streamed here
-  │
-  ├── Window "phase-1" (Claude brainstorm)    ← auto-created, auto-killed
-  ├── Window "phase-3" (Claude planning)      ← auto-created, auto-killed
-  └── Window "phase-5" (Claude implementation)← auto-created, auto-killed
-```
-
-| Phase | Where it runs | What happens |
-|-------|--------------|--------------|
-| 1 | tmux window `phase-1` | Claude brainstorms → spec doc |
-| 2 | control window | Codex reviews spec (stderr streamed) |
-| 3 | tmux window `phase-3` | Claude writes plan + checklist |
-| 4 | control window | Codex reviews plan |
-| 5 | tmux window `phase-5` | Claude implements (must git commit) |
-| 6 | control window | `harness-verify.sh` runs checklist (output streamed) |
-| 7 | control window | Codex reviews everything |
-
-### Lock handoff
-
-The outer process acquires the lock and sets `handoff: true` with its PID. The inner process claims ownership by updating `cliPid` to its own PID and setting `handoff: false`. The outer polls for this transition (max 5 seconds) before exiting. If the inner fails to start, the outer kills the tmux session and releases the lock.
-
-### Execution modes
-
-- **Dedicated mode** (default, outside tmux): Creates a new tmux session `harness-<runId>`. On completion, the entire session is killed.
-- **Reused mode** (inside an existing tmux session): Creates windows in the current session. On completion, only harness-owned windows are killed; the parent session is preserved.
-
-State is persisted in `.harness/<runId>/state.json` (atomically written). All artifacts (`spec`, `plan`, `eval report`) are auto-committed at phase boundaries so the eval gate (Phase 7) can review the full diff.
-
-**For a detailed phase-by-phase breakdown** (which AI agent runs where, model names, output locations, session clear points, state management, signal handling) see [`docs/HOW-IT-WORKS.md`](docs/HOW-IT-WORKS.md).
-
-**For the tmux rearchitecture design** (ADRs on outer/inner split, lock handoff, reused-session mode, control-plane signals), see [`docs/specs/2026-04-14-tmux-rearchitecture-design.md`](docs/specs/2026-04-14-tmux-rearchitecture-design.md).
-
-**For the original CLI design rationale** (ADRs, edge cases), see [`docs/specs/2026-04-12-harness-cli-design.md`](docs/specs/2026-04-12-harness-cli-design.md).
+- Harness uses **atomic state writes** and **lock handoff** between the outer starter process and the inner tmux process.
+- Interactive phases are validated with sentinel files such as `.harness/<runId>/phase-1.done`.
+- Phase 5 requires a clean tree and at least one commit after `implRetryBase` unless it is a reopen path that only fixes non-commit artifacts.
+- `skip` and `jump` are control-plane operations; they do not take the main run lock.
+- Re-selecting presets can invalidate saved gate replay sidecars when the effective runner/model lineage changes.
 
 ---
 
 ## Troubleshooting
 
-**First run in a new project looks hung** — On first use in a project directory, Claude Code prompts you to approve folder access (the "Do you trust the files in this folder?" dialog). The prompt appears in the Claude tmux window, not the control panel, so the control panel sits at *Phase 1 ▶* until you respond. Switch to the Claude window with `Ctrl-B 1` and pick the "trust / proceed" option in the dialog. Subsequent runs in the same directory skip this prompt.
+**First run looks idle on Phase 1**  
+Claude may be waiting in the workspace pane for a directory trust / proceed confirmation. Switch to the workspace pane and approve it.
 
-**`tmux is required. Install with: brew install tmux`** — The CLI requires tmux for its multi-window architecture. Install it and try again.
+**`Codex CLI not found in PATH`**  
+Install the Codex CLI and retry. Harness now validates the actual `codex` binary, not the older companion path.
 
-**`harness requires a git repository`** — Run from inside a git repo with at least one commit.
+**`Could not open a terminal window automatically.`**  
+Expected on Linux and possible on macOS fallback failure. Attach manually with the printed `tmux attach -t ...` command.
 
-**`harness is already running (PID: ...)`** — Another CLI instance holds the lock. If it really is dead, check `.harness/repo.lock` manually.
+**`No active run.`**  
+Run `harness list` to discover existing runs, or start a new one.
 
-**`Cannot start harness run: staged changes exist`** — Harness refuses to start with staged changes because it auto-commits artifacts. Unstage (`git restore --staged .`) or commit them first.
+**`flow is frozen at run creation`**  
+`--light` is a start-time choice only. Resume the existing run as-is, or start a fresh light run.
 
-**`Inner process failed to start within 5 seconds.`** — The `__inner` process didn't claim lock ownership in time. The tmux session is cleaned up automatically. Check for errors with `tmux list-sessions` and retry.
+**Dirty tree failure in phase 5**  
+Retry normally first. If you need a hard failure instead of auto-recovery for ignorable leftovers, start the run with `--strict-tree`.
 
-**`Could not open a terminal window automatically.`** — Neither iTerm2 nor Terminal.app could be launched via AppleScript. The tmux session is still alive — attach manually with the printed `tmux attach -t harness-<runId>` command.
+**Need to inspect current progress from another terminal?**  
+Use `harness status`, `harness skip`, or `harness jump <phase>`.
 
-**`claude @file syntax is required but not supported`** — Upgrade Claude Code CLI to the current version.
+---
 
-**Closed the iTerm2 window by accident?** — The tmux session survives. Run `harness resume` to re-attach, or manually: `tmux attach -t harness-<runId>`.
+## Related docs
 
-**Stuck on a phase?** — `harness status` shows exactly where you are. `harness resume` re-attaches to the running session. `harness skip` / `harness jump N` work from any terminal, even while the session is running.
+- [`docs/HOW-IT-WORKS.md`](docs/HOW-IT-WORKS.md)
+- [`README.ko.md`](README.ko.md)
 
 ---
 

--- a/docs/pr-drafts/2026-04-19-control-pane-multiline-task-paste.md
+++ b/docs/pr-drafts/2026-04-19-control-pane-multiline-task-paste.md
@@ -1,0 +1,93 @@
+# PR body draft — Control-pane multiline task paste support
+
+**Branch:** `fix/control-pane-multiline-task-paste` → `main`
+**Interview spec:** `.omx/specs/deep-interview-multiline-task-intake.md`
+
+## Summary
+
+Fixes the no-argument `harness start` / `harness run` task prompt so the control
+panel can accept a pasted multiline task brief without truncating at the first
+line or leaking the remaining lines into later prompts.
+
+The existing prompt used `readline.question()`, which is fundamentally a
+single-line abstraction. This PR replaces only that pre-loop intake surface with
+an isolated custom buffered prompt that preserves the current `Enter = submit`
+behavior for normal typing while safely admitting multiline paste blobs.
+
+## Why
+
+Users often paste spec-style task briefs into the initial control-panel prompt.
+With the old single-line prompt, the first newline ended the answer, so only the
+first line was captured and the rest of the pasted text could bleed into the
+next control prompt.
+
+## What changed
+
+- Added `src/task-prompt.ts`
+  - custom buffered task prompt for the initial no-arg task-entry path
+  - explicit bracketed-paste handling (`\x1b[200~` / `\x1b[201~`)
+  - implicit multiline-paste fallback for multiline chunks delivered without
+    bracketed wrappers
+  - preserves normal `Enter = submit` typing behavior
+- Updated `src/commands/inner.ts`
+  - removed the old `readline.question()` task prompt
+  - routed no-arg task entry through the new buffered prompt
+- Added `tests/task-prompt.test.ts`
+  - submit-on-enter behavior
+  - implicit multiline paste capture
+  - explicit bracketed paste capture
+  - split escape-sequence handling
+  - backspace behavior
+- Updated `README.md` / `README.ko.md`
+  - documented that the control-pane prompt supports multiline paste
+
+## Simplifications
+
+- The change is intentionally scoped to the **pre-loop no-arg task prompt only**.
+  It does not redesign the general phase-loop input system.
+- CLI one-shot task ingress (`harness start "..."`, `--task-file`, stdin) stays
+  out of scope.
+- Shift+Enter / typed multiline authoring is intentionally not introduced.
+
+## Verification
+
+```text
+pnpm run lint
+pnpm run build
+pnpm test
+```
+
+Observed result on this branch:
+- `pnpm run lint` ✅
+- `pnpm run build` ✅
+- `pnpm test` ✅ (`56 passed`, `794 passed / 1 skipped`)
+
+## Remaining risks
+
+1. **Real terminal variance:** bracketed paste support depends on terminal/tmux
+   behavior. The implementation includes a multiline-chunk fallback, but a real
+   manual smoke test is still valuable.
+2. **Prompt redraw behavior:** the prompt now performs a redraw on paste/control
+   edits. This is intentionally isolated to the startup task prompt so any UX
+   flicker risk does not affect the phase loop.
+3. **Out of scope ingress footguns remain:** shell-quoted one-shot invocation
+   can still be tripped up by shell quoting/backticks because this PR only fixes
+   the control-pane prompt path.
+
+## Manual smoke to run before merge
+
+```bash
+harness start
+```
+
+Then in the control pane:
+- paste a multiline brief containing blank lines
+- confirm the full text lands in `.harness/<runId>/task.md`
+- confirm later prompts are not polluted by trailing pasted lines
+- confirm a normal one-line typed task still submits with a single Enter
+
+## Scope notes
+
+- In scope: no-arg control-pane task entry only
+- Out of scope: CLI one-shot task ingress improvements, typed multiline authoring,
+  Shift+Enter conventions, editor-based compose UI

--- a/src/commands/inner.ts
+++ b/src/commands/inner.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import path, { join } from 'path';
-import { createInterface } from 'readline';
 import { getGitRoot } from '../git.js';
 import { updateLockPid, readLock, releaseLock } from '../lock.js';
 import { findHarnessRoot, clearCurrentRun } from '../root.js';
@@ -16,6 +15,7 @@ import { REQUIRED_PHASE_KEYS, getEffectiveReopenTarget, getRequiredPhaseKeys } f
 import { createSessionLogger } from '../logger.js';
 import { codexHomeFor } from '../runners/codex-isolation.js';
 import type { SessionLogger, HarnessState } from '../types.js';
+import { promptForTask } from '../task-prompt.js';
 
 export interface InnerOptions {
   root?: string;
@@ -90,7 +90,7 @@ export async function innerCommand(runId: string, options: InnerOptions = {}): P
 
     let capturedTask = '';
     while (!capturedTask) {
-      const result = await promptForTask();
+      const result = await promptForTask(state.runId);
       switch (result.kind) {
         case 'task':
           capturedTask = result.value;
@@ -337,37 +337,4 @@ function consumePendingAction(runDir: string, state: HarnessState): void {
     // Best-effort: corrupted pending action is skipped
     try { fs.unlinkSync(pendingPath); } catch { /* ignore */ }
   }
-}
-
-type PromptResult =
-  | { kind: 'task'; value: string }
-  | { kind: 'empty' }
-  | { kind: 'eof' }
-  | { kind: 'interrupt' };
-
-function promptForTask(): Promise<PromptResult> {
-  const rl = createInterface({ input: process.stdin, output: process.stderr });
-
-  return new Promise<PromptResult>((resolve) => {
-    let answered = false;
-
-    rl.on('SIGINT', () => {
-      answered = true;
-      rl.close();
-      resolve({ kind: 'interrupt' });
-    });
-
-    rl.question('  > ', (answer) => {
-      answered = true;
-      rl.close();
-      const trimmed = answer.trim();
-      resolve(trimmed ? { kind: 'task', value: trimmed } : { kind: 'empty' });
-    });
-
-    rl.on('close', () => {
-      if (!answered) {
-        resolve({ kind: 'eof' });
-      }
-    });
-  });
 }

--- a/src/task-prompt.ts
+++ b/src/task-prompt.ts
@@ -1,0 +1,228 @@
+import { renderWelcome } from './ui.js';
+
+export type PromptResult =
+  | { kind: 'task'; value: string }
+  | { kind: 'empty' }
+  | { kind: 'eof' }
+  | { kind: 'interrupt' };
+
+export interface TaskPromptState {
+  buffer: string;
+  inPaste: boolean;
+  pendingEscape: string;
+}
+
+export interface TaskPromptStep {
+  state: TaskPromptState;
+  signal?: 'submit' | 'eof' | 'interrupt';
+}
+
+const BRACKETED_PASTE_ENABLE = '\x1b[?2004h';
+const BRACKETED_PASTE_DISABLE = '\x1b[?2004l';
+export const BRACKETED_PASTE_START = '\x1b[200~';
+export const BRACKETED_PASTE_END = '\x1b[201~';
+
+const KNOWN_BRACKETED_SEQUENCES = [BRACKETED_PASTE_START, BRACKETED_PASTE_END] as const;
+
+export function createInitialTaskPromptState(): TaskPromptState {
+  return {
+    buffer: '',
+    inPaste: false,
+    pendingEscape: '',
+  };
+}
+
+function normalizeNewlines(text: string): string {
+  return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+export function looksLikeImplicitMultilinePaste(rawChunk: string): boolean {
+  if (rawChunk.includes(BRACKETED_PASTE_START) || rawChunk.includes(BRACKETED_PASTE_END)) {
+    return false;
+  }
+
+  const chunk = normalizeNewlines(rawChunk);
+  const firstNewline = chunk.indexOf('\n');
+  if (firstNewline === -1) return false;
+
+  const hasSecondNewline = chunk.indexOf('\n', firstNewline + 1) !== -1;
+  const hasTextAfterFirstNewline = chunk
+    .slice(firstNewline + 1)
+    .replace(/\n/g, '')
+    .length > 0;
+
+  return hasSecondNewline || hasTextAfterFirstNewline;
+}
+
+export function applyTaskPromptChunk(
+  prev: TaskPromptState,
+  rawChunk: string,
+): TaskPromptStep {
+  if (!prev.inPaste && prev.pendingEscape === '' && looksLikeImplicitMultilinePaste(rawChunk)) {
+    return {
+      state: {
+        ...prev,
+        buffer: prev.buffer + normalizeNewlines(rawChunk),
+      },
+    };
+  }
+
+  let buffer = prev.buffer;
+  let inPaste = prev.inPaste;
+  let pendingEscape = '';
+
+  const input = prev.pendingEscape + rawChunk;
+
+  for (let index = 0; index < input.length; index += 1) {
+    const char = input[index];
+    const rest = input.slice(index);
+
+    if (char === '\x1b') {
+      if (KNOWN_BRACKETED_SEQUENCES.some((sequence) => sequence.startsWith(rest) && rest.length < sequence.length)) {
+        pendingEscape = rest;
+        break;
+      }
+      if (rest.startsWith(BRACKETED_PASTE_START)) {
+        inPaste = true;
+        index += BRACKETED_PASTE_START.length - 1;
+        continue;
+      }
+      if (rest.startsWith(BRACKETED_PASTE_END)) {
+        inPaste = false;
+        index += BRACKETED_PASTE_END.length - 1;
+        continue;
+      }
+      continue;
+    }
+
+    if (char === '\x03') {
+      return {
+        state: { buffer, inPaste, pendingEscape },
+        signal: 'interrupt',
+      };
+    }
+
+    if (char === '\x04') {
+      return {
+        state: { buffer, inPaste, pendingEscape },
+        signal: 'eof',
+      };
+    }
+
+    if (char === '\x7f' || char === '\b') {
+      buffer = buffer.slice(0, -1);
+      continue;
+    }
+
+    if (char === '\r' || char === '\n') {
+      if (inPaste) {
+        buffer += '\n';
+        if (char === '\r' && input[index + 1] === '\n') {
+          index += 1;
+        }
+        continue;
+      }
+      return {
+        state: { buffer, inPaste, pendingEscape },
+        signal: 'submit',
+      };
+    }
+
+    buffer += char;
+  }
+
+  return {
+    state: { buffer, inPaste, pendingEscape },
+  };
+}
+
+function formatPromptBufferForDisplay(buffer: string): string {
+  if (buffer.length === 0) return '  > ';
+
+  const lines = buffer.split('\n');
+  if (lines.length === 1) {
+    return `  > ${lines[0]}`;
+  }
+  return `  > ${lines[0]}\n    ${lines.slice(1).join('\n    ')}`;
+}
+
+function renderTaskPrompt(runId: string, buffer: string): void {
+  renderWelcome(runId);
+  process.stderr.write(formatPromptBufferForDisplay(buffer));
+}
+
+function canAppendIncrementally(
+  prev: TaskPromptState,
+  next: TaskPromptState,
+  rawChunk: string,
+): boolean {
+  return prev.pendingEscape === ''
+    && next.pendingEscape === ''
+    && !prev.inPaste
+    && !next.inPaste
+    && !/[\x1b\r\n\x7f\b\x03\x04]/.test(rawChunk)
+    && next.buffer === prev.buffer + rawChunk;
+}
+
+export function promptForTask(runId: string): Promise<PromptResult> {
+  const stdin = process.stdin;
+
+  if (!stdin.isTTY) {
+    return Promise.resolve({ kind: 'eof' });
+  }
+
+  return new Promise<PromptResult>((resolve) => {
+    let state = createInitialTaskPromptState();
+    let done = false;
+
+    const cleanup = (): void => {
+      if (done) return;
+      done = true;
+      process.stderr.write(BRACKETED_PASTE_DISABLE);
+      stdin.removeListener('data', onData);
+      stdin.setRawMode(false);
+      stdin.pause();
+      process.stderr.write('\n');
+    };
+
+    const finish = (result: PromptResult): void => {
+      cleanup();
+      resolve(result);
+    };
+
+    const onData = (buf: Buffer): void => {
+      const prevState = state;
+      const rawChunk = buf.toString('utf-8');
+      const step = applyTaskPromptChunk(state, rawChunk);
+      state = step.state;
+
+      if (step.signal === 'interrupt') {
+        finish({ kind: 'interrupt' });
+        return;
+      }
+
+      if (step.signal === 'eof') {
+        finish({ kind: 'eof' });
+        return;
+      }
+
+      if (step.signal === 'submit') {
+        const trimmed = state.buffer.trim();
+        finish(trimmed ? { kind: 'task', value: trimmed } : { kind: 'empty' });
+        return;
+      }
+
+      if (canAppendIncrementally(prevState, state, rawChunk)) {
+        process.stderr.write(rawChunk);
+      } else {
+        renderTaskPrompt(runId, state.buffer);
+      }
+    };
+
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.on('data', onData);
+    process.stderr.write(BRACKETED_PASTE_ENABLE);
+    renderTaskPrompt(runId, state.buffer);
+  });
+}

--- a/tests/task-prompt.test.ts
+++ b/tests/task-prompt.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BRACKETED_PASTE_END,
+  BRACKETED_PASTE_START,
+  applyTaskPromptChunk,
+  createInitialTaskPromptState,
+  looksLikeImplicitMultilinePaste,
+} from '../src/task-prompt.js';
+
+describe('task-prompt', () => {
+  describe('looksLikeImplicitMultilinePaste', () => {
+    it('returns false for single-line typed input', () => {
+      expect(looksLikeImplicitMultilinePaste('hello')).toBe(false);
+      expect(looksLikeImplicitMultilinePaste('hello\r')).toBe(false);
+    });
+
+    it('returns true for a multiline pasted chunk without bracketed wrappers', () => {
+      expect(looksLikeImplicitMultilinePaste('line 1\nline 2')).toBe(true);
+      expect(looksLikeImplicitMultilinePaste('line 1\r\nline 2')).toBe(true);
+      expect(looksLikeImplicitMultilinePaste('line 1\n\nline 3')).toBe(true);
+    });
+  });
+
+  describe('applyTaskPromptChunk', () => {
+    it('submits on Enter for normal typed input', () => {
+      let state = createInitialTaskPromptState();
+      state = applyTaskPromptChunk(state, 'abc').state;
+      const step = applyTaskPromptChunk(state, '\r');
+
+      expect(step.signal).toBe('submit');
+      expect(step.state.buffer).toBe('abc');
+    });
+
+    it('captures an implicit multiline paste chunk without submitting', () => {
+      const step = applyTaskPromptChunk(
+        createInitialTaskPromptState(),
+        'line 1\nline 2',
+      );
+
+      expect(step.signal).toBeUndefined();
+      expect(step.state.buffer).toBe('line 1\nline 2');
+    });
+
+    it('captures explicit bracketed paste newlines and submits only on later Enter', () => {
+      let state = createInitialTaskPromptState();
+      let step = applyTaskPromptChunk(
+        state,
+        `${BRACKETED_PASTE_START}line 1\r\nline 2${BRACKETED_PASTE_END}`,
+      );
+      state = step.state;
+
+      expect(step.signal).toBeUndefined();
+      expect(state.buffer).toBe('line 1\nline 2');
+
+      step = applyTaskPromptChunk(state, '\r');
+      expect(step.signal).toBe('submit');
+      expect(step.state.buffer).toBe('line 1\nline 2');
+    });
+
+    it('handles bracketed paste sequences split across multiple chunks', () => {
+      let state = createInitialTaskPromptState();
+
+      state = applyTaskPromptChunk(state, '\x1b[20').state;
+      expect(state.pendingEscape).toBe('\x1b[20');
+
+      state = applyTaskPromptChunk(state, '0~hello\nworld').state;
+      expect(state.inPaste).toBe(true);
+      expect(state.buffer).toBe('hello\nworld');
+
+      const step = applyTaskPromptChunk(state, '\x1b[201~');
+      expect(step.state.inPaste).toBe(false);
+      expect(step.state.buffer).toBe('hello\nworld');
+    });
+
+    it('backspace removes the last buffered character', () => {
+      let state = createInitialTaskPromptState();
+      state = applyTaskPromptChunk(state, 'ab').state;
+
+      const step = applyTaskPromptChunk(state, '\x7f');
+      expect(step.state.buffer).toBe('a');
+    });
+  });
+});


### PR DESCRIPTION
# PR body draft — Control-pane multiline task paste support

**Branch:** `fix/control-pane-multiline-task-paste` → `main`
**Interview spec:** `.omx/specs/deep-interview-multiline-task-intake.md`

## Summary

Fixes the no-argument `harness start` / `harness run` task prompt so the control
panel can accept a pasted multiline task brief without truncating at the first
line or leaking the remaining lines into later prompts.

The existing prompt used `readline.question()`, which is fundamentally a
single-line abstraction. This PR replaces only that pre-loop intake surface with
an isolated custom buffered prompt that preserves the current `Enter = submit`
behavior for normal typing while safely admitting multiline paste blobs.

## Why

Users often paste spec-style task briefs into the initial control-panel prompt.
With the old single-line prompt, the first newline ended the answer, so only the
first line was captured and the rest of the pasted text could bleed into the
next control prompt.

## What changed

- Added `src/task-prompt.ts`
  - custom buffered task prompt for the initial no-arg task-entry path
  - explicit bracketed-paste handling (`\x1b[200~` / `\x1b[201~`)
  - implicit multiline-paste fallback for multiline chunks delivered without
    bracketed wrappers
  - preserves normal `Enter = submit` typing behavior
- Updated `src/commands/inner.ts`
  - removed the old `readline.question()` task prompt
  - routed no-arg task entry through the new buffered prompt
- Added `tests/task-prompt.test.ts`
  - submit-on-enter behavior
  - implicit multiline paste capture
  - explicit bracketed paste capture
  - split escape-sequence handling
  - backspace behavior
- Updated `README.md` / `README.ko.md`
  - documented that the control-pane prompt supports multiline paste

## Simplifications

- The change is intentionally scoped to the **pre-loop no-arg task prompt only**.
  It does not redesign the general phase-loop input system.
- CLI one-shot task ingress (`harness start "..."`, `--task-file`, stdin) stays
  out of scope.
- Shift+Enter / typed multiline authoring is intentionally not introduced.

## Verification

```text
pnpm run lint
pnpm run build
pnpm test
```

Observed result on this branch:
- `pnpm run lint` ✅
- `pnpm run build` ✅
- `pnpm test` ✅ (`56 passed`, `794 passed / 1 skipped`)

## Remaining risks

1. **Real terminal variance:** bracketed paste support depends on terminal/tmux
   behavior. The implementation includes a multiline-chunk fallback, but a real
   manual smoke test is still valuable.
2. **Prompt redraw behavior:** the prompt now performs a redraw on paste/control
   edits. This is intentionally isolated to the startup task prompt so any UX
   flicker risk does not affect the phase loop.
3. **Out of scope ingress footguns remain:** shell-quoted one-shot invocation
   can still be tripped up by shell quoting/backticks because this PR only fixes
   the control-pane prompt path.

## Manual smoke to run before merge

```bash
harness start
```

Then in the control pane:
- paste a multiline brief containing blank lines
- confirm the full text lands in `.harness/<runId>/task.md`
- confirm later prompts are not polluted by trailing pasted lines
- confirm a normal one-line typed task still submits with a single Enter

## Scope notes

- In scope: no-arg control-pane task entry only
- Out of scope: CLI one-shot task ingress improvements, typed multiline authoring,
  Shift+Enter conventions, editor-based compose UI
