### PR TITLE
feat(models): add Claude 1M presets and default new runs to them

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -23,16 +23,18 @@
 이 기본값은 런타임에 바꿀 수 있습니다. `harness start` / `harness resume`를 실행할 때마다, 남아 있는 non-verify phase들에 대해 모델 preset 선택 UI가 먼저 뜹니다.
 
 현재 내장 preset:
+- `opus-1m-max`, `opus-1m-xhigh`, `opus-1m-high`
+- `sonnet-1m-max`, `sonnet-1m-high`
 - `opus-max`, `opus-xhigh`, `opus-high`
 - `sonnet-max`, `sonnet-high`
 - `codex-high`, `codex-medium`
 
 기본 phase 매핑:
-- Phase 1 → `opus-high`
+- Phase 1 → `opus-1m-high`
 - Phase 2 → `codex-high`
-- Phase 3 → `sonnet-high`
+- Phase 3 → `sonnet-1m-high`
 - Phase 4 → `codex-high`
-- Phase 5 → `sonnet-high`
+- Phase 5 → `sonnet-1m-high`
 - Phase 7 → `codex-high`
 
 ---
@@ -101,6 +103,7 @@ Harness는 git working tree를 기준으로 동작하며, phase 경계에서 art
 - verify script는 먼저 설치된 패키지 내부 경로에서 찾고, 없으면 `~/.claude/scripts/harness-verify.sh`를 레거시 fallback으로 사용합니다.
 - interactive phase를 Codex preset으로 바꾸면, 해당 phase도 Codex CLI로 실행됩니다.
 - 기본적으로 Codex phase는 실제 `codex` CLI를 사용하고, `<runDir>/codex-home` 격리 환경에서 실행됩니다. 사용자 전역 `CODEX_HOME` 동작이 필요할 때만 `--codex-no-isolate`를 사용하세요.
+- 새 run은 이제 Claude phase 기본값으로 `*-1m-*` preset을 사용합니다. Claude Code 환경에서 1M context를 쓸 수 없다면, 모델 선택 단계에서 기존 non-1M preset으로 직접 바꾸거나 자체 포크의 `src/config.ts` 기본값을 수정하세요.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,16 +23,18 @@ By default, harness uses:
 Those defaults are configurable at runtime. On every `harness start` / `harness resume`, harness prompts for the model preset of every remaining non-verify phase.
 
 Current built-in presets:
+- `opus-1m-max`, `opus-1m-xhigh`, `opus-1m-high`
+- `sonnet-1m-max`, `sonnet-1m-high`
 - `opus-max`, `opus-xhigh`, `opus-high`
 - `sonnet-max`, `sonnet-high`
 - `codex-high`, `codex-medium`
 
 Default phase assignments:
-- Phase 1 → `opus-high`
+- Phase 1 → `opus-1m-high`
 - Phase 2 → `codex-high`
-- Phase 3 → `sonnet-high`
+- Phase 3 → `sonnet-1m-high`
 - Phase 4 → `codex-high`
-- Phase 5 → `sonnet-high`
+- Phase 5 → `sonnet-1m-high`
 - Phase 7 → `codex-high`
 
 ---
@@ -101,6 +103,7 @@ Notes:
 - The verify script is resolved from the installed package first, with legacy fallback to `~/.claude/scripts/harness-verify.sh`.
 - If you switch an interactive phase to a Codex preset, harness will use the Codex CLI for that phase too.
 - By default, Codex phases run through the real `codex` CLI inside an isolated `<runDir>/codex-home`; use `--codex-no-isolate` only when you intentionally want inherited `CODEX_HOME` behavior.
+- New runs now default Claude phases to the explicit `*-1m-*` presets. If your Claude Code environment does not support 1M context, pick one of the legacy non-1M presets during the model-selection step (or change the defaults in `src/config.ts` in your own fork).
 
 ---
 

--- a/docs/HOW-IT-WORKS.ko.md
+++ b/docs/HOW-IT-WORKS.ko.md
@@ -32,6 +32,11 @@ P1 design+plan → P5 implement → P6 verify → P7 eval gate
 
 | id | runner | model | effort |
 |---|---|---|---|
+| `opus-1m-max` | claude | `claude-opus-4-7[1m]` | `max` |
+| `opus-1m-xhigh` | claude | `claude-opus-4-7[1m]` | `xHigh` |
+| `opus-1m-high` | claude | `claude-opus-4-7[1m]` | `high` |
+| `sonnet-1m-max` | claude | `claude-sonnet-4-6[1m]` | `max` |
+| `sonnet-1m-high` | claude | `claude-sonnet-4-6[1m]` | `high` |
 | `opus-max` | claude | `claude-opus-4-7` | `max` |
 | `opus-xhigh` | claude | `claude-opus-4-7` | `xHigh` |
 | `opus-high` | claude | `claude-opus-4-7` | `high` |
@@ -41,11 +46,12 @@ P1 design+plan → P5 implement → P6 verify → P7 eval gate
 | `codex-medium` | codex | `gpt-5.4` | `medium` |
 
 기본 매핑:
-- full flow: P1 `opus-high`, P2 `codex-high`, P3 `sonnet-high`, P4 `codex-high`, P5 `sonnet-high`, P7 `codex-high`
-- light flow: P1 `opus-high`, P5 `sonnet-high`, P7 `codex-high`
+- full flow: P1 `opus-1m-high`, P2 `codex-high`, P3 `sonnet-1m-high`, P4 `codex-high`, P5 `sonnet-1m-high`, P7 `codex-high`
+- light flow: P1 `opus-1m-high`, P5 `sonnet-1m-high`, P7 `codex-high`
 
 사용자는 `harness start` / `harness resume` 때 모든 non-verify phase preset을 바꿀 수 있고,
 선택값은 `state.phasePresets`에 저장됩니다.
+기존 saved run은 자동으로 1M 기본값으로 마이그레이션되지 않고, 새로 만드는 run에만 1M 기본값이 자동 적용됩니다.
 
 ---
 
@@ -81,11 +87,11 @@ light flow 특이사항:
 
 | Phase | 기본 preset | runner 유형 | 주요 산출물 | reject/fail 시 |
 |---|---|---|---|---|
-| P1 Spec / Design+Plan | `opus-high` | interactive | spec/design 문서 + decisions + checklist(light) | Gate 2 reject 시 P1 재오픈, light P7 design/mixed reject도 P1 재오픈 |
+| P1 Spec / Design+Plan | `opus-1m-high` | interactive | spec/design 문서 + decisions + checklist(light) | Gate 2 reject 시 P1 재오픈, light P7 design/mixed reject도 P1 재오픈 |
 | P2 Spec Gate | `codex-high` | gate | verdict + feedback sidecar | P1 재오픈 |
-| P3 Plan | `sonnet-high` | interactive | plan + checklist | Gate 4 reject 시 P3 재오픈 |
+| P3 Plan | `sonnet-1m-high` | interactive | plan + checklist | Gate 4 reject 시 P3 재오픈 |
 | P4 Plan Gate | `codex-high` | gate | verdict + feedback sidecar | P3 재오픈 |
-| P5 Implement | `sonnet-high` | interactive | git commits | P6 fail, full-flow P7 reject, light-flow impl reject 시 P5 재오픈 |
+| P5 Implement | `sonnet-1m-high` | interactive | git commits | P6 fail, full-flow P7 reject, light-flow impl reject 시 P5 재오픈 |
 | P6 Verify | 고정 스크립트 | 자동 셸 | eval report + verify sidecar | fail 시 P5 재오픈, retry limit 3 |
 | P7 Eval Gate | `codex-high` | gate | verdict + feedback sidecar | full은 P5, light는 scope에 따라 P5 또는 P1 |
 
@@ -141,6 +147,8 @@ gate phase를 Claude preset으로 강제로 매핑한 경우에만 `claude --pri
 기본적으로 Codex subprocess는 `<runDir>/codex-home/` 안에서 실행되고, 그 안에는 `auth.json`만 symlink됩니다.
 이렇게 해야 사용자 전역 `CODEX_HOME` 규칙이 런타임에 섞여들지 않습니다.
 `--codex-no-isolate`는 이 안전장치를 끕니다.
+
+Claude Code 환경에서 1M context를 사용할 수 없다면, 모델 선택기에서 기존 non-1M Claude preset을 계속 사용하거나 자체 포크의 `src/config.ts` 기본값을 바꾸면 됩니다.
 
 ---
 

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -32,6 +32,11 @@ Built-in presets come from `src/config.ts`:
 
 | id | runner | model | effort |
 |---|---|---|---|
+| `opus-1m-max` | claude | `claude-opus-4-7[1m]` | `max` |
+| `opus-1m-xhigh` | claude | `claude-opus-4-7[1m]` | `xHigh` |
+| `opus-1m-high` | claude | `claude-opus-4-7[1m]` | `high` |
+| `sonnet-1m-max` | claude | `claude-sonnet-4-6[1m]` | `max` |
+| `sonnet-1m-high` | claude | `claude-sonnet-4-6[1m]` | `high` |
 | `opus-max` | claude | `claude-opus-4-7` | `max` |
 | `opus-xhigh` | claude | `claude-opus-4-7` | `xHigh` |
 | `opus-high` | claude | `claude-opus-4-7` | `high` |
@@ -41,11 +46,12 @@ Built-in presets come from `src/config.ts`:
 | `codex-medium` | codex | `gpt-5.4` | `medium` |
 
 Default assignments:
-- full flow: P1 `opus-high`, P2 `codex-high`, P3 `sonnet-high`, P4 `codex-high`, P5 `sonnet-high`, P7 `codex-high`
-- light flow: P1 `opus-high`, P5 `sonnet-high`, P7 `codex-high`
+- full flow: P1 `opus-1m-high`, P2 `codex-high`, P3 `sonnet-1m-high`, P4 `codex-high`, P5 `sonnet-1m-high`, P7 `codex-high`
+- light flow: P1 `opus-1m-high`, P5 `sonnet-1m-high`, P7 `codex-high`
 
 Users can change every non-verify phase preset during `harness start` and `harness resume`.
 Selections persist in `state.phasePresets`.
+Existing saved runs are not auto-migrated to the new 1M defaults; only newly created runs pick them up automatically.
 
 ---
 
@@ -81,11 +87,11 @@ Light-flow specifics:
 
 | Phase | Default preset | Runner type | Main outputs | On reject/fail |
 |---|---|---|---|---|
-| P1 Spec / Design+Plan | `opus-high` | interactive | spec/design doc + decisions + checklist (light only) | Gate 2 reject reopens P1; light-flow P7 design/mixed reject also reopens P1 |
+| P1 Spec / Design+Plan | `opus-1m-high` | interactive | spec/design doc + decisions + checklist (light only) | Gate 2 reject reopens P1; light-flow P7 design/mixed reject also reopens P1 |
 | P2 Spec Gate | `codex-high` | gate | verdict + optional feedback sidecars | reopen P1 |
-| P3 Plan | `sonnet-high` | interactive | plan + checklist | Gate 4 reject reopens P3 |
+| P3 Plan | `sonnet-1m-high` | interactive | plan + checklist | Gate 4 reject reopens P3 |
 | P4 Plan Gate | `codex-high` | gate | verdict + optional feedback sidecars | reopen P3 |
-| P5 Implement | `sonnet-high` | interactive | git commits | P6 fail reopens P5; P7 full-flow reject reopens P5; light-flow impl reject reopens P5 |
+| P5 Implement | `sonnet-1m-high` | interactive | git commits | P6 fail reopens P5; P7 full-flow reject reopens P5; light-flow impl reject reopens P5 |
 | P6 Verify | fixed script | automated shell | eval report + verify sidecars | fail reopens P5; retry limit 3 |
 | P7 Eval Gate | `codex-high` | gate | verdict + optional feedback sidecars | full: reopen P5; light: reopen P5 or P1 based on scope |
 
@@ -141,6 +147,8 @@ If a gate phase is explicitly mapped to a Claude preset, harness instead runs a 
 By default, Codex subprocesses run inside `<runDir>/codex-home/` with only `auth.json` symlinked in.
 This avoids inheriting unrelated user-level `CODEX_HOME` conventions.
 `--codex-no-isolate` disables that safeguard.
+
+If your Claude Code environment does not support 1M context, keep using the legacy non-1M Claude presets from the model picker or change the defaults in `src/config.ts` in your own fork.
 
 ---
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,13 +8,23 @@ export interface ModelPreset {
   effort: string;
 }
 
+export interface PhasePresetMap {
+  [phase: number]: string;
+}
+
 // Model effort axes (per Anthropic 2026-04 guidance):
 //   - Opus 4.7: high < xHigh < max (three distinct tiers)
 //   - Sonnet 4.6: high < max (two tiers; no xHigh)
-// The catalog registers every tier on each axis so users can make explicit
-// cost/quality tradeoffs via `promptModelConfig`. PHASE_DEFAULTS still points
-// at the conservative tier; `max` variants are opt-in.
+// The catalog registers both the legacy tiers and explicit 1M-context tiers so
+// users can choose compatibility vs. long-context defaults via
+// `promptModelConfig`. New runs prefer the conservative 1M tiers; legacy tiers
+// remain available as manual fallback choices.
 export const MODEL_PRESETS: ModelPreset[] = [
+  { id: 'opus-1m-max',   label: 'Claude Opus 4.7 1M / max',    runner: 'claude', model: 'claude-opus-4-7[1m]',   effort: 'max'    },
+  { id: 'opus-1m-xhigh', label: 'Claude Opus 4.7 1M / xHigh',  runner: 'claude', model: 'claude-opus-4-7[1m]',   effort: 'xHigh'  },
+  { id: 'opus-1m-high',  label: 'Claude Opus 4.7 1M / high',   runner: 'claude', model: 'claude-opus-4-7[1m]',   effort: 'high'   },
+  { id: 'sonnet-1m-max', label: 'Claude Sonnet 4.6 1M / max',  runner: 'claude', model: 'claude-sonnet-4-6[1m]', effort: 'max'    },
+  { id: 'sonnet-1m-high',label: 'Claude Sonnet 4.6 1M / high', runner: 'claude', model: 'claude-sonnet-4-6[1m]', effort: 'high'   },
   { id: 'opus-max',     label: 'Claude Opus 4.7 / max',    runner: 'claude', model: 'claude-opus-4-7',   effort: 'max'    },
   { id: 'opus-xhigh',   label: 'Claude Opus 4.7 / xHigh',  runner: 'claude', model: 'claude-opus-4-7',   effort: 'xHigh'  },
   { id: 'opus-high',    label: 'Claude Opus 4.7 / high',   runner: 'claude', model: 'claude-opus-4-7',   effort: 'high'   },
@@ -24,7 +34,19 @@ export const MODEL_PRESETS: ModelPreset[] = [
   { id: 'codex-medium', label: 'Codex / medium',           runner: 'codex',  model: 'gpt-5.4',           effort: 'medium' },
 ];
 
-export const PHASE_DEFAULTS: Record<number, string> = {
+export const PHASE_DEFAULTS: PhasePresetMap = {
+  1: 'opus-1m-high',
+  2: 'codex-high',
+  3: 'sonnet-1m-high',
+  4: 'codex-high',
+  5: 'sonnet-1m-high',
+  7: 'codex-high',
+};
+
+// Existing saved runs should keep the historical non-1M defaults when older
+// state.json files are migrated. Only newly-created runs should pick up the
+// new 1M defaults above.
+export const LEGACY_PHASE_DEFAULTS: PhasePresetMap = {
   1: 'opus-high',
   2: 'codex-high',
   3: 'sonnet-high',
@@ -96,7 +118,13 @@ export const PHASE_ARTIFACT_FILES: Record<number, string[]> = {
 
 export const LIGHT_REQUIRED_PHASE_KEYS = ['1', '5', '7'] as const;
 
-export const LIGHT_PHASE_DEFAULTS: Record<number, string> = {
+export const LIGHT_PHASE_DEFAULTS: PhasePresetMap = {
+  1: 'opus-1m-high',
+  5: 'sonnet-1m-high',
+  7: 'codex-high',
+};
+
+export const LEGACY_LIGHT_PHASE_DEFAULTS: PhasePresetMap = {
   1: 'opus-high',
   5: 'sonnet-high',
   7: 'codex-high',
@@ -108,6 +136,10 @@ export function getRequiredPhaseKeys(flow: FlowMode): readonly string[] {
 
 export function getPhaseDefaults(flow: FlowMode): Record<number, string> {
   return flow === 'light' ? LIGHT_PHASE_DEFAULTS : PHASE_DEFAULTS;
+}
+
+export function getLegacyPhaseDefaults(flow: FlowMode): Record<number, string> {
+  return flow === 'light' ? LEGACY_LIGHT_PHASE_DEFAULTS : LEGACY_PHASE_DEFAULTS;
 }
 
 export function getPhaseArtifactFiles(

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -138,7 +138,7 @@ function runItem(item: PreflightItem, cwd?: string): { codexPath?: string } {
         writeFileSync(tmpFile, '', 'utf-8');
         const result = spawnSync(
           'claude',
-          ['--model', 'claude-sonnet-4-6', `@${tmpFile}`, '--print', ''],
+          ['--model', 'claude-sonnet-4-6[1m]', `@${tmpFile}`, '--print', ''],
           {
             stdio: 'pipe',
             encoding: 'utf-8',

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,7 +1,13 @@
 import fs from 'fs';
 import path from 'path';
 import type { HarnessState, PhaseStatus } from './types.js';
-import { PHASE_DEFAULTS, REQUIRED_PHASE_KEYS, MODEL_PRESETS, getPresetById } from './config.js';
+import {
+  PHASE_DEFAULTS,
+  REQUIRED_PHASE_KEYS,
+  MODEL_PRESETS,
+  getLegacyPhaseDefaults,
+  getPresetById,
+} from './config.js';
 
 const STATE_FILE = 'state.json';
 const STATE_TMP_FILE = 'state.json.tmp';
@@ -60,9 +66,14 @@ export function readState(runDir: string): HarnessState | null {
  * Migrate a raw state object (potentially from an older version) to the current HarnessState shape.
  */
 export function migrateState(raw: any): HarnessState {
+  if (raw.flow !== 'full' && raw.flow !== 'light') {
+    raw.flow = 'full';
+  }
+
   if (!raw.phasePresets || typeof raw.phasePresets !== 'object') {
     raw.phasePresets = {};
   }
+  const legacyDefaults = getLegacyPhaseDefaults(raw.flow);
   // Note: the legacy `opus-max` → `opus-xhigh` migration (PR #22) was dropped
   // when the catalog re-introduced a real `opus-max` preset pinned to Opus 4.7
   // effort=`max`. Any state.json from before PR #22 that stored `opus-max`
@@ -72,7 +83,7 @@ export function migrateState(raw: any): HarnessState {
   for (const phase of REQUIRED_PHASE_KEYS) {
     const presetId = raw.phasePresets[phase];
     if (!presetId || !MODEL_PRESETS.find(p => p.id === presetId)) {
-      raw.phasePresets[phase] = PHASE_DEFAULTS[Number(phase)] ?? 'sonnet-high';
+      raw.phasePresets[phase] = legacyDefaults[Number(phase)] ?? 'sonnet-high';
     }
   }
   if (raw.lastWorkspacePid === undefined) raw.lastWorkspacePid = null;
@@ -113,9 +124,6 @@ export function migrateState(raw: any): HarnessState {
     ) {
       raw.phaseCodexSessions[key] = null;
     }
-  }
-  if (raw.flow !== 'full' && raw.flow !== 'light') {
-    raw.flow = 'full';
   }
   if (!('carryoverFeedback' in raw) || raw.carryoverFeedback === undefined) {
     raw.carryoverFeedback = null;

--- a/tests/preflight-claude-at-file.test.ts
+++ b/tests/preflight-claude-at-file.test.ts
@@ -36,7 +36,7 @@ describe('claude @file preflight', () => {
 
     expect(vi.mocked(spawnSync)).toHaveBeenCalledWith(
       'claude',
-      ['--model', 'claude-sonnet-4-6', expect.stringMatching(/^@/), '--print', ''],
+      ['--model', 'claude-sonnet-4-6[1m]', expect.stringMatching(/^@/), '--print', ''],
       expect.objectContaining({ timeout: 10_000, killSignal: 'SIGKILL' }),
     );
 

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -235,8 +235,8 @@ describe('createInitialState (updated)', () => {
 
   it('initializes phasePresets from PHASE_DEFAULTS', () => {
     const state = createInitialState('run-1', 'task', 'abc123', false);
-    expect(state.phasePresets['1']).toBe('opus-high');
-    expect(state.phasePresets['5']).toBe('sonnet-high');
+    expect(state.phasePresets['1']).toBe('opus-1m-high');
+    expect(state.phasePresets['5']).toBe('sonnet-1m-high');
   });
 
   it('initializes phaseReopenFlags to false', () => {
@@ -255,9 +255,14 @@ describe('migrateState', () => {
   it('backfills missing phasePresets', () => {
     const raw = { runId: 'test' };
     const migrated = migrateState(raw);
-    for (const key of ['1', '2', '3', '4', '5', '7']) {
-      expect(migrated.phasePresets[key]).toBe(PHASE_DEFAULTS[Number(key)]);
-    }
+    expect(migrated.phasePresets).toMatchObject({
+      '1': 'opus-high',
+      '2': 'codex-high',
+      '3': 'sonnet-high',
+      '4': 'codex-high',
+      '5': 'sonnet-high',
+      '7': 'codex-high',
+    });
   });
 
   it('backfills individual missing phase keys', () => {
@@ -271,6 +276,13 @@ describe('migrateState', () => {
     const migrated = migrateState(raw);
     expect(migrated.phasePresets['1']).toBe('opus-high');
     expect(migrated.phasePresets['2']).toBe('codex-high');
+  });
+
+  it('legacy migration backfills missing presets to non-1M defaults for old runs', () => {
+    const migrated = migrateState({ runId: 'legacy-run' });
+    expect(migrated.phasePresets['1']).toBe('opus-high');
+    expect(migrated.phasePresets['3']).toBe('sonnet-high');
+    expect(migrated.phasePresets['5']).toBe('sonnet-high');
   });
 
   it('preserves opus-max (now a real max-effort preset) across migration', () => {
@@ -354,6 +366,13 @@ describe('flow + carryoverFeedback (light-flow spec)', () => {
     const migrated = migrateState(raw);
     expect(migrated.flow).toBe('light');
     expect(migrated.carryoverFeedback).toBeNull();
+  });
+
+  it('legacy light-flow migration backfills non-1M Claude defaults for saved runs', () => {
+    const migrated = migrateState({ runId: 'legacy-light', flow: 'light' });
+    expect(migrated.phasePresets['1']).toBe('opus-high');
+    expect(migrated.phasePresets['5']).toBe('sonnet-high');
+    expect(migrated.phasePresets['7']).toBe('codex-high');
   });
 
   it('carryoverFeedback survives writeState → readState round-trip', () => {


### PR DESCRIPTION
## Summary
- add explicit Claude 1M presets alongside the legacy non-1M Claude presets
- default new runs to the 1M Claude presets while preserving old saved-run behavior
- document the manual fallback path for environments where Claude Code 1M context is unavailable

## What changed
- extended `MODEL_PRESETS` with:
  - `opus-1m-max`, `opus-1m-xhigh`, `opus-1m-high`
  - `sonnet-1m-max`, `sonnet-1m-high`
- switched `PHASE_DEFAULTS` and `LIGHT_PHASE_DEFAULTS` so new runs prefer the 1M Claude presets
- kept the legacy non-1M Claude presets in the picker as manual fallback options
- updated `migrateState()` so existing saved runs with missing/legacy preset state backfill to the old non-1M defaults instead of silently upgrading to 1M
- updated the Claude `@file` preflight weak-signal probe to follow the 1M default path
- updated `README.md`, `README.ko.md`, `docs/HOW-IT-WORKS.md`, and `docs/HOW-IT-WORKS.ko.md` for the new catalog/default/fallback behavior

## Why this shape
- the requested policy was: **add** 1M support, do not make Claude paths 1M-only
- new runs should default to 1M
- existing saved runs should remain untouched
- users on environments without 1M support should have an explicit fallback path instead of losing Claude support entirely

## Verification
- `pnpm run lint`
- `pnpm test`
- `pnpm run build`

## Notes
- README/HOW-IT-WORKS were reviewed and updated because the model catalog/default behavior changed.
- Existing non-1M Claude presets intentionally remain available unless we later decide to drop compatibility support.
