### PR TITLE
feat(npm): rename to phase-harness and prep for npm publish

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Daniel Mon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,6 @@
-# harness-cli
+# phase-harness
 
-`harness-cli`는 AI 기반 개발 작업을 **재현 가능하고 재개 가능한 tmux 워크플로우**로 실행하는 TypeScript CLI입니다.
+`phase-harness`는 AI 기반 개발 작업을 **재현 가능하고 재개 가능한 tmux 워크플로우**로 실행하는 TypeScript CLI입니다.
 
 지원 기능:
 - **7단계 full flow**: spec → spec gate → plan → plan gate → implement → verify → eval gate
@@ -109,11 +109,19 @@ Harness는 git working tree를 기준으로 동작하며, phase 경계에서 art
 
 ## 설치
 
+npm에서 전역 설치:
+
+```bash
+npm install -g phase-harness
+# or
+pnpm add -g phase-harness
+```
+
 로컬 개발 기준 설치:
 
 ```bash
-git clone <repo-url> harness-cli
-cd harness-cli
+git clone <repo-url> phase-harness
+cd phase-harness
 pnpm install
 pnpm run build
 pnpm link --global
@@ -130,7 +138,7 @@ pnpm run build
 전역 링크 제거:
 
 ```bash
-pnpm unlink --global harness-cli
+pnpm unlink --global phase-harness
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# harness-cli
+# phase-harness
 
-`harness-cli` is a TypeScript CLI for running AI-assisted engineering work as a reproducible, resumable tmux workflow.
+`phase-harness` is a TypeScript CLI for running AI-assisted engineering work as a reproducible, resumable tmux workflow.
 
 It supports:
 - a **full 7-phase flow**: spec → spec gate → plan → plan gate → implement → verify → eval gate
@@ -109,11 +109,19 @@ Notes:
 
 ## Installation
 
+Install globally from npm:
+
+```bash
+npm install -g phase-harness
+# or
+pnpm add -g phase-harness
+```
+
 For local development:
 
 ```bash
-git clone <repo-url> harness-cli
-cd harness-cli
+git clone <repo-url> phase-harness
+cd phase-harness
 pnpm install
 pnpm run build
 pnpm link --global
@@ -130,7 +138,7 @@ pnpm run build
 Remove the global link:
 
 ```bash
-pnpm unlink --global harness-cli
+pnpm unlink --global phase-harness
 ```
 
 ---

--- a/docs/process/evals/2026-04-19-untitled-2-eval.md
+++ b/docs/process/evals/2026-04-19-untitled-2-eval.md
@@ -1,27 +1,21 @@
 # Auto Verification Report
 - Date: 2026-04-19
-- Related Spec: docs/specs/2026-04-19-untitled-2-design.md
-- Related Plan: docs/plans/2026-04-19-untitled-2.md
-- RunId: 2026-04-19-untitled-2 (Phase 6 run manually after Phase 5→6 transition crash blocked on untracked prompt.txt)
+- Related Spec: N/A
+- Related Plan: N/A
 
 ## Results
 | Check | Status | Detail |
 |-------|--------|--------|
 | typecheck | pass |  |
-| tests | pass |  |
+| vitest | pass |  |
 | build | pass |  |
-| invariant: LIGHT_REQUIRED_PHASE_KEYS contains 2 | pass |  |
-| invariant: LIGHT_PHASE_DEFAULTS[2] === codex-high | pass |  |
-| invariant: getGateRetryLimit gate-aware signature | pass |  |
-| invariant: createInitialState light phases[2]=pending not skipped | pass |  |
-| invariant: FIVE_AXIS_DESIGN_GATE_LIGHT constant exists | pass |  |
-| invariant: buildLifecycleContext 5-phase light stanza | pass |  |
-| invariant: buildGatePromptPhase2 light branch present | pass |  |
-| invariant: runner passes gate to getGateRetryLimit | pass |  |
+| package-name-is-phase-harness | pass |  |
+| license-file-exists | pass |  |
+| npm-pack-dry-run | pass |  |
 
 ## Summary
-- Total: 11 checks
-- Pass: 11
+- Total: 6 checks
+- Pass: 6
 - Fail: 0
 
 ## Raw Output
@@ -48,7 +42,7 @@
 
 </details>
 
-### tests
+### vitest
 **Command:** `pnpm vitest run`
 **Exit code:** 0
 
@@ -57,96 +51,86 @@
 
 ```
 
- RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/light-pre-impl-gate
+ RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/npm-release
 
- ✓ tests/state.test.ts (46 tests) 48ms
- ✓ tests/context/skills-rendering.test.ts (45 tests) 98ms
- ✓ tests/logger.test.ts (31 tests) 102ms
- ✓ tests/phases/gate.test.ts (27 tests) 142ms
- ✓ tests/lock.test.ts (20 tests) 250ms
- ✓ tests/commands/inner.test.ts (20 tests) 265ms
- ✓ tests/commands/footer-ticker.test.ts (10 tests) 138ms
- ✓ tests/context/assembler.test.ts (64 tests) 383ms
- ✓ tests/integration/logging.test.ts (15 tests) 323ms
- ✓ tests/phases/gate-resume.test.ts (13 tests) 213ms
- ✓ tests/signal.test.ts (16 tests) 433ms
- ✓ tests/preflight.test.ts (29 tests | 1 skipped) 223ms
- ✓ tests/runners/claude-usage.test.ts (12 tests) 39ms
- ✓ tests/phases/runner.test.ts (76 tests) 512ms
+ ✓ tests/state.test.ts (48 tests) 89ms
+ ✓ tests/logger.test.ts (32 tests) 127ms
+ ✓ tests/context/skills-rendering.test.ts (45 tests) 128ms
+ ✓ tests/phases/gate.test.ts (27 tests) 157ms
+ ✓ tests/lock.test.ts (20 tests) 262ms
+ ✓ tests/commands/inner.test.ts (20 tests) 253ms
+ ✓ tests/commands/footer-ticker.test.ts (10 tests) 75ms
+ ✓ tests/phases/gate-resume.test.ts (13 tests) 140ms
+ ✓ tests/context/assembler.test.ts (64 tests) 419ms
+ ✓ tests/integration/logging.test.ts (15 tests) 333ms
+ ✓ tests/signal.test.ts (16 tests) 556ms
+ ✓ tests/preflight.test.ts (29 tests | 1 skipped) 291ms
+ ✓ tests/runners/claude-usage.test.ts (12 tests) 34ms
+ ✓ tests/phases/runner.test.ts (76 tests) 694ms
  ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 5ms
- ✓ tests/integration/codex-session-resume.test.ts (6 tests) 97ms
- ✓ tests/resume-light.test.ts (10 tests) 68ms
- ✓ tests/commands/inner-footer.test.ts (2 tests) 17ms
- ✓ tests/phases/runner-token-capture.test.ts (6 tests) 20ms
- ✓ tests/integration/light-flow.test.ts (4 tests) 180ms
- ✓ tests/runners/codex-resume.test.ts (8 tests) 60ms
- ✓ tests/phases/verify.test.ts (12 tests) 14ms
- ✓ tests/context/assembler-resume.test.ts (9 tests) 81ms
+ ✓ tests/commands/inner-footer.test.ts (2 tests) 23ms
+ ✓ tests/phases/runner-token-capture.test.ts (6 tests) 29ms
+ ✓ tests/integration/codex-session-resume.test.ts (6 tests) 87ms
+ ✓ tests/resume-light.test.ts (10 tests) 76ms
+ ✓ tests/runners/codex-resume.test.ts (8 tests) 62ms
+ ✓ tests/integration/light-flow.test.ts (4 tests) 175ms
+ ✓ tests/phases/verify.test.ts (12 tests) 7ms
  ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 8ms
- ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 50ms
- ✓ tests/runners/codex-isolation.test.ts (8 tests) 28ms
- ✓ tests/state-invalidation.test.ts (5 tests) 10ms
- ✓ tests/tmux.test.ts (33 tests) 814ms
-   ✓ pollForPidFile > returns null on timeout when file never appears 404ms
-   ✓ pollForPidFile > returns null when file contains non-numeric content 404ms
- ✓ tests/runners/codex.test.ts (6 tests) 53ms
- ✓ tests/phases/verdict.test.ts (16 tests) 3ms
- ✓ tests/root.test.ts (10 tests) 319ms
- ✓ tests/commands/status-list.test.ts (7 tests) 799ms
- ✓ tests/resume.test.ts (6 tests) 1499ms
-   ✓ resumeRun > errors when specCommit is not in git history 329ms
-[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui.test.ts (5 tests) 3ms
- ✓ tests/commands/resume-cmd.test.ts (12 tests) 2418ms
-   ✓ resumeCommand > resumeCommand — loggingEnabled inheritance > resume defaults to false when state has loggingEnabled=false 301ms
- ✓ tests/git.test.ts (16 tests) 1615ms
- ✓ tests/phases/gate-resume-escalation.test.ts (1 test) 33ms
- ✓ tests/ui-footer.test.ts (9 tests) 3ms
- ✓ tests/context/reviewer-contract.test.ts (4 tests) 69ms
- ✓ tests/input.test.ts (12 tests) 6ms
- ✓ tests/preflight-claude-at-file.test.ts (2 tests) 5ms
- ✓ tests/terminal.test.ts (5 tests) 4ms
+ ✓ tests/context/assembler-resume.test.ts (9 tests) 73ms
+ ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 47ms
+ ✓ tests/runners/codex-isolation.test.ts (8 tests) 23ms
+ ✓ tests/state-invalidation.test.ts (5 tests) 11ms
+ ✓ tests/runners/codex.test.ts (6 tests) 34ms
+ ✓ tests/tmux.test.ts (33 tests) 810ms
+   ✓ pollForPidFile > returns null on timeout when file never appears 403ms
+   ✓ pollForPidFile > returns null when file contains non-numeric content 402ms
+ ✓ tests/phases/verdict.test.ts (16 tests) 4ms
+ ✓ tests/root.test.ts (10 tests) 186ms
+ ✓ tests/commands/resume-cmd.test.ts (12 tests) 2036ms
+ ✓ tests/resume.test.ts (6 tests) 1309ms
+ ✓ tests/commands/status-list.test.ts (7 tests) 699ms
+[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui.test.ts (5 tests) 4ms
+ ✓ tests/phases/gate-resume-escalation.test.ts (1 test) 35ms
+ ✓ tests/ui-footer.test.ts (9 tests) 7ms
+ ✓ tests/context/reviewer-contract.test.ts (4 tests) 51ms
+ ✓ tests/git.test.ts (16 tests) 1361ms
+ ✓ tests/input.test.ts (12 tests) 3ms
+ ✓ tests/task-prompt.test.ts (7 tests) 2ms
+ ✓ tests/integration/lifecycle.test.ts (11 tests) 1333ms
+ ✓ tests/commands/jump.test.ts (6 tests) 664ms
+ ✓ tests/terminal.test.ts (5 tests) 3ms
+ ✓ tests/preflight-claude-at-file.test.ts (2 tests) 6ms
  ✓ tests/conformance/phase-models.test.ts (9 tests) 6ms
- ✓ tests/commands/jump.test.ts (6 tests) 689ms
- ✓ tests/integration/lifecycle.test.ts (11 tests) 1725ms
-   ✓ CLI lifecycle integration > harness --version outputs version 380ms
- ✓ tests/ui-separator.test.ts (5 tests) 3ms
- ✓ tests/process.test.ts (6 tests) 23ms
  ✓ tests/config.test.ts (8 tests) 2ms
- ✓ tests/runners/claude.test.ts (1 test) 16ms
- ✓ tests/commands/skip.test.ts (4 tests) 464ms
- ✓ tests/phases/dirty-tree.test.ts (12 tests) 2706ms
-   ✓ tryAutoRecoverDirtyTree > recovers python __pycache__ residuals under a tracked parent dir 366ms
-   ✓ tryAutoRecoverDirtyTree > recovers pytest cache residuals 318ms
-   ✓ tryAutoRecoverDirtyTree > recovers node_modules residuals 374ms
-   ✓ tryAutoRecoverDirtyTree > creates .gitignore when missing 357ms
-   ✓ tryAutoRecoverDirtyTree > commits with the expected chore message and includes runId 301ms
- ✓ tests/artifact.test.ts (12 tests) 2988ms
-   ✓ normalizeArtifactCommit > recovers from interrupted git add (target-only staged) 402ms
-   ✓ runPhase6Preconditions > no eval report → no-op, passes 355ms
-   ✓ runPhase6Preconditions > deletes untracked eval report 306ms
-   ✓ runPhase6Preconditions > git rm stages tracked eval report deletion without creating a reset commit 423ms
- ✓ tests/phases/eval-report-commit-squash.test.ts (6 tests) 3653ms
-   ✓ eval report commit squash > stages tracked eval report deletion without creating a reset commit and commits one rev-K report per round 1035ms
-   ✓ eval report commit squash > treats an already-staged eval report deletion as an idempotent precondition 616ms
-   ✓ eval report commit squash > resumes cleanly from the staged-D crash window and produces exactly one new rev-K commit 932ms
-   ✓ eval report commit squash > uses the rev 1 eval report message on the live verify pass path 372ms
-   ✓ eval report commit squash > uses the rev-K eval report message on both resume recovery paths 475ms
- ✓ tests/phases/interactive.test.ts (48 tests) 4285ms
-   ✓ validatePhaseArtifacts — Phase 5 > returns true when HEAD has advanced and working tree is clean 313ms
-   ✓ validatePhaseArtifacts — Phase 5 > auto-recovers a dirty tree with ignorable artifacts and returns true 429ms
-   ✓ validatePhaseArtifacts — Phase 5 > blocks on non-ignorable residual and writes diagnostic 332ms
-   ✓ validatePhaseArtifacts — Phase 5 > strictTree=true skips auto-recovery and writes strict-tree diagnostic 334ms
-   ✓ runInteractivePhase — Claude dispatch command shape > sendKeysToPane command includes --dangerously-skip-permissions and --effort 1629ms
- ✓ tests/commands/run.test.ts (19 tests) 4450ms
-   ✓ startCommand > accepts empty task as untitled 367ms
-   ✓ startCommand > creates required directories 313ms
-   ✓ startCommand > adds .harness/ to .gitignore 483ms
-   ✓ startCommand > is no-op when .gitignore already has .harness/ 382ms
+ ✓ tests/ui-separator.test.ts (5 tests) 1ms
+ ✓ tests/process.test.ts (6 tests) 37ms
+ ✓ tests/runners/claude.test.ts (1 test) 14ms
+ ✓ tests/commands/skip.test.ts (4 tests) 439ms
+ ✓ tests/phases/dirty-tree.test.ts (12 tests) 2361ms
+   ✓ tryAutoRecoverDirtyTree > recovers python __pycache__ residuals under a tracked parent dir 334ms
+ ✓ tests/artifact.test.ts (12 tests) 2584ms
+   ✓ normalizeArtifactCommit > recovers from interrupted git add (target-only staged) 381ms
+   ✓ runPhase6Preconditions > git rm stages tracked eval report deletion without creating a reset commit 360ms
+ ✓ tests/phases/eval-report-commit-squash.test.ts (6 tests) 3255ms
+   ✓ eval report commit squash > stages tracked eval report deletion without creating a reset commit and commits one rev-K report per round 988ms
+   ✓ eval report commit squash > treats an already-staged eval report deletion as an idempotent precondition 566ms
+   ✓ eval report commit squash > resumes cleanly from the staged-D crash window and produces exactly one new rev-K commit 706ms
+   ✓ eval report commit squash > uses the rev 1 eval report message on the live verify pass path 333ms
+   ✓ eval report commit squash > uses the rev-K eval report message on both resume recovery paths 428ms
+ ✓ tests/phases/interactive.test.ts (48 tests) 4199ms
+   ✓ validatePhaseArtifacts — Phase 5 > returns true when HEAD has advanced and working tree is clean 311ms
+   ✓ validatePhaseArtifacts — Phase 5 > auto-recovers a dirty tree with ignorable artifacts and returns true 338ms
+   ✓ runInteractivePhase — Claude dispatch command shape > sendKeysToPane command includes --dangerously-skip-permissions and --effort 1600ms
+ ✓ tests/commands/run.test.ts (19 tests) 3977ms
+   ✓ startCommand > accepts empty task as untitled 346ms
+   ✓ startCommand > creates required directories 319ms
+   ✓ startCommand > adds .harness/ to .gitignore 319ms
+   ✓ startCommand > is no-op when .gitignore already has .harness/ 303ms
 
- Test Files  55 passed (55)
-      Tests  803 passed | 1 skipped (804)
-   Start at  19:27:20
-   Duration  5.48s (transform 1.57s, setup 0ms, collect 3.80s, tests 32.46s, environment 6ms, prepare 2.43s)
+ Test Files  56 passed (56)
+      Tests  813 passed | 1 skipped (814)
+   Start at  20:16:32
+   Duration  5.28s (transform 1.54s, setup 0ms, collect 3.74s, tests 29.61s, environment 52ms, prepare 2.55s)
 ```
 
 </details>
@@ -218,7 +202,7 @@ Diff output format options
 
 ```
 
-> harness-cli@0.1.0 build /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/light-pre-impl-gate
+> phase-harness@0.1.0 build /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/npm-release
 > tsc && node scripts/copy-assets.mjs
 
 [copy-assets] copied src/context/prompts -> dist/src/context/prompts
@@ -238,8 +222,8 @@ Diff output format options
 
 </details>
 
-### invariant: LIGHT_REQUIRED_PHASE_KEYS contains 2
-**Command:** `grep -q "'2'" src/config.ts && grep -q 'LIGHT_REQUIRED_PHASE_KEYS' src/config.ts`
+### package-name-is-phase-harness
+**Command:** `node -e "const p=require('./package.json'); if(p.name!=='phase-harness'){console.error('expected name=phase-harness, got '+p.name);process.exit(1)}"`
 **Exit code:** 0
 
 <details>
@@ -260,8 +244,8 @@ Diff output format options
 
 </details>
 
-### invariant: LIGHT_PHASE_DEFAULTS[2] === codex-high
-**Command:** `grep -q '2:.*codex-high' src/config.ts`
+### license-file-exists
+**Command:** `test -f LICENSE`
 **Exit code:** 0
 
 <details>
@@ -282,15 +266,15 @@ Diff output format options
 
 </details>
 
-### invariant: getGateRetryLimit gate-aware signature
-**Command:** `grep -q 'gate\?: GatePhase' src/config.ts`
+### npm-pack-dry-run
+**Command:** `npm pack --dry-run`
 **Exit code:** 0
 
 <details>
 <summary>stdout (truncated to 100 lines)</summary>
 
 ```
-
+phase-harness-0.1.0.tgz
 ```
 
 </details>
@@ -299,117 +283,56 @@ Diff output format options
 <summary>stderr (truncated to 50 lines)</summary>
 
 ```
-
-```
-
-</details>
-
-### invariant: createInitialState light phases[2]=pending not skipped
-**Command:** `grep -q "'2': 'pending', '3': 'skipped'" src/state.ts`
-**Exit code:** 0
-
-<details>
-<summary>stdout (truncated to 100 lines)</summary>
-
-```
-
-```
-
-</details>
-
-<details>
-<summary>stderr (truncated to 50 lines)</summary>
-
-```
-
-```
-
-</details>
-
-### invariant: FIVE_AXIS_DESIGN_GATE_LIGHT constant exists
-**Command:** `grep -q 'FIVE_AXIS_DESIGN_GATE_LIGHT' src/context/assembler.ts`
-**Exit code:** 0
-
-<details>
-<summary>stdout (truncated to 100 lines)</summary>
-
-```
-
-```
-
-</details>
-
-<details>
-<summary>stderr (truncated to 50 lines)</summary>
-
-```
-
-```
-
-</details>
-
-### invariant: buildLifecycleContext 5-phase light stanza
-**Command:** `grep -q '5-phase light harness lifecycle' src/context/assembler.ts`
-**Exit code:** 0
-
-<details>
-<summary>stdout (truncated to 100 lines)</summary>
-
-```
-
-```
-
-</details>
-
-<details>
-<summary>stderr (truncated to 50 lines)</summary>
-
-```
-
-```
-
-</details>
-
-### invariant: buildGatePromptPhase2 light branch present
-**Command:** `grep -q "state.flow === 'light'" src/context/assembler.ts`
-**Exit code:** 0
-
-<details>
-<summary>stdout (truncated to 100 lines)</summary>
-
-```
-
-```
-
-</details>
-
-<details>
-<summary>stderr (truncated to 50 lines)</summary>
-
-```
-
-```
-
-</details>
-
-### invariant: runner passes gate to getGateRetryLimit
-**Command:** `grep -q 'getGateRetryLimit(state.flow, phase)' src/phases/runner.ts`
-**Exit code:** 0
-
-<details>
-<summary>stdout (truncated to 100 lines)</summary>
-
-```
-
-```
-
-</details>
-
-<details>
-<summary>stderr (truncated to 50 lines)</summary>
-
-```
-
+npm notice
+npm notice 📦  phase-harness@0.1.0
+npm notice Tarball Contents
+npm notice 1.1kB LICENSE
+npm notice 11.7kB README.ko.md
+npm notice 10.5kB README.md
+npm notice 31B dist/bin/harness.d.ts
+npm notice 3.9kB dist/bin/harness.js
+npm notice 3.6kB dist/bin/harness.js.map
+npm notice 3.3kB dist/scripts/harness-verify.sh
+npm notice 865B dist/src/artifact.d.ts
+npm notice 5.1kB dist/src/artifact.js
+npm notice 3.8kB dist/src/artifact.js.map
+npm notice 328B dist/src/commands/footer-ticker.d.ts
+npm notice 2.4kB dist/src/commands/footer-ticker.js
+npm notice 2.3kB dist/src/commands/footer-ticker.js.map
+npm notice 816B dist/src/commands/inner.d.ts
+npm notice 13.5kB dist/src/commands/inner.js
+npm notice 11.9kB dist/src/commands/inner.js.map
+npm notice 145B dist/src/commands/jump.d.ts
+npm notice 2.8kB dist/src/commands/jump.js
+npm notice 2.7kB dist/src/commands/jump.js.map
+npm notice 127B dist/src/commands/list.d.ts
+npm notice 2.2kB dist/src/commands/list.js
+npm notice 2.6kB dist/src/commands/list.js.map
+npm notice 170B dist/src/commands/resume.d.ts
+npm notice 7.9kB dist/src/commands/resume.js
+npm notice 6.6kB dist/src/commands/resume.js.map
+npm notice 127B dist/src/commands/skip.d.ts
+npm notice 2.1kB dist/src/commands/skip.js
+npm notice 2.0kB dist/src/commands/skip.js.map
+npm notice 310B dist/src/commands/start.d.ts
+npm notice 10.4kB dist/src/commands/start.js
+npm notice 8.5kB dist/src/commands/start.js.map
+npm notice 133B dist/src/commands/status.d.ts
+npm notice 3.1kB dist/src/commands/status.js
+npm notice 3.8kB dist/src/commands/status.js.map
+npm notice 2.5kB dist/src/config.d.ts
+npm notice 6.1kB dist/src/config.js
+npm notice 5.7kB dist/src/config.js.map
+npm notice 1.0kB dist/src/context/assembler.d.ts
+npm notice 28.5kB dist/src/context/assembler.js
+npm notice 15.3kB dist/src/context/assembler.js.map
+npm notice 11.1kB dist/src/context/playbooks/context-engineering.md
+npm notice 10.5kB dist/src/context/playbooks/git-workflow-and-versioning.md
+npm notice 1.1kB dist/src/context/playbooks/LICENSE-agent-skills.md
+npm notice 1.1kB dist/src/context/playbooks/VENDOR.md
+npm notice 3.6kB dist/src/context/prompts/phase-1-light.md
+npm notice 466B dist/src/context/prompts/phase-1.md
+npm notice 544B dist/src/context/prompts/phase-3.md
 ```
 
 </details>

--- a/docs/specs/2026-04-19-untitled-2-design.md
+++ b/docs/specs/2026-04-19-untitled-2-design.md
@@ -1,267 +1,155 @@
-# Light Flow Pre-Impl Gate (Phase 2) — Design Spec
-
-- Date: 2026-04-19
-- Status: Phase 1 output (harness light flow, runId `2026-04-19-untitled-2`)
-- Scope: `harness start --light` — activate Phase 2 Codex review slot *before* implementation
-- Supersedes / amends: [docs/specs/2026-04-18-light-flow-design.md](2026-04-18-light-flow-design.md) (ADR-4 keeps the P1-reopen-on-gate7 rule; ADR-15 below adds a new pre-impl gate)
-- Related decisions: `.harness/2026-04-19-untitled-2/decisions.md`
-- Implementation: **design only in this Phase 1; implementation plan produced in Phase 3**
-
+---
+related:
+  - .harness/2026-04-19-untitled-2/task.md
+  - .harness/2026-04-19-untitled-2/decisions.md
+  - .harness/2026-04-19-untitled-2/checklist.json
 ---
 
-## Context & Decisions
-
-### Why this work
-
-Today's light flow is `P1 design → P5 impl → P6 verify → P7 eval-gate`. Codex independent review happens exactly once, at P7. Because P7 runs after implementation, a design-level reject there triggers a `P7 REJECT → P1 reopen → P5 re-execute` chain in which the entire implementation is discarded and redone. Dog-food runs have observed this chain repeatedly. The "one gate" philosophy of the light flow was chosen to minimize Codex calls, but it deliberately trades away the cheapest review — the one that runs *before* any impl time is spent.
-
-**Solution:** activate the existing Phase 2 slot (currently `'skipped'` in light flow) so Codex reviews the combined design doc *before* Phase 5 runs. Full flow is not touched. The state schema already has `phases['2']`, `phaseCodexSessions['2']`, and `gateRetries['2']` reserved — light previously filled them with `'skipped'` / `null` / `0`. This spec flips that to active for newly-created light runs only.
-
-### What changes in the flow
-
-```
-BEFORE (light, today):
-  P1 design → [P2/P3/P4 skipped] → P5 impl → P6 verify → P7 eval-gate
-                                                              │
-                                         P7 REJECT → P1 reopen ┘
-                                                     └→ P5 → P6 → P7
-
-AFTER (light, this spec):
-  P1 design → P2 pre-impl review → [P3/P4 skipped] → P5 impl → P6 verify → P7 eval-gate
-                      │                                                         │
-                      P2 REJECT → P1 reopen ┐           P7 REJECT → P1 reopen ──┤
-                                            └→ P2 → P5 ...              (existing behavior retained)
-```
-
-- **Added**: single Codex gate at P2 reviewing the combined design doc (spec + Implementation Plan section).
-- **Unchanged**: P1 output shape; P3/P4 remain `'skipped'`; P5/P6/P7 behavior; full-flow behavior.
-- **Unchanged for existing runs**: runs created before this spec ships have `phases['2']='skipped'` persisted in `state.json`; forward migration does **not** flip that to `'pending'`, so resume behavior is identical.
-
-### Key Decisions
-
-| ID | Decision |
-|----|----------|
-| **ADR-15** | Light flow activates Phase 2 Codex review with combined-doc input (`<spec>` slot only; no `<plan>` slot — same precedent as light P7). |
-| **ADR-16** | Light P2 REJECT always reopens Phase 1 (`getReopenTarget(light, 2) === 1`, already the default). Scope-aware routing is **not** introduced at P2 — combined doc can't cleanly split design vs impl scope. |
-| **ADR-17** | Light P2 retry limit is **3** (same as full P2). Light P7 retry limit stays at **5** (status quo). Asymmetry preserved; `getGateRetryLimit` gains a `gate?: GatePhase` parameter so callers can resolve per-gate. (Open Question #2 flags whether P7 should also drop to 3.) |
-| **ADR-18** | Phase 2 feedback uses `pendingAction.feedbackPaths` only. **No `carryoverFeedback`** — feedback only travels one step (P2 → P1-reopen → P2), and P2 re-reads the updated spec artifact directly on retry. |
-| **ADR-19** | Forward-only state migration: existing light runs keep `phases['2']='skipped'`; only new light runs get `phases['2']='pending'`. Decision point is `createInitialState`, not `migrateState`. |
-| **ADR-20** | New reviewer rubric `FIVE_AXIS_DESIGN_GATE_LIGHT` covers spec + plan axes in a single 4-axis block. Reuse the existing full-flow SPEC+PLAN rubrics by concatenation is tempting but creates an 8-axis overload; a purpose-built rubric is cleaner and matches the combined-doc artifact shape. |
-| **ADR-21** | Slash-command integration is **out of scope** — the `/harness` skill was removed 2026-04-19 (CLAUDE.md). Only CLI + phase runner + assembler change here. |
-
----
+# Rename to `phase-harness` + npm publish prep — Design Spec (Light)
 
 ## Complexity
 
-Medium — single new gate activation touching `config.ts`, `state.ts`, `assembler.ts`, runner-level REJECT routing, plus doc updates; no new subsystem.
+Medium — 패키지 이름 변경 + npm 배포 산출물(publishConfig, LICENSE, prepublish hook) 정비 + 사용자 대면 문자열(README 2종, skill frontmatter 3종) 동기화. 파일 수는 많지 않으나 여러 카테고리를 조화롭게 바꿔야 하므로 Small은 아니다.
 
----
+## Context & Decisions
 
-## Requirements
+### 현재 상태
+- `package.json`: `name=harness-cli`, `version=0.1.0`, `bin={ harness: ./dist/bin/harness.js }`, `files=[dist, scripts/harness-verify.sh, README.md, README.ko.md]`, MIT, `engines.node>=18`.
+- `LICENSE` 파일 없음 (MIT 선언만 있음).
+- `.npmignore`/`.npmrc` 없음 — `files` 화이트리스트로 배포 대상 제어 중.
+- `prepublishOnly`/`repository`/`homepage`/`bugs` 필드 없음.
+- `src/context/skills/harness-phase-{1,3,5}-*.md` frontmatter/본문에 `harness-cli Phase N` 문구 존재 (assembler가 런타임에 렌더 → Claude에게 노출됨).
+- `README.md` / `README.ko.md` 제목/본문/설치 섹션이 `harness-cli`를 전제로 작성됨 (`pnpm link --global` 위주).
+- `tests/context/skills-rendering.test.ts:64` — `description: Use during harness-cli Phase 1` 문구가 **렌더 결과에 남지 않음**을 assert (음수 조건). skill description을 rename해도 이 assertion은 여전히 참이어야 한다.
+- `tests/runners/claude-usage.test.ts`의 경로 리터럴(`/Users/daniel/.grove/github.com/DongGukMon/harness-cli`)은 `encodeProjectDir` 인코딩 로직 검증용 → 패키지 이름과 무관, 변경 불필요.
 
-### R1 — CLI surface is unchanged
+### 핵심 결정
 
-`harness start --light "…"` keeps the same flag set. No new flag is introduced. Users do not opt in to the pre-impl gate — it is the only light mode after this change ships.
+1. **패키지 이름**: `harness-cli` → `phase-harness` (unscoped). 스코프(`@owner/phase-harness`) 사용 여부는 사용자가 명시하지 않았으므로 unscoped 기본값.
+2. **바이너리 이름 유지**: `bin.harness` 그대로. 이미 문서·스킬·tmux 세션명(`harness-<runId>`, `harness-ctrl`)·state 키까지 `harness` 토큰에 의존. 바이너리명을 바꾸면 사용자·운영자 학습 비용 증가 + 내부 문자열 수백 곳 연쇄 수정 필요. 패키지 식별자(`phase-harness`)와 명령어(`harness`)는 독립적이라는 것이 npm 표준 관례(예: `typescript` → `tsc`).
+3. **LICENSE 파일 추가**: MIT 원문을 `LICENSE`로 작성 → npm registry가 자동 인식. `files`에 포함시키지 않아도 npm이 LICENSE/README를 자동 포함하나, 명시적으로 `files`에 `"LICENSE"` 추가하여 의도 명확화.
+4. **prepublishOnly 훅**: `pnpm build`가 dist + 자산 복제를 수행하므로 `"prepublishOnly": "pnpm run build"` 추가 → `npm publish` 전 빌드 산출물 최신성 보장.
+5. **publishConfig.access=public**: 향후 scoped name으로 바꾸더라도 안전; 현재 unscoped 이름에는 no-op이나 명시 권장.
+6. **repository/homepage/bugs**: 현재 GitHub 경로(`github.com/DongGukMon/harness-cli`)를 참조. 리포 rename은 **사용자 요청 범위 밖**이므로 URL은 현 상태 유지(rename 후 GitHub 자동 리다이렉트).
+7. **skill 문자열 rename**: `harness-cli Phase N` → `phase-harness Phase N`. Frontmatter `description`은 실 런타임에서 strip되므로 기능 영향 없음 (`skills-rendering.test.ts:64` 계약 유지). 본문에서 노출되는 인라인 언급도 함께 통일.
+8. **README 2종 업데이트**: 제목/설명/설치 섹션. npm install 경로(`npm install -g phase-harness` / `pnpm add -g phase-harness`) 추가. `pnpm link --global`은 로컬 개발 섹션으로 유지. 7단계 → 5단계 light flow 등 기존 사실은 보존 (task에 명시된 "README 최신화"는 이름 변경 반영).
+9. **테스트 조정**: `skills-rendering.test.ts:64` — 음수 assertion이므로 rename 후에도 참(description 문자열 자체가 렌더 결과에서 빠지므로). 단, 새 문자열 `phase-harness Phase 1`이 **본문에** 남는지 여부를 별도로 테스트하는 케이스가 없으므로 assertion 수정 불필요. 실제로 그리기만 검증.
+10. **CLAUDE.md / docs/specs**: 이 결합 문서 및 향후 작업 문서는 갱신 대상. 하지만 `docs/specs/2026-04-12-harness-cli-design.md` 등 **역사 ADR**은 파일명에 날짜 + 구명칭을 포함하므로 변경하지 않는다 (ADR 불변성 관례). 본문 내용은 읽기만 할 뿐 기능에 영향 없음.
+11. **pnpm-lock.yaml**: 의존성 변경 없음 → `pnpm install` 실행시 lockfile의 `name: harness-cli` 부분이 재생성될 수 있음. 빌드 중 패키지명 변경 후 한 번 `pnpm install` 실행하여 lockfile 동기화.
 
-### R2 — State initialization (new light runs)
+### 범위 밖
+- GitHub 리포 rename
+- 바이너리 이름 변경
+- 버전 범프 (현재 `0.1.0` 유지 — 첫 publish 후 사용자 결정)
+- `npm publish` 실제 실행 (토큰/권한 필요, 본 phase는 준비만)
+- 오래된 design doc/plan doc 내 `harness-cli` 단어 전수 치환 (ADR 불변성)
 
-`createInitialState(runId, task, base, auto, logging, flow='light', …)` initializes `phases` with `'2': 'pending'` (instead of `'skipped'`). All other light-mode phase statuses (`'3': 'skipped'`, `'4': 'skipped'`) are unchanged.
+## Requirements / Scope
 
-### R3 — State migration (existing runs)
+**필수 산출물**
+1. `package.json`이 `phase-harness`로 publish 가능 (npm pack dry-run 성공, 필수 필드 존재).
+2. `LICENSE` 파일 존재 + MIT 원문.
+3. `README.md` / `README.ko.md` 첫 단락·설치 섹션이 새 이름 반영.
+4. 사용자 대면 skill 문자열(`src/context/skills/*.md`)이 새 이름 반영.
+5. `pnpm tsc --noEmit` / `pnpm vitest run` / `pnpm build` 모두 grün.
 
-`migrateState()` **must not** flip `phases['2']` from `'skipped'` to `'pending'`. Existing light runs resume with their persisted `'skipped'` and the loop walks over them as it does today. No state.json schema version bump. This is forward-only: only runs created by post-change `createInitialState` have P2 active.
+**비-목표**
+- 바이너리 command 이름 변경
+- 기능적 동작(phase flow, runner 선택, state 스키마) 변경
+- 역사 문서(`docs/specs/*-design.md`, `docs/plans/*.md`) 내 구명칭 전수 치환
 
-### R4 — Phase defaults
+## Design
 
-`LIGHT_PHASE_DEFAULTS[2] = 'codex-high'` is added. `LIGHT_REQUIRED_PHASE_KEYS` gains `'2'`.  `getPhaseDefaults('light')` then returns `{1: 'opus-high', 2: 'codex-high', 5: 'sonnet-high', 7: 'codex-high'}`. `promptModelConfig` iteration set expands by one key; no other UI behavior change.
+### 1. `package.json` 변환
 
-### R5 — Gate prompt assembly
+Before → After 핵심 diff:
 
-`buildGatePromptPhase2(state, cwd)` gains a `state.flow === 'light'` branch:
-
-```ts
-if (state.flow === 'light') {
-  return (
-    REVIEWER_CONTRACT_BASE + FIVE_AXIS_DESIGN_GATE_LIGHT +
-    buildLifecycleContext(2, 'light') +
-    `<spec>\n${specResult.content}\n</spec>\n`
-  );
+```jsonc
+{
+  "name": "phase-harness",                       // 변경
+  "version": "0.1.0",                            // 유지
+  "description": "AI agent harness orchestrator — multi-phase brainstorm/spec/plan/implement/verify lifecycle with gate reviews",
+  "type": "module",
+  "bin": { "harness": "./dist/bin/harness.js" }, // 바이너리명 유지
+  "files": ["dist", "scripts/harness-verify.sh", "README.md", "README.ko.md", "LICENSE"], // LICENSE 추가
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DongGukMon/harness-cli.git"
+  },
+  "homepage": "https://github.com/DongGukMon/harness-cli#readme",
+  "bugs": { "url": "https://github.com/DongGukMon/harness-cli/issues" },
+  "publishConfig": { "access": "public" },
+  "scripts": {
+    "build": "tsc && node scripts/copy-assets.mjs",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "tsc --noEmit",
+    "prepublishOnly": "pnpm run build"           // 추가
+  },
+  // keywords, license, engines, devDependencies, dependencies 유지
 }
-// existing full-flow path
-return (
-  REVIEWER_CONTRACT_BY_GATE[2] +
-  buildLifecycleContext(2) +
-  `<spec>\n${specResult.content}\n</spec>\n`
-);
 ```
 
-`buildLifecycleContext(2, flow)` extends to accept the flow parameter (matching the existing Phase 7 signature) and returns a light-aware stanza explaining "This is Gate 2 of a 5-phase light harness lifecycle (P1 design → P2 pre-impl review → P5 impl → P6 verify → P7 eval). The combined design spec contains the Implementation Plan section; there is no separate plan artifact. Implementation has not yet been produced." The full-flow stanza is unchanged.
+### 2. `LICENSE` 파일
 
-`buildResumeSections(phase, state, cwd)` for `phase === 2` is already correct for light: it emits only `<spec>`, no `<plan>`, no eval report — identical to full-flow P2 resume. No change needed.
+표준 MIT 라이선스 (저작권: `2026 Daniel Mon`). `files` 배열에 명시.
 
-### R6 — New rubric: `FIVE_AXIS_DESIGN_GATE_LIGHT`
+### 3. skill 문자열 rename
 
-Added to `src/context/assembler.ts`:
+- `src/context/skills/harness-phase-1-spec.md`
+  - `description: Use during harness-cli Phase 1 to ...` → `description: Use during phase-harness Phase 1 to ...`
+  - `당신은 harness-cli 파이프라인의 Phase 1에 있다` → `당신은 phase-harness 파이프라인의 Phase 1에 있다`
+- `src/context/skills/harness-phase-3-plan.md`
+  - `description: Use during harness-cli Phase 3 ...` → `description: Use during phase-harness Phase 3 ...`
+- `src/context/skills/harness-phase-5-implement.md`
+  - `description: Use during harness-cli Phase 5 ...` → `description: Use during phase-harness Phase 5 ...`
+  - `harness-cli 설치 디렉터리(dist 또는 src)` → `phase-harness 설치 디렉터리(dist 또는 src)`
 
-```
-## Five-Axis Evaluation (Phase 2 — design gate, light flow)
-평가 대상은 결합 design spec (spec + Implementation Plan 섹션이 한 문서에 있음). 4축 적용:
-1. Correctness — 요구사항/비요구사항/경계조건/성공기준 명시; plan 섹션이 spec 요구사항을 커버?
-2. Architecture — 태스크 분해가 수직 슬라이스이고 의존성 순서가 명확?
-3. Readability — 섹션 구성이 명확하고 모호 표현이 없는가?
-4. Scope — 단일 구현 세션으로 분해 가능한 크기? 여러 독립 프로젝트 섞이지 않음?
+파일명은 `harness-phase-*`로 유지 (assembler가 실제 파일명 토큰을 사용; 이름 변경 시 assembler 수정 필요). **파일 rename 없음.**
 
-Additional required check: spec MUST contain an explicit '## Open Questions' section. Missing/empty-without-rationale → P1.
-Note: light flow에는 별도 plan 아티팩트가 없다. plan 파일 부재를 finding으로 올리지 말 것. 구현(Phase 5) 아직 수행되지 않음 — 구현 관련 이슈는 Phase 7에서 다룬다.
-```
+### 4. README 업데이트 (2종 동시)
 
-Severity/Scope tagging and P0/P1 approval rules are inherited from `REVIEWER_CONTRACT_BASE`.
+- 제목: `# harness-cli` → `# phase-harness`
+- 첫 문단: 이름 반영
+- 설치 섹션에 npm install 경로 추가:
+  ```bash
+  # global install (end users)
+  npm install -g phase-harness
+  # or
+  pnpm add -g phase-harness
+  ```
+- 기존 `git clone` 로컬 개발 블록은 유지 (디렉터리명만 `phase-harness`로, repo URL은 유지). `pnpm unlink --global harness-cli` → `pnpm unlink --global phase-harness`.
 
-### R7 — REJECT routing
+### 5. 테스트/빌드 검증 전략
 
-`getGateRejectReopenTarget(state, phase=2, scope)` reuses the existing helper. `getReopenTarget(flow='light', gate=2)` → `1` (already the code path). The light+P7+scope='impl' → P5 carve-out does **not** extend to P2. All P2 REJECT outcomes route to P1 reopen regardless of `Scope:` tag.
-
-### R8 — Retry limit per gate
-
-`getGateRetryLimit(flow: FlowMode, gate?: GatePhase): number` signature becomes gate-aware:
-
-```ts
-export function getGateRetryLimit(flow: FlowMode, gate?: GatePhase): number {
-  if (flow === 'light' && gate === 2) return GATE_RETRY_LIMIT_FULL;   // 3
-  return flow === 'light' ? GATE_RETRY_LIMIT_LIGHT : GATE_RETRY_LIMIT_FULL;
-}
-```
-
-All existing call sites (`runner.ts::handleGateReject`, `runner.ts::handleGateEscalation`) pass the current `phase` as `gate`. Default behavior (no gate argument) is unchanged, so unrelated callers keep working.
-
-### R9 — Phase loop is unchanged structurally
-
-`runPhaseLoop` already dispatches on `isGatePhase(phase)` for `{2,4,7}` and walks past `'skipped'` phases. The only flow-level effect of R2 is that `phases['2']==='pending'` now falls through to `handleGatePhase(2, …)` for light runs. No new branch in the loop is required.
-
-### R10 — Logging / events
-
-Phase 2 emissions in light runs reuse the existing events with no schema extension:
-
-- `phase_start` / `gate_verdict` / `gate_retry` / `gate_error` carry `phase: 2` exactly as full flow does.
-- `preset.id === 'codex-high'` for new runs (R4 default).
-- `state.flow` is not added to gate events (already available via `session_start`'s contextual inference if needed later — out of scope here).
-
-### R11 — Artifact inputs visible to Phase 2
-
-`state.artifacts.spec` → combined doc at `docs/specs/<runId>-design.md` (already the light artifact layout). `state.artifacts.plan` is `''` for light; the light branch in `buildGatePromptPhase2` must not read it. Asserted by R5's branching.
-
-### R12 — Docs synchronized with behavior
-
-Same-PR doc updates:
-
-- `docs/specs/2026-04-18-light-flow-design.md`: add "See also: 2026-04-19-untitled-2-design.md — adds ADR-15/16/17 pre-impl gate" note; do **not** mutate ADR-4 (P1 reopen on P7 REJECT still holds).
-- `docs/HOW-IT-WORKS.md` / `.ko.md`: light-flow section replaces the 4-phase diagram with the 5-slot diagram (P2 active).
-- `CLAUDE.md`: project one-liner updates from "4-phase 경량 모드(P1 → P5 → P6 → P7)" to "5-slot 경량 모드(P1 → P2 → P5 → P6 → P7)".
-
----
-
-## Non-Requirements (Out of Scope)
-
-- **Full flow changes.** Full P1–P7 behavior, defaults, rubrics, and retry limits are untouched.
-- **Plan gate (P3/P4) in light.** No separate plan artifact and no P4 review — light keeps its single-document design model.
-- **Automatic complexity-based gate skip.** Whether a `Complexity: Small` spec should bypass P2 is a future question. This spec always runs P2 on new light runs.
-- **State schema breaking change.** `PhaseStatus` union, `HarnessState` shape, `phaseCodexSessions['2']`, `gateRetries['2']` — all preserved.
-- **Resume of pre-change runs.** Runs created before the change keep `phases['2']='skipped'` permanently. No retroactive migration.
-- **Slash-command (`/harness`) updates.** The skill was removed 2026-04-19.
-- **`carryoverFeedback` extension.** P2 feedback does not chain across more than one phase hop.
-- **P7 retry-limit change.** Left at 5 (status quo). Flagged as Open Question #2.
-
----
-
-## Invariants
-
-Any reviewer or implementer can verify these by grep / local test without running the harness:
-
-1. `getReopenTarget('light', 2) === 1` — grep `src/config.ts` for the `getReopenTarget` body.
-2. `getGateRetryLimit('light', 2) === 3` and `getGateRetryLimit('light', 7) === 5`.
-3. `LIGHT_REQUIRED_PHASE_KEYS` includes `'2'` — string match.
-4. `LIGHT_PHASE_DEFAULTS[2] === 'codex-high'`.
-5. `createInitialState(flow='light')` produces `phases['2'] === 'pending'` and `phases['3'] === phases['4'] === 'skipped'`.
-6. `migrateState()` on a pre-change state.json with `phases['2']==='skipped'` returns a state object whose `phases['2']` is still `'skipped'`.
-7. `buildGatePromptPhase2(state)` with `state.flow==='light'` returns a string that contains the substring `FIVE_AXIS_DESIGN_GATE_LIGHT` marker (e.g. `"Phase 2 — design gate, light flow"`) and does **not** read `state.artifacts.plan`.
-8. `buildLifecycleContext(2, 'light')` mentions `"5-phase light harness lifecycle"` and `"combined design spec"`.
-9. Existing full-flow gate2 output is byte-identical to pre-change (snapshot fixture).
-
----
-
-## Success Criteria
-
-1. **Unit:** A new test case `createInitialState('light')` asserts `phases['2']='pending'`. Companion test on `migrateState` with a seeded legacy state asserts `'skipped'` is preserved.
-2. **Unit:** `getGateRetryLimit` test matrix for `(full, undefined)`, `(full, 2)`, `(light, 2)`, `(light, 7)`, `(light, undefined)`.
-3. **Unit:** `assembleGatePrompt(2, state_light)` snapshot: contains the new rubric string; does not contain `<plan>`; contains light lifecycle stanza. The existing full-flow snapshot for `(2, state_full)` is unchanged.
-4. **Integration (light path):** runner test stepping a seeded run through `phases: {1:done, 2:pending, 3:skipped, 4:skipped, 5:pending, 6:pending, 7:pending}` verifies that after a mocked `APPROVE` at P2 the loop advances directly to P5 (skipping 3 and 4).
-5. **Integration (reject):** mocked `REJECT + Scope: design` at P2 → state transitions to `currentPhase=1`, `phases['1']='pending'`, `phaseReopenFlags['1']===true`, `pendingAction.feedbackPaths` non-empty.
-6. **Regression:** `pnpm tsc --noEmit`, `pnpm vitest run`, `pnpm build` all pass. Full-flow tests are untouched.
-
----
-
-## Risks
-
-| ID | Risk | Mitigation |
-|----|------|-----------|
-| R-A | Light P2 adds a Codex call → per-run cost increases by one high-effort review | Expected & intended. The alternative (post-impl P7 REJECT → full re-impl chain) is strictly more expensive. Mitigated further by R8 retry limit 3. |
-| R-B | New rubric drifts from full-flow SPEC/PLAN rubrics over time | Keep rubric text adjacent to the existing `FIVE_AXIS_SPEC_GATE` / `FIVE_AXIS_PLAN_GATE` constants so edits land together. |
-| R-C | `getGateRetryLimit` signature change breaks an external caller | Default parameter keeps old behavior (no gate argument → flow-level fallback). Add a compile-time test that the old call style still type-checks. |
-| R-D | Existing light run resumes and the user expects the new P2 to run | Documented: forward-only. Release note in the merge PR body must state this explicitly. |
-| R-E | Reviewer at P2 over-reaches into impl territory (flags missing tests/code) | Mitigated by the rubric's note "구현(Phase 5) 아직 수행되지 않음 — 구현 관련 이슈는 Phase 7에서 다룬다" and by `buildLifecycleContext(2, 'light')`. |
-| R-F | The combined-doc approach makes `Scope: design | impl | mixed` tagging noisy at P2 | ADR-16: ignore scope tag at P2. All REJECTs route to P1. Open Question #4 reconsiders. |
-| R-G | `phaseCodexSessions['2']` now gets populated; resume-from-error path already handles this identically to full flow | No new logic. Covered by existing Phase 2 session-invalidate tests. |
-
----
-
-## File-level Change List (preview for Phase 3)
-
-The Phase 3 plan will break these into tasks; listed here for spec correctness only.
-
-### Modify
-
-| File | Change |
-|---|---|
-| `src/config.ts` | `LIGHT_PHASE_DEFAULTS[2] = 'codex-high'`; `LIGHT_REQUIRED_PHASE_KEYS = ['1','2','5','7']`; `getGateRetryLimit(flow, gate?)` per-gate signature |
-| `src/state.ts` | `createInitialState`: light branch sets `phases['2']='pending'`. `migrateState`: no change (explicit comment: forward-only). |
-| `src/context/assembler.ts` | new `FIVE_AXIS_DESIGN_GATE_LIGHT`; `buildLifecycleContext(phase, flow)` signature extended; `buildGatePromptPhase2` adds `state.flow === 'light'` branch |
-| `src/phases/runner.ts` | `handleGateReject` + `handleGateEscalation` pass `phase` as second arg to `getGateRetryLimit` |
-| `docs/specs/2026-04-18-light-flow-design.md` | cross-reference note (non-mutating) |
-| `docs/HOW-IT-WORKS.md` + `.ko.md` | light-flow diagram: 4-phase → 5-slot |
-| `CLAUDE.md` | project one-liner updates |
-
-### Create
-
-| File | Purpose |
-|---|---|
-| `docs/specs/2026-04-19-untitled-2-design.md` | This spec |
-| `.harness/2026-04-19-untitled-2/decisions.md` | Decision log with trade-offs and alternatives |
-
-### Delete
-
-None.
-
----
+- `pnpm install` 한 번 실행하여 lockfile 동기화 (의도적 커밋 대상).
+- `pnpm tsc --noEmit`으로 타입 회귀 확인 (skill MD 변경은 타입에 영향 없음).
+- `pnpm vitest run`으로 전체 스위트 실행.
+- `pnpm build`로 dist + 자산 복제 확인 (copy-assets가 새 skill 문자열을 그대로 복제).
+- `npm pack --dry-run`으로 tarball 구조 점검 (checklist에 포함).
 
 ## Open Questions
 
-These are ambiguities the Gate 2 reviewer should flag or confirm:
+- **npm scope 여부**: 사용자가 unscoped `phase-harness`를 원하는지, 개인/조직 scope(예: `@danielmon/phase-harness`)를 원하는지 미확인. 현 설계는 unscoped 가정. 실 publish 직전 사용자 확인 필요.
+- **GitHub 리포 rename 타이밍**: `package.json.repository`가 현재 `DongGukMon/harness-cli`를 가리킨다. 리포 자체 rename은 본 작업 범위 밖이므로 URL은 현 상태. 리포 rename 시 GitHub redirect가 자동 유효하나, 사용자가 리포도 rename하기를 원하는 경우 후속 작업으로 분리.
+- **버전 정책**: 현 `0.1.0` 유지 (pre-1.0). 초기 publish 후 SemVer 정책은 사용자 결정.
 
-1. **Rubric shape — 4 axes vs carry-over of both full rubrics.** This spec uses a new 4-axis `FIVE_AXIS_DESIGN_GATE_LIGHT` rubric (Correctness / Architecture / Readability / Scope). Alternative: concatenate the existing `FIVE_AXIS_SPEC_GATE` (3 axes) and `FIVE_AXIS_PLAN_GATE` (4 axes) producing a 7-axis block. The bespoke 4-axis choice is cleaner but deviates from the "five-axis" naming convention. Acceptable?
-2. **Light P7 retry limit.** ADR-17 keeps it at 5; task intent text says "재검토". Recommendation: lower to 3 to match P2 now that design issues are caught earlier, but only after one dog-food cycle shows P7 REJECT frequency dropping. Defer or decide now?
-3. **Scope-tag handling at P2 light.** ADR-16 ignores the `Scope:` tag and always routes REJECT to P1. If a reviewer ever tags `Scope: impl` at P2 (unexpected since impl doesn't exist yet), current spec still reopens P1. Should we warn/log this anomaly, or is silent P1-reopen acceptable?
-4. **Combined-doc size at P2 vs size limits.** `MAX_PROMPT_SIZE_KB=500` / `MAX_FILE_SIZE_KB=200` bounds apply. Is an explicit size-specific pre-check at P2 needed, or does the existing `assembleGatePrompt` size guard suffice?
-5. **Backward-compat release-note wording.** Existing light runs keep `phases['2']='skipped'` forever. Should the CLI emit a one-time info line at resume time when it detects this legacy shape, or is a changelog-only note enough?
+## Implementation Plan
 
----
+- **Task 1 — package.json 재구성**: `name`, `repository`, `homepage`, `bugs`, `publishConfig`, `prepublishOnly`, `files`(+LICENSE) 추가/변경.
+- **Task 2 — LICENSE 파일 생성**: MIT 표준 원문 + 저작권 연도/이름.
+- **Task 3 — skill 문자열 rename**: `src/context/skills/harness-phase-{1,3,5}-*.md` 본문/frontmatter의 `harness-cli` → `phase-harness` (파일 rename 없음).
+- **Task 4 — README.md + README.ko.md 업데이트**: 제목·첫 문단·설치 섹션(npm install 경로 추가)·unlink 명령 동기화.
+- **Task 5 — 의존성/빌드 동기화**: `pnpm install` 실행하여 `pnpm-lock.yaml`을 새 이름으로 갱신, `pnpm build`로 dist 재생성.
+- **Task 6 — 검증**: `pnpm tsc --noEmit` / `pnpm vitest run` / `pnpm build` / `npm pack --dry-run` 모두 성공 확인. skills-rendering 테스트의 음수 assertion이 여전히 참인지 재확인.
 
-## Acceptance (self-check for this Phase 1 output)
+## Eval Checklist Summary
 
-- [x] `## Context & Decisions` at top
-- [x] `## Complexity` present with one of {Small, Medium, Large} — value: `Medium`
-- [x] `## Open Questions` non-empty (5 items)
-- [x] Scope and non-requirements explicitly separated
-- [x] Full flow untouched (stated + verified via file-level change list)
-- [x] Forward-only migration stated
-- [x] Retry-limit decision explicit (ADR-17)
-- [x] Rubric, lifecycle context, reopen target all pinned by invariants
+실제 검증 JSON은 `.harness/2026-04-19-untitled-2/checklist.json` 참조. 요약:
+
+1. **typecheck** — `pnpm tsc --noEmit`
+2. **vitest** — `pnpm vitest run`
+3. **build** — `pnpm build`
+4. **package name** — `node -e` 로 `package.json.name === 'phase-harness'` 단언
+5. **npm pack dry-run** — `npm pack --dry-run`가 0-exit로 완료하고 tarball에 `LICENSE` 포함
+6. **LICENSE exists** — `test -f LICENSE`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "harness-cli",
+  "name": "phase-harness",
   "version": "0.1.0",
   "description": "AI agent harness orchestrator — multi-phase brainstorm/spec/plan/implement/verify lifecycle with gate reviews",
   "type": "module",
@@ -8,8 +8,16 @@
     "dist",
     "scripts/harness-verify.sh",
     "README.md",
-    "README.ko.md"
+    "README.ko.md",
+    "LICENSE"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DongGukMon/harness-cli.git"
+  },
+  "homepage": "https://github.com/DongGukMon/harness-cli#readme",
+  "bugs": { "url": "https://github.com/DongGukMon/harness-cli/issues" },
+  "publishConfig": { "access": "public" },
   "engines": {
     "node": ">=18.0.0"
   },
@@ -17,7 +25,8 @@
     "build": "tsc && node scripts/copy-assets.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "prepublishOnly": "pnpm run build"
   },
   "keywords": [
     "ai",

--- a/src/context/skills/harness-phase-1-spec.md
+++ b/src/context/skills/harness-phase-1-spec.md
@@ -1,12 +1,12 @@
 ---
 name: harness-phase-1-spec
-description: Use during harness-cli Phase 1 to brainstorm and write a spec that passes the harness spec gate (Phase 2).
+description: Use during phase-harness Phase 1 to brainstorm and write a spec that passes the harness spec gate (Phase 2).
 ---
 
 # harness Phase 1 — Spec writing
 
 ## Context
-당신은 harness-cli 파이프라인의 Phase 1에 있다. 산출물(spec)은 Phase 2에서 Codex가 다음 5축 rubric의 subset으로 평가한다:
+당신은 phase-harness 파이프라인의 Phase 1에 있다. 산출물(spec)은 Phase 2에서 Codex가 다음 5축 rubric의 subset으로 평가한다:
 - **Correctness** — 요구사항/비요구사항/경계조건/성공기준이 명시되었는가?
 - **Readability** — 섹션 구성이 명확하고 모호한 표현이 없는가?
 - **Scope** — 단일 구현 plan으로 분해 가능한 크기인가? 여러 독립 프로젝트가 섞이지 않았는가?

--- a/src/context/skills/harness-phase-3-plan.md
+++ b/src/context/skills/harness-phase-3-plan.md
@@ -1,6 +1,6 @@
 ---
 name: harness-phase-3-plan
-description: Use during harness-cli Phase 3 to write an implementation plan + eval checklist that passes the harness plan gate (Phase 4).
+description: Use during phase-harness Phase 3 to write an implementation plan + eval checklist that passes the harness plan gate (Phase 4).
 ---
 
 # harness Phase 3 — Planning

--- a/src/context/skills/harness-phase-5-implement.md
+++ b/src/context/skills/harness-phase-5-implement.md
@@ -1,6 +1,6 @@
 ---
 name: harness-phase-5-implement
-description: Use during harness-cli Phase 5 to implement the plan with harness invariants (commits, context management, git discipline).
+description: Use during phase-harness Phase 5 to implement the plan with harness invariants (commits, context management, git discipline).
 ---
 
 # harness Phase 5 — Implementation
@@ -33,7 +33,7 @@ superpowers가 커버하지 않는 두 원칙을 지킨다:
 - Context management: @{{playbookDir}}/context-engineering.md
 - Git workflow: @{{playbookDir}}/git-workflow-and-versioning.md
 
-*(`{{playbookDir}}`는 harness-cli 설치 디렉터리(dist 또는 src) 내부의 `playbooks/` 경로로 assembler가 해결한다.)*
+*(`{{playbookDir}}`는 phase-harness 설치 디렉터리(dist 또는 src) 내부의 `playbooks/` 경로로 assembler가 해결한다.)*
 
 ## Process
 0. **(Scaffolding only — prevention-first gitignore)** 구현을 시작하기 전에 대상 언어·프레임워크의 표준 `.gitignore` 엔트리(예: `__pycache__/`, `.pytest_cache/`, `.venv/`, `node_modules/`, `dist/`, `build/`, `.DS_Store`)를 프로젝트 루트 `.gitignore`에 보강한다. 기존 `.gitignore`가 이미 해당 엔트리를 포함하면 no-op. 이 변경은 `chore: add standard gitignore entries` 등 **독립된 scaffolding commit**으로 두고, impl 커밋과 섞지 않는다. Sentinel 직전에 `git status --porcelain`을 셀프 체크해 tracked 파일이 전부 커밋된 상태인지 확인한다. 하네스에 자동 recovery가 있어도 이 단계는 효율성과 로그 가독성 측면에서 값어치가 있다.


### PR DESCRIPTION
## Summary
- Rename package `harness-cli` → `phase-harness` (package.json, README, skill frontmatter/body references)
- Add MIT `LICENSE` (2026 Daniel Mon), include in `files[]`
- Add `repository` / `homepage` / `bugs` / `publishConfig` / `prepublishOnly` to package.json for npm publish

## Context
- Spec: `docs/specs/2026-04-19-untitled-2-design.md`
- Eval: `docs/process/evals/2026-04-19-untitled-2-eval.md`

## Test plan
- [ ] `pnpm tsc --noEmit`
- [ ] `pnpm vitest run`
- [ ] `pnpm build` produces dist with renamed assets
- [ ] `npm pack --dry-run` shows LICENSE + expected files