### PR TITLE
polish: review follow-ups for debugging branch (T1/T2/T3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ pnpm build          # tsc + scripts/copy-assets.mjs (dist 생성)
 | `gate_verdict` | `phase`, `retryIndex`, `runner`, `verdict`, `durationMs`, `tokensTotal`, `promptBytes`, `codexSessionId`, `resumedFrom`, `resumeFallback`, `preset` |
 | `gate_retry` | `phase`, `retryIndex`, `retryCount`, `retryLimit`, `feedbackPath`, `feedbackBytes`, `feedbackPreview` |
 | `gate_error` | `preset` (PR #11) |
-| `ui_render` | `phase`, `phaseStatus`, `callsite` (PR <next> — emitted from every `renderControlPanel(state, logger, callsite)` call: `loop-top`, `interactive-*`, `gate-*`, `verify-*`, `terminal-*`) |
+| `ui_render` | `phase`, `phaseStatus`, `callsite: RenderCallsite` (PR #39 — emitted from every `renderControlPanel(state, logger, callsite)` call; `callsite` is a literal union of `loop-top`, `interactive-*`, `gate-*`, `verify-*`, `terminal-*`) |
 
 `claudeTokens` 3-state 계약: 성공 시 객체, 추출 실패 시 `null` + 단일 stderr warn (best-effort, 런 실패시키지 않음), 시도 자체가 해당 없으면 필드 부재.
 

--- a/src/commands/inner.ts
+++ b/src/commands/inner.ts
@@ -227,9 +227,9 @@ export async function innerCommand(runId: string, options: InnerOptions = {}): P
     } else if (anyPhaseFailed(state)) {
       await enterFailedTerminalState(state, harnessDir, runDir, cwd, inputManager, logger);
       // After R/J flow returns: classify, and surface idle panel if it ended in completion.
-      // Re-read state.status via a cast — the call above can mutate it, but TS still
-      // narrows from the surrounding if/else-if chain that excluded 'completed'/'paused'.
-      const postStatus = state.status as HarnessState['status'];
+      // The else-if chain narrowed state.status to 'in_progress'; the call above can mutate it,
+      // so widen via indirect access before classifying.
+      const postStatus = (state as HarnessState).status;
       if (postStatus === 'completed') {
         sessionEndStatus = 'completed';
         await enterIdle();

--- a/src/phases/terminal-ui.ts
+++ b/src/phases/terminal-ui.ts
@@ -9,7 +9,7 @@ import type {
 } from '../types.js';
 import type { InputManager } from '../input.js';
 import { writeState, invalidatePhaseSessionsOnJump } from '../state.js';
-import { renderControlPanel, printError, printInfo, printWarning } from '../ui.js';
+import { renderControlPanel, printError, printInfo } from '../ui.js';
 
 export function anyPhaseFailed(state: HarnessState): boolean {
   return Object.values(state.phases).some(s => s === 'failed' || s === 'error');
@@ -70,9 +70,10 @@ export async function performResume(
   sidecarReplayAllowed: { value: boolean },
 ): Promise<void> {
   const failed = findFailedPhase(state);
-  if (failed !== null) {
-    state.phases[String(failed)] = 'pending';
+  if (failed === null) {
+    throw new Error('performResume called with no failed phase — caller should gate via anyPhaseFailed');
   }
+  state.phases[String(failed)] = 'pending';
   // Clear the run-level paused fields if anything left them set.
   state.status = 'in_progress';
   state.pauseReason = null;
@@ -137,9 +138,8 @@ export async function enterFailedTerminalState(
     const failedPhase = findFailedPhase(state);
     if (failedPhase !== null) {
       printError(`Phase ${failedPhase} failed.`);
-    } else {
-      printWarning('No failed phase detected (defensive).');
     }
+    // else: unreachable — anyPhaseFailed gates entry; asserted via tests.
 
     process.stderr.write('\nRecent events:\n');
     process.stderr.write(summarizeRecentEvents(runDir) + '\n');
@@ -193,12 +193,11 @@ export async function enterFailedTerminalState(
  */
 export async function enterCompleteTerminalState(
   state: HarnessState,
-  runDir: string,
-  cwd: string,
+  _runDir: string,
+  _cwd: string,
   logger: SessionLogger,
   abortSignal?: AbortSignal,
 ): Promise<void> {
-  void cwd;
   renderControlPanel(state, logger, 'terminal-complete');
 
   process.stderr.write('\n');
@@ -220,8 +219,14 @@ export async function enterCompleteTerminalState(
     return;
   }
 
+  // Fallback path: no AbortSignal supplied. Production callers (inner.ts)
+  // always pass a signal, but this branch keeps the helper usable from
+  // ad-hoc scripts / future callers without forcing them to wire one up.
+  // NOTE: the SIGINT handler is registered via `once`, so it auto-removes
+  // on fire — but if the caller resolves through some other path before
+  // SIGINT, the listener leaks until the process exits. This is acceptable
+  // because the helper is only invoked at terminal state.
   await new Promise<void>((resolve) => {
     process.once('SIGINT', () => resolve());
   });
-  void runDir;
 }

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -486,6 +486,12 @@ function updateExternalCommitsDetected(state: HarnessState, cwd: string, runDir:
 /**
  * Validate Phase 1/3/5 artifacts when fresh sentinel is detected on resume.
  * Runs normalize_artifact_commit for Phase 1/3.
+ *
+ * Phase 5 success: HEAD has advanced past `implRetryBase`. No working-tree
+ * cleanliness check (auto-recovery removed 2026-04-19). Reopen-zero-commit
+ * is intentionally NOT accepted here because this helper runs only for
+ * fresh-sentinel recovery (not the verify-failure reopen path).
+ *
  * Returns true if the phase can be treated as completed.
  */
 export function completeInteractivePhaseFromFreshSentinel(

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,6 +185,17 @@ export interface ClaudeTokens {
 
 // --- Session Logging Events ---
 
+export type RenderCallsite =
+  | 'loop-top'
+  | 'interactive-redirect'
+  | 'interactive-complete'
+  | 'gate-redirect'
+  | 'gate-approve'
+  | 'verify-complete'
+  | 'verify-redirect'
+  | 'terminal-failed'
+  | 'terminal-complete';
+
 // Distributive Omit: applies Omit to each member of a union separately,
 // preserving discriminated-union specificity (needed for LogEvent variants).
 export type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never;
@@ -248,7 +259,7 @@ export type LogEvent =
       event: 'ui_render';
       phase: number;
       phaseStatus: PhaseStatus;
-      callsite: string;
+      callsite: RenderCallsite;
     })
   | (LogEventBase & { event: 'session_end'; status: 'completed' | 'paused' | 'interrupted'; totalWallMs: number });
 

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,6 +1,6 @@
 import { MODEL_PRESETS, REQUIRED_PHASE_KEYS, getPresetById } from './config.js';
 import type { FooterSummary } from './metrics/footer-aggregator.js';
-import type { HarnessState, FlowMode, SessionLogger } from './types.js';
+import type { HarnessState, FlowMode, SessionLogger, RenderCallsite } from './types.js';
 import type { InputManager } from './input.js';
 
 // ANSI color codes
@@ -34,7 +34,7 @@ function phaseLabel(phase: number, flow: FlowMode = 'full'): string {
 export function renderControlPanel(
   state: HarnessState,
   logger?: SessionLogger,
-  callsite?: string,
+  callsite?: RenderCallsite,
 ): void {
   process.stdout.write('\x1b[2J\x1b[H'); // clear screen
   console.error(separator());

--- a/tests/phases/terminal-ui.test.ts
+++ b/tests/phases/terminal-ui.test.ts
@@ -111,6 +111,13 @@ describe('performResume (inner-side)', () => {
     expect(state.phases['5']).toBe('pending');
     expect(runPhaseLoop).toHaveBeenCalledOnce();
   });
+
+  it('throws when called with no failed phase', async () => {
+    const state = makeState({ phases: { '1': 'completed', '2': 'completed', '3': 'completed', '4': 'completed', '5': 'pending', '6': 'pending', '7': 'pending' } });
+    await expect(
+      performResume(state, '/h', makeTmpDir(), '/cwd', new MockInput() as unknown as InputManager, makeLogger(), { value: false })
+    ).rejects.toThrow(/no failed phase/);
+  });
 });
 
 describe('performJump (inner-side)', () => {
@@ -156,6 +163,24 @@ describe('enterFailedTerminalState', () => {
     input.enqueue('r');
     await enterFailedTerminalState(state, '/harness', makeTmpDir(), '/cwd', input as unknown as InputManager, makeLogger());
     expect(runPhaseLoop).toHaveBeenCalledOnce();
+  });
+
+  it('R triggers performResume; if a fresh failure surfaces, loop continues until Q', async () => {
+    const { runPhaseLoop } = await import('../../src/phases/runner.js');
+    vi.mocked(runPhaseLoop).mockClear();
+    // First R: runPhaseLoop runs, leaves state with phase 6 newly failed.
+    vi.mocked(runPhaseLoop).mockImplementationOnce(async (s: any) => {
+      s.phases['5'] = 'completed';
+      s.phases['6'] = 'failed';
+      // status stays 'in_progress' — loop should re-prompt
+    });
+    const state = makeState();
+    const input = new MockInput();
+    // R → loop returns with new failure → render again → Q to exit
+    input.enqueue('r', 'q');
+    await enterFailedTerminalState(state, '/harness', makeTmpDir(), '/cwd', input as unknown as InputManager, makeLogger());
+    expect(runPhaseLoop).toHaveBeenCalledOnce();
+    expect(state.phases['6']).toBe('failed');
   });
 
   it('Q exits cleanly without re-entering the loop', async () => {

--- a/tests/ui.test.ts
+++ b/tests/ui.test.ts
@@ -125,7 +125,7 @@ describe('renderControlPanel — ui_render emission', () => {
     const origErr = console.error;
     console.error = (...args: any[]) => { captured.push(args.join(' ')); };
     try {
-      renderControlPanel(state, logger, 'unit-test');
+      renderControlPanel(state, logger, 'loop-top');
     } finally {
       console.error = origErr;
     }
@@ -133,7 +133,7 @@ describe('renderControlPanel — ui_render emission', () => {
       event: 'ui_render',
       phase: 5,
       phaseStatus: 'in_progress',
-      callsite: 'unit-test',
+      callsite: 'loop-top',
     });
   });
 


### PR DESCRIPTION
## Summary

Cumulative review follow-ups from the T1/T2/T3 code reviews of the `debugging` branch (PR #39). Stacked on top of `debugging`, so this targets `debugging` and should merge after #39 lands (or be re-based onto `main`).

- **P1** — `LogEvent.ui_render.callsite` promoted from `string` to a `RenderCallsite` literal union (9 members). Catches typos at compile time.
- **P2** — `performResume` now throws when no phase is failed (instead of silently no-oping). Matches the `anyPhaseFailed` entry invariant.
- **P3** — `enterCompleteTerminalState` SIGINT-only fallback now has a clarifying comment on the `once`-registered listener leak semantics.
- **P4** — `CLAUDE.md` `ui_render` row: `<next>` replaced with PR #39, note that `callsite` is a literal union.
- **P5** — Dropped `void cwd;` / `void runDir;` lines (underscore params instead); replaced `state.status as HarnessState['status']` with `(state as HarnessState).status` in `inner.ts`.
- **P6** — `completeInteractivePhaseFromFreshSentinel` JSDoc refreshed to reflect the post-2026-04-19 Phase 5 contract.
- **T1** — New test: "R then fresh failure → loop continues" — the most interesting R/J/Q failure mode.
- **T2** — Deleted the unreachable defensive `printWarning('No failed phase detected')` branch + now-unused `printWarning` import.

## Test plan

- [x] `pnpm tsc --noEmit`
- [x] `pnpm vitest run` (790 passed, 1 skipped — includes 2 new tests)
- [x] `pnpm build`