### PR TITLE
feat(config): change default sonnet preset from 1M to standard context

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -32,9 +32,9 @@
 기본 phase 매핑:
 - Phase 1 → `opus-1m-high`
 - Phase 2 → `codex-high`
-- Phase 3 → `sonnet-1m-high`
+- Phase 3 → `sonnet-high`
 - Phase 4 → `codex-high`
-- Phase 5 → `sonnet-1m-high`
+- Phase 5 → `sonnet-high`
 - Phase 7 → `codex-high`
 
 ---

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Current built-in presets:
 Default phase assignments:
 - Phase 1 → `opus-1m-high`
 - Phase 2 → `codex-high`
-- Phase 3 → `sonnet-1m-high`
+- Phase 3 → `sonnet-high`
 - Phase 4 → `codex-high`
-- Phase 5 → `sonnet-1m-high`
+- Phase 5 → `sonnet-high`
 - Phase 7 → `codex-high`
 
 ---

--- a/docs/HOW-IT-WORKS.ko.md
+++ b/docs/HOW-IT-WORKS.ko.md
@@ -46,8 +46,8 @@ P1 design+plan → P2 pre-impl gate → P5 implement → P6 verify → P7 eval g
 | `codex-medium` | codex | `gpt-5.4` | `medium` |
 
 기본 매핑:
-- full flow: P1 `opus-1m-high`, P2 `codex-high`, P3 `sonnet-1m-high`, P4 `codex-high`, P5 `sonnet-1m-high`, P7 `codex-high`
-- light flow: P1 `opus-1m-high`, P2 `codex-high`, P5 `sonnet-1m-high`, P7 `codex-high`
+- full flow: P1 `opus-1m-high`, P2 `codex-high`, P3 `sonnet-high`, P4 `codex-high`, P5 `sonnet-high`, P7 `codex-high`
+- light flow: P1 `opus-1m-high`, P2 `codex-high`, P5 `sonnet-high`, P7 `codex-high`
 
 사용자는 `phase-harness start` / `phase-harness resume` 때 모든 non-verify phase preset을 바꿀 수 있고,
 선택값은 `state.phasePresets`에 저장됩니다.
@@ -91,9 +91,9 @@ light flow 특이사항:
 |---|---|---|---|---|
 | P1 Spec / Design+Plan | `opus-1m-high` | interactive | spec/design 문서 + decisions + checklist(light) | Gate 2 reject 시 P1 재오픈, light P7 design/mixed reject도 P1 재오픈 |
 | P2 Spec Gate | `codex-high` | gate | verdict + feedback sidecar | P1 재오픈 |
-| P3 Plan | `sonnet-1m-high` | interactive | plan + checklist | Gate 4 reject 시 P3 재오픈 |
+| P3 Plan | `sonnet-high` | interactive | plan + checklist | Gate 4 reject 시 P3 재오픈 |
 | P4 Plan Gate | `codex-high` | gate | verdict + feedback sidecar | P3 재오픈 |
-| P5 Implement | `sonnet-1m-high` | interactive | git commits | P6 fail, full-flow P7 reject, light-flow impl reject 시 P5 재오픈 |
+| P5 Implement | `sonnet-high` | interactive | git commits | P6 fail, full-flow P7 reject, light-flow impl reject 시 P5 재오픈 |
 | P6 Verify | 고정 스크립트 | 자동 셸 | eval report + verify sidecar | fail 시 P5 재오픈, retry limit 3 |
 | P7 Eval Gate | `codex-high` | gate | verdict + feedback sidecar | full은 P5, light는 scope에 따라 P5 또는 P1 |
 

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -46,8 +46,8 @@ Built-in presets come from `src/config.ts`:
 | `codex-medium` | codex | `gpt-5.4` | `medium` |
 
 Default assignments:
-- full flow: P1 `opus-1m-high`, P2 `codex-high`, P3 `sonnet-1m-high`, P4 `codex-high`, P5 `sonnet-1m-high`, P7 `codex-high`
-- light flow: P1 `opus-1m-high`, P2 `codex-high`, P5 `sonnet-1m-high`, P7 `codex-high`
+- full flow: P1 `opus-1m-high`, P2 `codex-high`, P3 `sonnet-high`, P4 `codex-high`, P5 `sonnet-high`, P7 `codex-high`
+- light flow: P1 `opus-1m-high`, P2 `codex-high`, P5 `sonnet-high`, P7 `codex-high`
 
 Users can change every non-verify phase preset during `phase-harness start` and `phase-harness resume`.
 Selections persist in `state.phasePresets`.
@@ -91,9 +91,9 @@ Light-flow specifics:
 |---|---|---|---|---|
 | P1 Spec / Design+Plan | `opus-1m-high` | interactive | spec/design doc + decisions + checklist (light only) | Gate 2 reject reopens P1; light-flow P7 design/mixed reject also reopens P1 |
 | P2 Spec Gate | `codex-high` | gate | verdict + optional feedback sidecars | reopen P1 |
-| P3 Plan | `sonnet-1m-high` | interactive | plan + checklist | Gate 4 reject reopens P3 |
+| P3 Plan | `sonnet-high` | interactive | plan + checklist | Gate 4 reject reopens P3 |
 | P4 Plan Gate | `codex-high` | gate | verdict + optional feedback sidecars | reopen P3 |
-| P5 Implement | `sonnet-1m-high` | interactive | git commits | P6 fail reopens P5; P7 full-flow reject reopens P5; light-flow impl reject reopens P5 |
+| P5 Implement | `sonnet-high` | interactive | git commits | P6 fail reopens P5; P7 full-flow reject reopens P5; light-flow impl reject reopens P5 |
 | P6 Verify | fixed script | automated shell | eval report + verify sidecars | fail reopens P5; retry limit 3 |
 | P7 Eval Gate | `codex-high` | gate | verdict + optional feedback sidecars | full: reopen P5; light: reopen P5 or P1 based on scope |
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,9 +37,9 @@ export const MODEL_PRESETS: ModelPreset[] = [
 export const PHASE_DEFAULTS: PhasePresetMap = {
   1: 'opus-1m-high',
   2: 'codex-high',
-  3: 'sonnet-1m-high',
+  3: 'sonnet-high',
   4: 'codex-high',
-  5: 'sonnet-1m-high',
+  5: 'sonnet-high',
   7: 'codex-high',
 };
 
@@ -98,7 +98,7 @@ export const LIGHT_REQUIRED_PHASE_KEYS = ['1', '2', '5', '7'] as const;
 export const LIGHT_PHASE_DEFAULTS: PhasePresetMap = {
   1: 'opus-1m-high',
   2: 'codex-high',
-  5: 'sonnet-1m-high',
+  5: 'sonnet-high',
   7: 'codex-high',
 };
 

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -138,7 +138,7 @@ function runItem(item: PreflightItem, cwd?: string): { codexPath?: string } {
         writeFileSync(tmpFile, '', 'utf-8');
         const result = spawnSync(
           'claude',
-          ['--model', 'claude-sonnet-4-6[1m]', `@${tmpFile}`, '--print', ''],
+          ['--model', 'claude-sonnet-4-6', `@${tmpFile}`, '--print', ''],
           {
             stdio: 'pipe',
             encoding: 'utf-8',

--- a/tests/phases/runner-claude-resume.test.ts
+++ b/tests/phases/runner-claude-resume.test.ts
@@ -129,7 +129,7 @@ function makeReopenState(phase: 1 | 3 | 5, withPrevSession = true): HarnessState
   if (withPrevSession) {
     s.phaseClaudeSessions[String(phase) as '1' | '3' | '5'] = {
       runner: 'claude',
-      model: 'claude-sonnet-4-6[1m]',
+      model: 'claude-sonnet-4-6',
       effort: 'high',
     };
   }
@@ -380,7 +380,7 @@ describe('handleInteractivePhase — lineage atomicity regression (R7)', () => {
     const sentinelPath = path.join(runDir, 'phase-5.done');
     fs.writeFileSync(sentinelPath, 'stale-content');
 
-    const PREV_SESSION = { runner: 'claude' as const, model: 'claude-sonnet-4-6[1m]', effort: 'high' };
+    const PREV_SESSION = { runner: 'claude' as const, model: 'claude-sonnet-4-6', effort: 'high' };
     const state = makeReopenState(5);
     state.phaseClaudeSessions['5'] = PREV_SESSION;
 

--- a/tests/preflight-claude-at-file.test.ts
+++ b/tests/preflight-claude-at-file.test.ts
@@ -36,7 +36,7 @@ describe('claude @file preflight', () => {
 
     expect(vi.mocked(spawnSync)).toHaveBeenCalledWith(
       'claude',
-      ['--model', 'claude-sonnet-4-6[1m]', expect.stringMatching(/^@/), '--print', ''],
+      ['--model', 'claude-sonnet-4-6', expect.stringMatching(/^@/), '--print', ''],
       expect.objectContaining({ timeout: 10_000, killSignal: 'SIGKILL' }),
     );
 

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -217,7 +217,7 @@ describe('createInitialState (updated)', () => {
   it('initializes phasePresets from PHASE_DEFAULTS', () => {
     const state = createInitialState('run-1', 'task', 'abc123', false);
     expect(state.phasePresets['1']).toBe('opus-1m-high');
-    expect(state.phasePresets['5']).toBe('sonnet-1m-high');
+    expect(state.phasePresets['5']).toBe('sonnet-high');
   });
 
   it('initializes phaseReopenFlags to false', () => {


### PR DESCRIPTION
## Summary

- Change `PHASE_DEFAULTS` P3 and P5 from `sonnet-1m-high` → `sonnet-high`
- Change `LIGHT_PHASE_DEFAULTS` P5 from `sonnet-1m-high` → `sonnet-high`
- Update `preflight.ts` claudeAtFile check model from `claude-sonnet-4-6[1m]` → `claude-sonnet-4-6`
- Update affected tests (`state.test.ts`, `preflight-claude-at-file.test.ts`, `runner-claude-resume.test.ts`) to match new defaults
- Update docs (README, README.ko, HOW-IT-WORKS, HOW-IT-WORKS.ko)

## Test plan

- [x] `pnpm lint` passes (tsc --noEmit)
- [x] `pnpm vitest run` — no new failures introduced (pre-existing 11 integration test failures require dist build, unchanged before/after)