### PR TITLE
docs(readme): fix pnpm global unlink command

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -139,8 +139,10 @@ pnpm run build
 전역 링크 제거:
 
 ```bash
-pnpm unlink --global phase-harness
+pnpm remove --global phase-harness harness-cli
 ```
+
+> **참고:** `pnpm unlink --global`은 링크된 패키지에 아무 작동도 하지 않습니다 — 대신 `pnpm remove --global`을 사용하세요.
 
 ### 독립 스킬 설치
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -139,7 +139,7 @@ pnpm run build
 전역 링크 제거:
 
 ```bash
-pnpm remove --global phase-harness harness-cli
+pnpm remove --global phase-harness
 ```
 
 > **참고:** `pnpm unlink --global`은 링크된 패키지에 아무 작동도 하지 않습니다 — 대신 `pnpm remove --global`을 사용하세요.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ pnpm run build
 Remove the global link:
 
 ```bash
-pnpm remove --global phase-harness harness-cli
+pnpm remove --global phase-harness
 ```
 
 > **Note:** `pnpm unlink --global` silently does nothing for linked packages — use `pnpm remove --global` instead.

--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ pnpm run build
 Remove the global link:
 
 ```bash
-pnpm unlink --global phase-harness
+pnpm remove --global phase-harness harness-cli
 ```
+
+> **Note:** `pnpm unlink --global` silently does nothing for linked packages — use `pnpm remove --global` instead.
 
 ### Install standalone skills
 


### PR DESCRIPTION
## Summary

- `pnpm unlink --global phase-harness` silently does nothing for linked packages (pnpm bug)
- Correct command is `pnpm remove --global phase-harness harness-cli` — removes both linked entries
- Updated both `README.md` and `README.ko.md` with a note explaining why

## Test plan

- [ ] Run `pnpm link --global` in the repo
- [ ] Verify `pnpm remove --global phase-harness harness-cli` removes the binary
- [ ] Confirm `which phase-harness` returns nothing after removal