### PR TITLE
docs(readme): sync light flow to 5-phase with P2 pre-impl gate

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -4,7 +4,7 @@
 
 지원 기능:
 - **7단계 full flow**: spec → spec gate → plan → plan gate → implement → verify → eval gate
-- 작은 작업을 위한 **4단계 light flow**: design+plan → implement → verify → eval gate
+- 작은 작업을 위한 **5단계 light flow**: design+plan → pre-impl gate → implement → verify → eval gate
 - 시작/재개 시점의 **phase별 모델 preset 선택**
 - `resume`, `status`, `list`, `skip`, `jump`를 통한 **tmux 기반 복구/제어**
 - **선택적 세션 로깅**과 경과 시간·토큰 수를 보여주는 live footer
@@ -52,14 +52,15 @@ P1 spec → P2 spec gate → P3 plan → P4 plan gate → P5 implement → P6 ve
 ### Light flow (`phase-harness start --light "task"`)
 
 ```text
-P1 design+plan → P5 implement → P6 verify → P7 eval gate
+P1 design+plan → P2 pre-impl gate → P5 implement → P6 verify → P7 eval gate
 ```
 
 light flow에서는:
-- **2 / 3 / 4 phase**가 `skipped` 상태로 처리됩니다
+- **3 / 4 phase**가 `skipped` 상태로 처리됩니다 (P2/P7 Codex gate는 활성)
 - phase 1이 `## Complexity`, `## Open Questions`, `## Implementation Plan`이 들어간 결합 문서를 만들어야 합니다
+- **P2 (pre-impl gate)**: Codex가 결합 설계 문서를 light flow 전용 design rubric으로 리뷰합니다. REJECT 시 phase 1을 reopen하고, 피드백은 `pendingAction.feedbackPaths`로만 전달됩니다 (Gate 2는 `carryoverFeedback`를 쓰지 않음).
 - phase 7 피드백이 구현 범위면 **phase 5**, 설계/혼합 범위면 **phase 1**을 다시 엽니다
-- light flow의 gate retry 한도는 **5**이고, full flow는 **3**입니다
+- gate retry 한도: **light P2 = 3**, **light P7 = 5**, full flow = 3
 - flow는 run 생성 시점에 고정되므로 `phase-harness resume --light`는 거부됩니다
 
 ---
@@ -212,7 +213,7 @@ phase-harness start --root /tmp/demo "task"
 - `--require-clean` — working tree에 uncommitted change가 하나라도 있으면 차단
 - `--auto` — escalation 처리 시 autonomous mode 사용
 - `--enable-logging` — `~/.harness/sessions/...` 아래에 세션 로그 저장
-- `--light` — 4단계 light flow 사용
+- `--light` — 5단계 light flow 사용 (P1 design+plan → P2 pre-impl gate → P5 → P6 → P7)
 - `--codex-no-isolate` — Codex subprocess의 per-run `CODEX_HOME` isolation 비활성화; 권장하지 않음
 - 전역 `--root <dir>` — harness root를 `<dir>/.harness`로 강제
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 It supports:
 - a **full 7-phase flow**: spec → spec gate → plan → plan gate → implement → verify → eval gate
-- a **light 4-phase flow** for smaller tasks: design+plan → implement → verify → eval gate
+- a **light 5-phase flow** for smaller tasks: design+plan → pre-impl gate → implement → verify → eval gate
 - **per-phase model preset selection** at start/resume
 - **tmux-based crash recovery** with `resume`, `status`, `list`, `skip`, and `jump`
 - **optional session logging** and a live footer with elapsed time and token totals
@@ -52,14 +52,15 @@ Use the full flow when independent pre-implementation review matters: migrations
 ### Light flow (`phase-harness start --light "task"`)
 
 ```text
-P1 design+plan → P5 implement → P6 verify → P7 eval gate
+P1 design+plan → P2 pre-impl gate → P5 implement → P6 verify → P7 eval gate
 ```
 
 In light flow:
-- phases **2 / 3 / 4** are marked as `skipped`
+- phases **3 / 4** are marked as `skipped` (P2 and P7 remain active Codex gates)
 - phase 1 must produce a combined design document with `## Complexity`, `## Open Questions`, and `## Implementation Plan`
+- **P2 (pre-impl gate)**: Codex reviews the combined design doc with a light-flow design rubric. REJECT reopens phase 1; the feedback is delivered only via `pendingAction.feedbackPaths` (no `carryoverFeedback` at Gate 2).
 - phase 7 can reopen **phase 5** for impl-only feedback, or **phase 1** for design/mixed feedback
-- light-flow gate retry limit is **5** (full flow stays at **3**)
+- gate retry limits: **light P2 = 3**, **light P7 = 5**, full flow = 3
 - the flow is frozen when the run is created, so `phase-harness resume --light` is rejected
 
 ---
@@ -212,7 +213,7 @@ Flags:
 - `--require-clean` — block if the working tree has any uncommitted changes
 - `--auto` — autonomous mode for escalation handling
 - `--enable-logging` — write session logs under `~/.harness/sessions/...`
-- `--light` — use the 4-phase light flow
+- `--light` — use the 5-phase light flow (P1 design+plan → P2 pre-impl gate → P5 → P6 → P7)
 - `--codex-no-isolate` — disable per-run `CODEX_HOME` isolation for Codex subprocesses; not recommended
 - global `--root <dir>` — use `<dir>/.harness` as the harness root
 


### PR DESCRIPTION
## Summary
- README.md / README.ko.md는 여전히 light flow를 4단계(P2/3/4 모두 skipped)로 기술하고 있었음.
- 실제 코드(ADR-15~20, 2026-04-19 `2026-04-19-untitled-2-design.md`)는 **P2를 pre-impl Codex gate로 활성화한 5단계**로 돌아감: `P1 design+plan → P2 pre-impl gate → P5 impl → P6 verify → P7 eval gate`.
- `docs/HOW-IT-WORKS.md`와 `CLAUDE.md`는 이미 5단계로 동기화되어 있으므로, README 2종만 drift 상태였음. 본 PR이 그 drift를 제거함.

## Changes
- light flow 다이어그램에 `P2 pre-impl gate` 추가
- skipped 페이즈 집합을 `2/3/4` → `3/4`로 정정 (P2/P7는 active Codex gate)
- P2 동작 항목 추가: light-flow design rubric, REJECT → P1 reopen (피드백은 `pendingAction.feedbackPaths`로만 전달; Gate 2는 `carryoverFeedback` 미사용)
- retry 한도 표기를 정확히 분할: **light P2 = 3**, **light P7 = 5**, full = 3 (기존 "light = 5"는 P2에 틀림)
- `--light` 플래그 설명을 5단계로 갱신

## Verification
- `git diff` 검토 — README.md, README.ko.md만 변경, 12 insertions / 10 deletions
- 코드/로직 변경 없음 (문서 전용)
- 대응 근거:
  - 페이즈 초기화: `src/state.ts:208-213` (`'3': 'skipped', '4': 'skipped'`)
  - Light P2 retry limit 예외: `src/config.ts:144` (`if (flow === 'light' && gate === 2) return GATE_RETRY_LIMIT_FULL`)
  - Light P2 프롬프트: `src/context/assembler.ts:314-331` (FIVE_AXIS_DESIGN_GATE_LIGHT + `buildLifecycleContext(2, 'light')`)

## Test plan
- [ ] `README.md` / `README.ko.md` light flow 섹션을 렌더링해 새 다이어그램/bullet 문구가 맞는지 확인
- [ ] 기존 `HOW-IT-WORKS.md` 기술과 상충되는 부분 없는지 diff 재확인