### PR TITLE
chore(release): 0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phase-harness",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "AI agent harness orchestrator — multi-phase brainstorm/spec/plan/implement/verify lifecycle with gate reviews",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump version `0.2.2` → `0.2.3`

## Included PRs

- #52 feat(run-id+orphan-cleanup): runId 4-hex suffix + orphan tmux session cleanup
- #53 fix(crash): Phase 6 gitignore-aware eval commit + loop exit on error + D4 paused+null recovery
- #54 feat(config): change default sonnet preset from 1M to standard context

## Release checklist

- [ ] Squash merge this PR
- [ ] `npm publish` (or `pnpm publish`) from merged main