### PR TITLE
fix: 3 user-impacting bugs (model selection, claudeTokens, findFailedPhase)

### DIFF
--- a/src/phases/terminal-ui.ts
+++ b/src/phases/terminal-ui.ts
@@ -15,8 +15,11 @@ export function anyPhaseFailed(state: HarnessState): boolean {
   return Object.values(state.phases).some(s => s === 'failed' || s === 'error');
 }
 
-function findFailedPhase(state: HarnessState): number | null {
-  for (const key of Object.keys(state.phases)) {
+// Sort numerically so "lowest-numbered failed phase" doesn't depend on V8's
+// integer-like key enumeration order (which a JSON round-trip could disturb).
+export function findFailedPhase(state: HarnessState): number | null {
+  const sortedKeys = Object.keys(state.phases).sort((a, b) => Number(a) - Number(b));
+  for (const key of sortedKeys) {
     const s = state.phases[key];
     if (s === 'failed' || s === 'error') return Number(key);
   }

--- a/src/runners/claude-usage.ts
+++ b/src/runners/claude-usage.ts
@@ -87,6 +87,10 @@ export function readClaudeSessionUsage(input: ReadClaudeSessionUsageInput): Clau
     try {
       const { tokens, skippedLines } = parseSessionFile(pinnedPath);
       if (skippedLines > 0) warn(`skipped ${skippedLines} malformed line(s) in ${pinnedPath}`);
+      // 3-state contract: zero tokens means no assistant response was logged
+      // before Claude exited. Return null so the caller omits claudeTokens
+      // from phase_end instead of writing a misleading all-zero object.
+      if (tokens.total === 0) return null;
       return tokens;
     } catch (err) {
       warn(`failed to read pinned session ${pinnedPath}: ${(err as Error).message}`);
@@ -133,6 +137,7 @@ export function readClaudeSessionUsage(input: ReadClaudeSessionUsageInput): Clau
   try {
     const { tokens, skippedLines } = parseSessionFile(path.join(projectDir, winner.file));
     if (skippedLines > 0) warn(`skipped ${skippedLines} malformed line(s) in ${winner.file}`);
+    if (tokens.total === 0) return null;
     return tokens;
   } catch (err) {
     warn(`fallback read failed ${winner.file}: ${(err as Error).message}`);

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -263,17 +263,16 @@ export async function promptModelConfig(
     console.error('');
     console.error(`  Phase ${phase} (${phaseLabels[phase]}) — model:`);
 
-    const presetKeys = new Set<string>();
     MODEL_PRESETS.forEach((p, i) => {
       const current = p.id === presets[phase] ? ` ${YELLOW}← current${RESET}` : '';
       console.error(`  [${i + 1}] ${p.label}${current}`);
-      presetKeys.add(String(i + 1));
     });
-    console.error(`  Select (1-${MODEL_PRESETS.length}):`);
+    console.error(`  Select (1-${MODEL_PRESETS.length}, Enter to cancel):`);
 
-    const choice = await inputManager.waitForKey(presetKeys);
+    const choice = (await inputManager.waitForLine()).trim();
+    if (choice === '') continue;
     const idx = Number(choice) - 1;
-    if (idx >= 0 && idx < MODEL_PRESETS.length) {
+    if (Number.isInteger(idx) && idx >= 0 && idx < MODEL_PRESETS.length) {
       presets[phase] = MODEL_PRESETS[idx].id;
     }
   }

--- a/tests/phases/terminal-ui.test.ts
+++ b/tests/phases/terminal-ui.test.ts
@@ -8,6 +8,7 @@ import {
   performResume,
   performJump,
   anyPhaseFailed,
+  findFailedPhase,
 } from '../../src/phases/terminal-ui.js';
 import { InputManager } from '../../src/input.js';
 import type { HarnessState, SessionLogger } from '../../src/types.js';
@@ -95,6 +96,31 @@ describe('anyPhaseFailed', () => {
   });
   it('false when all phases are pending/completed/skipped/in_progress', () => {
     expect(anyPhaseFailed(makeState({ phases: { '1': 'completed', '2': 'completed', '3': 'pending', '4': 'pending', '5': 'pending', '6': 'pending', '7': 'pending' } }))).toBe(false);
+  });
+});
+
+describe('findFailedPhase', () => {
+  it('returns the lowest-numbered failed phase regardless of key insertion order', () => {
+    // Build phases map in reverse insertion order to defeat any
+    // implementation relying on insertion ordering.
+    const phases: Record<string, any> = {};
+    phases['7'] = 'failed';
+    phases['5'] = 'failed';
+    phases['3'] = 'pending';
+    phases['1'] = 'completed';
+    expect(findFailedPhase(makeState({ phases: phases as any }))).toBe(5);
+  });
+
+  it('returns null when no phase is failed/error', () => {
+    expect(findFailedPhase(makeState({
+      phases: { '1': 'completed', '2': 'completed', '3': 'completed', '4': 'completed', '5': 'completed', '6': 'completed', '7': 'pending' } as any,
+    }))).toBeNull();
+  });
+
+  it('treats "error" status as failed', () => {
+    expect(findFailedPhase(makeState({
+      phases: { '1': 'completed', '2': 'completed', '3': 'completed', '4': 'completed', '5': 'error', '6': 'pending', '7': 'pending' } as any,
+    }))).toBe(5);
   });
 });
 

--- a/tests/runners/claude-usage.test.ts
+++ b/tests/runners/claude-usage.test.ts
@@ -176,8 +176,8 @@ describe('readClaudeSessionUsage', () => {
     expect(skippedWrites).toHaveLength(1);
   });
 
-  // Case 5 — no assistant entries → zero-sum, not null
-  it('returns a zero-sum object when the session has no assistant entries', () => {
+  // Case 5 — no assistant entries → null (3-state contract: object | null | absent)
+  it('returns null when the pinned session has no assistant entries', () => {
     const dir = projectDirFor(tmpHome, CWD);
     writeSession(path.join(dir, `${ATTEMPT_ID}.jsonl`), [
       nonAssistantLine('queue-operation', PHASE_START),
@@ -189,7 +189,20 @@ describe('readClaudeSessionUsage', () => {
       phaseStartTs: PHASE_START,
       homeDir: tmpHome,
     });
-    expect(result).toEqual({ input: 0, output: 0, cacheRead: 0, cacheCreate: 0, total: 0 });
+    expect(result).toBeNull();
+  });
+
+  // Case 5b — pinned file is completely empty → null
+  it('returns null when the pinned JSONL is completely empty', () => {
+    const dir = projectDirFor(tmpHome, CWD);
+    writeSession(path.join(dir, `${ATTEMPT_ID}.jsonl`), []);
+    const result = readClaudeSessionUsage({
+      sessionId: ATTEMPT_ID,
+      cwd: CWD,
+      phaseStartTs: PHASE_START,
+      homeDir: tmpHome,
+    });
+    expect(result).toBeNull();
   });
 
   // Case 6 — cache-only entries sum correctly

--- a/tests/ui-prompt-model-config.test.ts
+++ b/tests/ui-prompt-model-config.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { promptModelConfig } from '../src/ui.js';
+import type { InputManager } from '../src/input.js';
+import { MODEL_PRESETS } from '../src/config.js';
+
+function mockInput(queue: string[]): InputManager {
+  const items = [...queue];
+  return {
+    waitForKey: async (_valid: Set<string>) => {
+      const next = items.shift();
+      if (next === undefined) throw new Error('test: no key/line queued');
+      if (next === '\r' || next === '\n') return next;
+      return next.toLowerCase().toUpperCase();
+    },
+    waitForLine: async () => {
+      const next = items.shift();
+      if (next === undefined) throw new Error('test: no line queued');
+      return next;
+    },
+  } as unknown as InputManager;
+}
+
+describe('promptModelConfig — multi-digit preset selection', () => {
+  it('accepts a numeric preset index typed as a line', async () => {
+    const initial: Record<string, string> = {
+      '1': MODEL_PRESETS[0].id,
+      '2': 'codex-high',
+      '3': 'sonnet-high',
+      '4': 'codex-high',
+      '5': 'sonnet-high',
+      '7': 'codex-high',
+    };
+    const input = mockInput(['1', '5', '\r']);
+    const out = await promptModelConfig(initial, input, ['1'], 'full');
+    expect(out['1']).toBe(MODEL_PRESETS[4].id);
+  });
+
+  it('rejects out-of-range numeric input and re-prompts', async () => {
+    const initial: Record<string, string> = {
+      '1': MODEL_PRESETS[0].id,
+      '2': 'codex-high',
+      '3': 'sonnet-high',
+      '4': 'codex-high',
+      '5': 'sonnet-high',
+      '7': 'codex-high',
+    };
+    const input = mockInput(['1', '99', '1', '2', '\r']);
+    const out = await promptModelConfig(initial, input, ['1'], 'full');
+    expect(out['1']).toBe(MODEL_PRESETS[1].id);
+  });
+
+  it('treats empty line as cancel and returns to phase select', async () => {
+    const initial: Record<string, string> = {
+      '1': MODEL_PRESETS[0].id,
+      '2': 'codex-high',
+      '3': 'sonnet-high',
+      '4': 'codex-high',
+      '5': 'sonnet-high',
+      '7': 'codex-high',
+    };
+    // phase 1 → empty line (cancel) → confirm without changes
+    const input = mockInput(['1', '', '\r']);
+    const out = await promptModelConfig(initial, input, ['1'], 'full');
+    expect(out['1']).toBe(MODEL_PRESETS[0].id);
+  });
+});


### PR DESCRIPTION
## Summary

3개의 독립적인 버그 수정. `debugging` 브랜치 위에 stack.

- **B1** `src/ui.ts` — `promptModelConfig`의 preset 선택을 `waitForKey` → `waitForLine`로 전환. 현재 7개 preset이라 latent 상태지만 10번째가 추가되는 순간 두 자리 입력이 first-digit으로 truncate되어 잘못된 preset이 선택됨. Phase 선택은 1-7로 고정이라 single-key 그대로 유지.
- **B2** `src/runners/claude-usage.ts` — pinned JSONL이 존재하지만 assistant 응답이 한 건도 기록되기 전에 Claude가 종료한 경우 `{0,0,0,0,0}` 객체를 그대로 반환하고 있었음. PR #16의 3-state contract(object | null | absent) 위반. 이제 `total === 0`이면 `null` 반환 → caller가 `phase_end.claudeTokens` 필드 자체를 생략.
- **B3** `src/phases/terminal-ui.ts` — `findFailedPhase`가 `Object.keys` 열거 순서에 의존(V8의 integer-like key 정렬 동작이 우연히 부합)했으나 JSON round-trip 등으로 깨질 수 있음. 명시적으로 numeric sort. 단위 테스트 가능하도록 `export`.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm vitest run` — 795 passed / 1 skipped
  - 신규 테스트: `tests/ui-prompt-model-config.test.ts` (3 cases), `tests/runners/claude-usage.test.ts` Case 5/5b 갱신, `tests/phases/terminal-ui.test.ts` `findFailedPhase` 3 cases
- [x] `pnpm build` — clean

## Notes

- Base = `debugging`. 해당 브랜치가 `main`에 머지된 후 자연 fast-forward 또는 rebase 후 머지 가능.
- 각 버그는 독립 commit으로 분리되어 있어 필요 시 cherry-pick 가능.