### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phase-harness",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "AI agent harness orchestrator — multi-phase brainstorm/spec/plan/implement/verify lifecycle with gate reviews",
   "type": "module",
   "bin": { "phase-harness": "./dist/bin/harness.js" },


### PR DESCRIPTION
## Summary

Bumps `package.json` version `0.1.0 → 0.2.0` in preparation for the next npm publish.

## What shipped since 0.1.0

| PR | Scope |
|---|---|
| #38 | rename to `phase-harness` for npm |
| #43 | `install-skills` command + vendored `phase-harness-codex-gate-review` skill |
| #44 | README sync to 5-phase light flow with P2 pre-impl gate |
| #45 | Phase 1 live developer Q&A (replaces Open Questions stash) |
| #46 | research doc: harness-engineering fit assessment |
| #47 | same-phase same-session Claude interactive reopen + sentinel purge |
| misc | terminal-state UI, ui_render instrumentation, phase-5 softening, Claude token capture, 1M preset defaults, misc fixes |

Minor bump (0.x) is warranted by the new user-visible features across `install-skills`, light-flow P2 gate activation, and the reopen-aware interactive runner.

## Verification

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm vitest run` — 853 pass, 1 skip (no regressions vs main)
- [x] `pnpm build` — dist regenerated with version 0.2.0
- [x] `npm pack --dry-run` — tarball name / version / files list verified

## Release steps after merge

1. User runs `npm publish` from a clean checkout of `main` at the merge commit
2. `git push origin v0.2.0` to publish the tag (created locally on this branch)

## Notes / follow-up

- The published tarball currently includes `dist/tests/` (pre-existing since 0.1.0; ~2.1 MB unpacked). Worth excluding in a follow-up — not a release blocker.