### PR TITLE
feat: observability additions for terminal-ui (O1 + O2 + U1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ pnpm build          # tsc + scripts/copy-assets.mjs (dist 생성)
 | `gate_retry` | `phase`, `retryIndex`, `retryCount`, `retryLimit`, `feedbackPath`, `feedbackBytes`, `feedbackPreview` |
 | `gate_error` | `preset` (PR #11) |
 | `ui_render` | `phase`, `phaseStatus`, `callsite` (PR <next> — emitted from every `renderControlPanel(state, logger, callsite)` call: `loop-top`, `interactive-*`, `gate-*`, `verify-*`, `terminal-*`) |
+| `terminal_action` | `action: 'resume' \| 'jump' \| 'quit'`, `fromPhase: number`, `targetPhase?: number` (PR <next> — emitted from `enterFailedTerminalState` when user picks an action) |
 
 `claudeTokens` 3-state 계약: 성공 시 객체, 추출 실패 시 `null` + 단일 stderr warn (best-effort, 런 실패시키지 않음), 시도 자체가 해당 없으면 필드 부재.
 

--- a/docs/HOW-IT-WORKS.ko.md
+++ b/docs/HOW-IT-WORKS.ko.md
@@ -223,7 +223,7 @@ light flow에서는 skipped phase로 jump할 수 없습니다.
   summary.json
 ```
 
-주요 이벤트는 `phase_start`, `phase_end`, `gate_verdict`, `gate_error`, `gate_retry`, `verify_result`, `ui_render`, `session_end` 등입니다.
+주요 이벤트는 `phase_start`, `phase_end`, `gate_verdict`, `gate_error`, `gate_retry`, `verify_result`, `ui_render`, `terminal_action`, `session_end` 등입니다.
 control pane footer는 이 로그를 바탕으로 경과 시간과 Claude/gate 토큰 합계를 집계합니다.
 
 ---

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -223,7 +223,7 @@ When enabled, harness writes under:
   summary.json
 ```
 
-Important logged events include `phase_start`, `phase_end`, `gate_verdict`, `gate_error`, `gate_retry`, `verify_result`, `ui_render`, and `session_end`.
+Important logged events include `phase_start`, `phase_end`, `gate_verdict`, `gate_error`, `gate_retry`, `verify_result`, `ui_render`, `terminal_action`, and `session_end`.
 The control-pane footer aggregates elapsed time plus Claude/gate token totals from those logs.
 
 ---

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "build": "tsc && node scripts/copy-assets.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "sessions:summary": "node scripts/sessions-summary.mjs"
   },
   "keywords": [
     "ai",

--- a/scripts/sessions-summary.mjs
+++ b/scripts/sessions-summary.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const SESSIONS_ROOT = process.env.HARNESS_SESSIONS_ROOT
+  ?? path.join(os.homedir(), '.harness', 'sessions');
+
+const args = process.argv.slice(2);
+const sinceDaysIdx = args.indexOf('--since-days');
+const sinceDays = sinceDaysIdx >= 0 ? Number(args[sinceDaysIdx + 1]) : 14;
+const sinceMs = Date.now() - sinceDays * 24 * 60 * 60 * 1000;
+
+if (!fs.existsSync(SESSIONS_ROOT)) {
+  console.error(`No sessions root at ${SESSIONS_ROOT}`);
+  process.exit(0);
+}
+
+const stats = {
+  totalSessions: 0,
+  sessionsWithEvents: 0,
+  endStatuses: { completed: 0, paused: 0, interrupted: 0 },
+  phaseFailures: 0,
+  terminalActions: { resume: 0, jump: 0, quit: 0 },
+  uiRenderTotal: 0,
+};
+
+function scanSession(jsonlPath, mtimeMs) {
+  if (mtimeMs < sinceMs) return;
+  stats.totalSessions += 1;
+  const raw = fs.readFileSync(jsonlPath, 'utf-8');
+  const lines = raw.split('\n').filter(Boolean);
+  if (lines.length === 0) return;
+  stats.sessionsWithEvents += 1;
+  for (const line of lines) {
+    let ev;
+    try { ev = JSON.parse(line); } catch { continue; }
+    if (ev.event === 'session_end' && stats.endStatuses[ev.status] !== undefined) {
+      stats.endStatuses[ev.status] += 1;
+    }
+    if (ev.event === 'phase_end' && ev.status === 'failed') stats.phaseFailures += 1;
+    if (ev.event === 'terminal_action' && stats.terminalActions[ev.action] !== undefined) {
+      stats.terminalActions[ev.action] += 1;
+    }
+    if (ev.event === 'ui_render') stats.uiRenderTotal += 1;
+  }
+}
+
+function walk(dir) {
+  for (const name of fs.readdirSync(dir)) {
+    const abs = path.join(dir, name);
+    const st = fs.statSync(abs);
+    if (st.isDirectory()) walk(abs);
+    else if (name === 'events.jsonl') scanSession(abs, st.mtimeMs);
+  }
+}
+
+walk(SESSIONS_ROOT);
+
+console.log(`Sessions in last ${sinceDays} days: ${stats.totalSessions} total, ${stats.sessionsWithEvents} with events`);
+console.log(`session_end statuses:`);
+for (const [k, v] of Object.entries(stats.endStatuses)) console.log(`  ${k}: ${v}`);
+console.log(`phase_end status=failed: ${stats.phaseFailures}`);
+console.log(`terminal_action counts: resume=${stats.terminalActions.resume}, jump=${stats.terminalActions.jump}, quit=${stats.terminalActions.quit}`);
+console.log(`ui_render events: ${stats.uiRenderTotal}`);

--- a/src/phases/terminal-ui.ts
+++ b/src/phases/terminal-ui.ts
@@ -148,10 +148,15 @@ export async function enterFailedTerminalState(
     process.stderr.write('\n[R] Resume   [J] Jump to phase   [Q] Quit\n');
 
     const choice = await inputManager.waitForKey(new Set(['r', 'j', 'q']));
+    const fromPhase = findFailedPhase(state) ?? state.currentPhase;
 
-    if (choice === 'Q') return;
+    if (choice === 'Q') {
+      logger.logEvent({ event: 'terminal_action', action: 'quit', fromPhase });
+      return;
+    }
 
     if (choice === 'R') {
+      logger.logEvent({ event: 'terminal_action', action: 'resume', fromPhase });
       try {
         await performResume(state, harnessDir, runDir, cwd, inputManager, logger, sidecarReplayAllowed);
       } catch (err) {
@@ -175,6 +180,7 @@ export async function enterFailedTerminalState(
     process.stderr.write(`\nJump to which phase? (${targets.join(' / ')})\n`);
     const phaseKey = await inputManager.waitForKey(targetKeys);
     const target = Number(phaseKey) as InteractivePhase;
+    logger.logEvent({ event: 'terminal_action', action: 'jump', fromPhase, targetPhase: target });
 
     try {
       await performJump(target, state, harnessDir, runDir, cwd, inputManager, logger);

--- a/src/phases/terminal-ui.ts
+++ b/src/phases/terminal-ui.ts
@@ -43,6 +43,32 @@ function summarizeRecentEvents(runDir: string, limit = 10): string {
   }
 }
 
+function fastClaudeFailureHint(eventsPath: string): string | null {
+  try {
+    const raw = fs.readFileSync(eventsPath, 'utf-8');
+    const lines = raw.trimEnd().split('\n');
+    for (let i = lines.length - 1; i >= 0; i--) {
+      let ev: any;
+      try { ev = JSON.parse(lines[i]); } catch { continue; }
+      if (ev.event !== 'phase_end' || ev.status !== 'failed') continue;
+      const tokens = ev.claudeTokens;
+      const dur = ev.durationMs ?? 0;
+      const zeroObj = tokens && typeof tokens === 'object' && tokens.total === 0;
+      const nullToken = tokens === null;
+      if ((zeroObj || nullToken) && dur < 30_000) {
+        return [
+          'Hint: Claude exited within ' + Math.round(dur / 1000) + 's with no assistant output.',
+          'Common causes: folder-trust dialog blocking the workspace pane, immediate crash,',
+          'or the Claude binary failing to launch. Check the workspace tmux pane for a dialog',
+          'before pressing [R] (a fresh attempt will hit the same wall).',
+        ].join('\n');
+      }
+      return null;
+    }
+  } catch { /* file missing or unreadable */ }
+  return null;
+}
+
 function summarizeGitStatus(cwd: string, headLines = 10): string {
   try {
     const out = execSync('git status --porcelain', { cwd, encoding: 'utf-8' }).trimEnd();
@@ -143,6 +169,12 @@ export async function enterFailedTerminalState(
 
     process.stderr.write('\nRecent events:\n');
     process.stderr.write(summarizeRecentEvents(runDir) + '\n');
+
+    const hint = fastClaudeFailureHint(path.join(runDir, 'events.jsonl'));
+    if (hint !== null) {
+      process.stderr.write('\n' + hint + '\n');
+    }
+
     process.stderr.write('\nWorking tree:\n');
     process.stderr.write(summarizeGitStatus(cwd) + '\n');
     process.stderr.write('\n[R] Resume   [J] Jump to phase   [Q] Quit\n');

--- a/src/types.ts
+++ b/src/types.ts
@@ -250,6 +250,12 @@ export type LogEvent =
       phaseStatus: PhaseStatus;
       callsite: string;
     })
+  | (LogEventBase & {
+      event: 'terminal_action';
+      action: 'resume' | 'jump' | 'quit';
+      fromPhase: number;
+      targetPhase?: number;
+    })
   | (LogEventBase & { event: 'session_end'; status: 'completed' | 'paused' | 'interrupted'; totalWallMs: number });
 
 export interface SessionMeta {

--- a/tests/phases/terminal-ui.test.ts
+++ b/tests/phases/terminal-ui.test.ts
@@ -201,6 +201,33 @@ describe('enterFailedTerminalState', () => {
     }));
   });
 
+  it('shows a fast-Claude-failure hint when the most recent phase_end matches', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const state = makeState();
+    const runDir = makeTmpDir();
+    fs.writeFileSync(path.join(runDir, 'events.jsonl'),
+      JSON.stringify({ event: 'phase_end', phase: 5, status: 'failed', durationMs: 6800, claudeTokens: { input: 0, output: 0, cacheRead: 0, cacheCreate: 0, total: 0 } }) + '\n');
+    const input = new MockInput();
+    input.enqueue('q');
+    await enterFailedTerminalState(state, '/harness', runDir, '/cwd', input as unknown as InputManager, makeLogger());
+    const hintShown = stderrSpy.mock.calls.some(c => /Hint: Claude exited within/.test(String(c[0])));
+    expect(hintShown).toBe(true);
+    stderrSpy.mockRestore();
+  });
+
+  it('does not show the hint when duration is long', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const state = makeState();
+    const runDir = makeTmpDir();
+    fs.writeFileSync(path.join(runDir, 'events.jsonl'),
+      JSON.stringify({ event: 'phase_end', phase: 5, status: 'failed', durationMs: 600_000, claudeTokens: null }) + '\n');
+    const input = new MockInput();
+    input.enqueue('q');
+    await enterFailedTerminalState(state, '/harness', runDir, '/cwd', input as unknown as InputManager, makeLogger());
+    const hintShown = stderrSpy.mock.calls.some(c => /Hint: Claude exited within/.test(String(c[0])));
+    expect(hintShown).toBe(false);
+    stderrSpy.mockRestore();
+  });
 });
 
 describe('enterCompleteTerminalState', () => {

--- a/tests/phases/terminal-ui.test.ts
+++ b/tests/phases/terminal-ui.test.ts
@@ -142,7 +142,7 @@ describe('performJump (inner-side)', () => {
 });
 
 describe('enterFailedTerminalState', () => {
-  it("R triggers performResume and re-enters runPhaseLoop", async () => {
+  it("R triggers performResume and emits terminal_action event", async () => {
     const { runPhaseLoop } = await import('../../src/phases/runner.js');
     vi.mocked(runPhaseLoop).mockClear();
     const state = makeState();
@@ -154,21 +154,33 @@ describe('enterFailedTerminalState', () => {
     });
     const input = new MockInput();
     input.enqueue('r');
-    await enterFailedTerminalState(state, '/harness', makeTmpDir(), '/cwd', input as unknown as InputManager, makeLogger());
+    const logger = makeLogger();
+    await enterFailedTerminalState(state, '/harness', makeTmpDir(), '/cwd', input as unknown as InputManager, logger);
     expect(runPhaseLoop).toHaveBeenCalledOnce();
+    expect(logger.logEvent).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'terminal_action',
+      action: 'resume',
+      fromPhase: 5,
+    }));
   });
 
-  it('Q exits cleanly without re-entering the loop', async () => {
+  it('Q exits cleanly without re-entering the loop and emits terminal_action quit', async () => {
     const { runPhaseLoop } = await import('../../src/phases/runner.js');
     vi.mocked(runPhaseLoop).mockClear();
     const state = makeState();
     const input = new MockInput();
     input.enqueue('q');
-    await enterFailedTerminalState(state, '/harness', makeTmpDir(), '/cwd', input as unknown as InputManager, makeLogger());
+    const logger = makeLogger();
+    await enterFailedTerminalState(state, '/harness', makeTmpDir(), '/cwd', input as unknown as InputManager, logger);
     expect(runPhaseLoop).not.toHaveBeenCalled();
+    expect(logger.logEvent).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'terminal_action',
+      action: 'quit',
+      fromPhase: 5,
+    }));
   });
 
-  it('J prompts for phase number, then dispatches performJump', async () => {
+  it('J prompts for phase number, then dispatches performJump and emits terminal_action jump', async () => {
     const { runPhaseLoop } = await import('../../src/phases/runner.js');
     vi.mocked(runPhaseLoop).mockClear();
     vi.mocked(runPhaseLoop).mockImplementationOnce(async (s: any) => {
@@ -177,10 +189,18 @@ describe('enterFailedTerminalState', () => {
     const state = makeState();
     const input = new MockInput();
     input.enqueue('j', '3');
-    await enterFailedTerminalState(state, '/harness', makeTmpDir(), '/cwd', input as unknown as InputManager, makeLogger());
+    const logger = makeLogger();
+    await enterFailedTerminalState(state, '/harness', makeTmpDir(), '/cwd', input as unknown as InputManager, logger);
     expect(state.currentPhase).toBe(3);
     expect(runPhaseLoop).toHaveBeenCalledOnce();
+    expect(logger.logEvent).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'terminal_action',
+      action: 'jump',
+      fromPhase: 5,
+      targetPhase: 3,
+    }));
   });
+
 });
 
 describe('enterCompleteTerminalState', () => {


### PR DESCRIPTION
## Summary

- **O1**: New `terminal_action` LogEvent emitted from `enterFailedTerminalState`
  when user picks R / J / Q. Lets us measure recovery-action distribution.
- **O2**: New `pnpm sessions:summary` one-shot script that scans
  `~/.harness/sessions/**/events.jsonl` and reports session_end status
  distribution, phase failures, terminal-action counts, and ui_render totals.
- **U1**: In failed terminal-state, when the most recent phase_end shows
  Claude exited within 30s with zero tokens, surface a hint about the
  workspace pane (likely folder-trust dialog blocking).

> Base set to `debugging` so the diff shows only this PR's commits. After
> `debugging` lands on `main`, the base will collapse to `main` automatically.

## Test plan

- [x] pnpm tsc --noEmit
- [x] pnpm vitest run (new tests for O1 events + U1 hint; 790 passed)
- [x] pnpm build
- [x] pnpm sessions:summary --since-days 30 → prints summary block