### PR TITLE
fix(preflight): auto-restore +x on harness-verify.sh stripped by npm install

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -101,7 +101,7 @@ Harness는 git working tree를 기준으로 동작하며, phase 경계에서 art
 
 참고:
 - 지원 플랫폼은 **macOS와 Linux**입니다.
-- verify script는 먼저 설치된 패키지 내부 경로에서 찾고, 없으면 `~/.claude/scripts/harness-verify.sh`를 레거시 fallback으로 사용합니다.
+- verify 스크립트(`harness-verify.sh`)는 패키지에 번들되어 있으며 런타임에 자동으로 경로를 찾습니다.
 - interactive phase를 Codex preset으로 바꾸면, 해당 phase도 Codex CLI로 실행됩니다.
 - 기본적으로 Codex phase는 실제 `codex` CLI를 사용하고, `<runDir>/codex-home` 격리 환경에서 실행됩니다. 사용자 전역 `CODEX_HOME` 동작이 필요할 때만 `--codex-no-isolate`를 사용하세요.
 - 새 run은 이제 Claude phase 기본값으로 `*-1m-*` preset을 사용합니다. Claude Code 환경에서 1M context를 쓸 수 없다면, 모델 선택 단계에서 기존 non-1M preset으로 직접 바꾸거나 자체 포크의 `src/config.ts` 기본값을 수정하세요.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Install these first:
 
 Notes:
 - Supported platforms are **macOS and Linux**.
-- The verify script is resolved from the installed package first, with legacy fallback to `~/.claude/scripts/harness-verify.sh`.
+- The verify script (`harness-verify.sh`) is bundled in the package and resolved automatically at runtime.
 - If you switch an interactive phase to a Codex preset, harness will use the Codex CLI for that phase too.
 - By default, Codex phases run through the real `codex` CLI inside an isolated `<runDir>/codex-home`; use `--codex-no-isolate` only when you intentionally want inherited `CODEX_HOME` behavior.
 - New runs now default Claude phases to the explicit `*-1m-*` presets. If your Claude Code environment does not support 1M context, pick one of the legacy non-1M presets during the model-selection step (or change the defaults in `src/config.ts` in your own fork).

--- a/docs/HOW-IT-WORKS.ko.md
+++ b/docs/HOW-IT-WORKS.ko.md
@@ -157,7 +157,7 @@ Claude Code 환경에서 1M context를 사용할 수 없다면, 모델 선택기
 ## Verify 동작 (Phase 6)
 
 Phase 6은 항상 번들된 `harness-verify.sh` 스크립트를 실행합니다.
-스크립트 경로는 설치된 패키지 내부를 우선 사용하고, 없으면 레거시 fallback으로 `~/.claude/scripts/harness-verify.sh`를 사용합니다.
+스크립트는 설치된 패키지 내부의 `dist/scripts/harness-verify.sh`를 사용합니다. npm 설치 시 실행 권한이 제거된 경우, 런타임에 자동으로 복원합니다.
 
 입출력:
 - 입력: `.harness/<runId>/checklist.json`

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -175,7 +175,7 @@ If your Claude Code environment does not support 1M context, keep using the lega
 ## Verify behavior (Phase 6)
 
 Phase 6 always runs the bundled `harness-verify.sh` script.
-The script path is resolved from the installed package first, with legacy fallback to `~/.claude/scripts/harness-verify.sh`.
+The script is resolved from `dist/scripts/harness-verify.sh` inside the installed package. If npm stripped the executable bit on install, it is restored automatically at runtime.
 
 Inputs and outputs:
 - input: `.harness/<runId>/checklist.json`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phase-harness",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "AI agent harness orchestrator — multi-phase brainstorm/spec/plan/implement/verify lifecycle with gate reviews",
   "type": "module",
   "bin": {

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -1,5 +1,5 @@
 import { execSync, spawnSync } from 'child_process';
-import { existsSync, accessSync, readdirSync, writeFileSync, unlinkSync, constants } from 'fs';
+import { existsSync, accessSync, chmodSync, readdirSync, writeFileSync, unlinkSync, constants } from 'fs';
 import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -11,10 +11,9 @@ const _defaultPackageLocalRoot = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Resolve the harness-verify.sh path.
- * Lookup order:
- *  1. Package-local: <packageLocalRoot>/../scripts/harness-verify.sh (after build → dist/scripts/...)
- *  2. Legacy fallback: ~/.claude/scripts/harness-verify.sh
- * Returns null if neither is present + executable.
+ * Looks for: <packageLocalRoot>/../scripts/harness-verify.sh (after build → dist/scripts/...)
+ * If the file exists but is not executable (npm strips +x on install), attempts chmod +x.
+ * Returns null if the file is absent or cannot be made executable.
  *
  * @param packageLocalRoot - override the package-local search root (defaults to this module's __dirname).
  *                           Tests may pass a temp dir to deterministically exercise the package-local branch.
@@ -22,29 +21,23 @@ const _defaultPackageLocalRoot = path.dirname(fileURLToPath(import.meta.url));
 export function resolveVerifyScriptPath(
   packageLocalRoot: string = _defaultPackageLocalRoot
 ): string | null {
-  // 1. Package-local path
   const packageLocal = path.join(packageLocalRoot, '..', 'scripts', 'harness-verify.sh');
-  if (existsSync(packageLocal)) {
-    try {
-      accessSync(packageLocal, constants.R_OK | constants.X_OK);
-      return packageLocal;
-    } catch {
-      // not accessible — fall through to legacy
-    }
+  if (!existsSync(packageLocal)) {
+    return null;
   }
-
-  // 2. Legacy fallback: ~/.claude/scripts/harness-verify.sh
-  const legacy = path.join(os.homedir(), '.claude', 'scripts', 'harness-verify.sh');
-  if (existsSync(legacy)) {
-    try {
-      accessSync(legacy, constants.R_OK | constants.X_OK);
-      return legacy;
-    } catch {
-      // not accessible
-    }
+  try {
+    accessSync(packageLocal, constants.R_OK);
+  } catch {
+    return null; // unreadable
   }
-
-  return null;
+  // npm strips the executable bit on install — restore it
+  try { chmodSync(packageLocal, 0o755); } catch { /* best-effort */ }
+  try {
+    accessSync(packageLocal, constants.X_OK);
+    return packageLocal;
+  } catch {
+    return null;
+  }
 }
 
 // Map phase type → required preflight items.

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1,7 +1,7 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import os from 'os';
 import path from 'path';
-import { existsSync, mkdtempSync, mkdirSync, writeFileSync, chmodSync, rmSync } from 'fs';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, chmodSync, accessSync, rmSync, constants } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -235,82 +235,19 @@ describe('resolveVerifyScriptPath — package-local branch (deterministic via ov
     expect(result).toBe(target);
   });
 
-  it('returns legacy path when package-local is absent and legacy is present + executable', () => {
-    const homeBackup = process.env.HOME;
-    const fakeHome = mkdtempSync(join(tmpdir(), 'harness-fake-home-'));
-    const legacyDir = join(fakeHome, '.claude', 'scripts');
-    mkdirSync(legacyDir, { recursive: true });
-    const legacyTarget = join(legacyDir, 'harness-verify.sh');
-    writeFileSync(legacyTarget, '#!/bin/sh\necho ok\n');
-    chmodSync(legacyTarget, 0o755);
-    process.env.HOME = fakeHome;
-
-    try {
-      const result = resolveVerifyScriptPath(join(tmp, 'lib'));
-      expect(result).toBe(legacyTarget);
-    } finally {
-      process.env.HOME = homeBackup;
-      rmSync(fakeHome, { recursive: true, force: true });
-    }
+  it('auto-chmodss and returns package-local path when file exists but not executable (npm install strips +x)', () => {
+    const target = join(tmp, 'scripts', 'harness-verify.sh');
+    writeFileSync(target, '#!/bin/sh\necho ok\n');
+    chmodSync(target, 0o644); // simulate npm install stripping +x
+    const result = resolveVerifyScriptPath(join(tmp, 'lib'));
+    expect(result).toBe(target);
+    // verify the file is now executable
+    accessSync(target, constants.X_OK);
   });
 
-  it('falls through to legacy when package-local exists but is not executable', () => {
-    const pkgTarget = join(tmp, 'scripts', 'harness-verify.sh');
-    writeFileSync(pkgTarget, '#!/bin/sh\necho ok\n');
-    chmodSync(pkgTarget, 0o644); // not executable
-
-    const homeBackup = process.env.HOME;
-    const fakeHome = mkdtempSync(join(tmpdir(), 'harness-fake-home-'));
-    const legacyDir = join(fakeHome, '.claude', 'scripts');
-    mkdirSync(legacyDir, { recursive: true });
-    const legacyTarget = join(legacyDir, 'harness-verify.sh');
-    writeFileSync(legacyTarget, '#!/bin/sh\necho ok\n');
-    chmodSync(legacyTarget, 0o755);
-    process.env.HOME = fakeHome;
-
-    try {
-      const result = resolveVerifyScriptPath(join(tmp, 'lib'));
-      expect(result).toBe(legacyTarget);
-    } finally {
-      process.env.HOME = homeBackup;
-      rmSync(fakeHome, { recursive: true, force: true });
-    }
-  });
-
-  it('returns null when package-local is missing and legacy is missing', () => {
-    const homeBackup = process.env.HOME;
-    const fakeHome = mkdtempSync(join(tmpdir(), 'harness-fake-home-'));
-    process.env.HOME = fakeHome;
-    try {
-      const result = resolveVerifyScriptPath(join(tmp, 'lib'));
-      expect(result).toBeNull();
-    } finally {
-      process.env.HOME = homeBackup;
-      rmSync(fakeHome, { recursive: true, force: true });
-    }
-  });
-
-  it('returns null when both package-local and legacy exist but neither is executable', () => {
-    const pkgTarget = join(tmp, 'scripts', 'harness-verify.sh');
-    writeFileSync(pkgTarget, '#!/bin/sh\necho ok\n');
-    chmodSync(pkgTarget, 0o644);
-
-    const homeBackup = process.env.HOME;
-    const fakeHome = mkdtempSync(join(tmpdir(), 'harness-fake-home-'));
-    const legacyDir = join(fakeHome, '.claude', 'scripts');
-    mkdirSync(legacyDir, { recursive: true });
-    const legacyTarget = join(legacyDir, 'harness-verify.sh');
-    writeFileSync(legacyTarget, '#!/bin/sh\necho ok\n');
-    chmodSync(legacyTarget, 0o644);
-    process.env.HOME = fakeHome;
-
-    try {
-      const result = resolveVerifyScriptPath(join(tmp, 'lib'));
-      expect(result).toBeNull();
-    } finally {
-      process.env.HOME = homeBackup;
-      rmSync(fakeHome, { recursive: true, force: true });
-    }
+  it('returns null when package-local is missing', () => {
+    const result = resolveVerifyScriptPath(join(tmp, 'lib'));
+    expect(result).toBeNull();
   });
 });
 


### PR DESCRIPTION
## 원인

npm은 패키지 설치 시 파일 실행 권한(`+x`)을 제거합니다. `dist/scripts/harness-verify.sh`가 로컬 빌드에선 `-rwxr-xr-x`이지만, `npm install` / `pnpm add -g` 후엔 `-rw-r--r--`으로 바뀝니다. 기존 코드는 `accessSync(R_OK | X_OK)` 실패 시 레거시 경로(`~/.claude/scripts/harness-verify.sh`)로 폴백했는데, 신규 설치엔 그 파일이 없어서 에러가 발생했습니다.

```
Error: harness-verify.sh not found. Run `harness setup` or install the package globally.
```

## 수정 내용

- `resolveVerifyScriptPath()`: 파일이 존재하고 읽기 가능하면 `chmodSync(0o755)` 자동 실행 후 경로 반환
- 레거시 fallback(`~/.claude/scripts/harness-verify.sh`) 제거 — 패키지에 번들되므로 더 이상 불필요
- README / HOW-IT-WORKS 문서 업데이트

## 검증

재현 방법: `pnpm pack` → 로컬 tarball을 `npm install`로 설치 → `dist/scripts/harness-verify.sh`가 `-rw-r--r--`인 것 확인 → `resolveVerifyScriptPath()` 호출 시 자동 chmod 후 경로 반환 확인

- `pnpm tsc --noEmit` ✅
- `pnpm vitest run` ✅ (880 passed)