### PR TITLE
chore(release): 0.2.1 — slim published tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phase-harness",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "AI agent harness orchestrator — multi-phase brainstorm/spec/plan/implement/verify lifecycle with gate reviews",
   "type": "module",
   "bin": { "phase-harness": "./dist/bin/harness.js" },
@@ -22,7 +22,7 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "build": "tsc && node scripts/copy-assets.mjs",
+    "build": "tsc -p tsconfig.build.json && node scripts/copy-assets.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "tsc --noEmit",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*", "bin/**/*"],
+  "exclude": ["tests/**/*"]
+}


### PR DESCRIPTION
## Summary

Bumps `0.2.0 → 0.2.1` and introduces `tsconfig.build.json` so the published tarball no longer includes compiled test files.

## Changes

- **New** `tsconfig.build.json` extends base but drops `tests/**/*` from `include` and adds it to `exclude`
- `package.json` `build` script now runs `tsc -p tsconfig.build.json && node scripts/copy-assets.mjs`
- `lint` (`tsc --noEmit` against base `tsconfig.json`) still type-checks tests — no coverage regression for CI
- Version bumped to `0.2.1`

## Tarball impact

| | Before (0.2.0) | After (0.2.1) |
|---|---|---|
| Packaged size | 363.3 kB | **180.5 kB** |
| Unpacked size | 2.1 MB | **782.7 kB** |
| Total files | 332 | **146** |

`dist/tests/` no longer exists after build; only `dist/{bin,scripts,src}` are emitted.

## Verification

- [x] `pnpm tsc --noEmit` — still type-checks tests via base tsconfig
- [x] `pnpm build` — dist emits only bin/scripts/src
- [x] `pnpm vitest run` — 853 pass / 1 skip
- [x] `npm pack --dry-run` — confirmed no `dist/tests/*` entries in tarball listing

## Release steps after merge

Pull main and run `npm publish` manually.