### PR TITLE
fix(tmux): pin Claude cwd to harness anchor in reused-tmux mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phase-harness",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "AI agent harness orchestrator — multi-phase brainstorm/spec/plan/implement/verify lifecycle with gate reviews",
   "type": "module",
   "bin": {

--- a/src/commands/inner.ts
+++ b/src/commands/inner.ts
@@ -62,7 +62,7 @@ export async function innerCommand(runId: string, options: InnerOptions = {}): P
   if (controlValid && workspaceValid) {
     // Both panes valid and distinct — reuse
   } else if (controlValid) {
-    const workspacePaneId = splitPane(state.tmuxSession, controlPaneId, 'h', 60);
+    const workspacePaneId = splitPane(state.tmuxSession, controlPaneId, 'h', 60, cwd);
     state.tmuxWorkspacePane = workspacePaneId;
   } else {
     process.stderr.write(`Fatal: control pane ${controlPaneId} does not exist.\n`);

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -183,7 +183,7 @@ export async function resumeCommand(runId?: string, options: ResumeOptions = {})
     const controlPaneId = getDefaultPaneId(sessionName);
     sendKeys(sessionName, '0', `${innerCmd} --control-pane ${controlPaneId}`);
   } else {
-    const ctrlWindowId = createWindow(sessionName, 'harness-ctrl', '');
+    const ctrlWindowId = createWindow(sessionName, 'harness-ctrl', '', cwd);
     const controlPaneId = getDefaultPaneId(sessionName, ctrlWindowId);
     sendKeys(sessionName, ctrlWindowId, `${innerCmd} --control-pane ${controlPaneId}`);
     state.tmuxControlWindow = ctrlWindowId;

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -179,7 +179,7 @@ export async function startCommand(task: string | undefined, options: StartOptio
       const innerCmdWithPane = `${innerCmd} --control-pane ${controlPaneId}`;
       sendKeys(sessionName, '0', innerCmdWithPane);
     } else {
-      const ctrlWindowId = createWindow(sessionName, 'harness-ctrl', '');
+      const ctrlWindowId = createWindow(sessionName, 'harness-ctrl', '', cwd);
       const controlPaneId = getDefaultPaneId(sessionName, ctrlWindowId);
       sendKeys(sessionName, ctrlWindowId, `${innerCmd} --control-pane ${controlPaneId}`);
       state.tmuxControlWindow = ctrlWindowId;

--- a/src/phases/interactive.ts
+++ b/src/phases/interactive.ts
@@ -234,7 +234,7 @@ export async function runInteractivePhase(
   // Dispatch to runner
   if (preset.runner === 'claude') {
     const { pid: claudePid } = await runClaudeInteractive(
-      phase, updatedState, preset, harnessDir, runDir, promptFile, resume,
+      phase, updatedState, preset, harnessDir, runDir, promptFile, cwd, resume,
     );
     const sentinelPath = path.join(runDir, `phase-${phase}.done`);
     const resolvedAttemptId = updatedState.phaseAttemptId[String(phase)] ?? attemptId;

--- a/src/runners/claude.ts
+++ b/src/runners/claude.ts
@@ -21,6 +21,7 @@ export async function runClaudeInteractive(
   harnessDir: string,
   runDir: string,
   promptFile: string,
+  cwd: string,
   resume: boolean = false,
 ): Promise<ClaudeInteractiveResult> {
   const sessionName = state.tmuxSession;
@@ -67,7 +68,11 @@ export async function runClaudeInteractive(
     ? (attemptId ? `--resume ${attemptId} ` : '')
     : (attemptId ? `--session-id ${attemptId} ` : '');
   const claudeArgs = `--dangerously-skip-permissions ${sessionFlag}--model ${preset.model} --effort ${preset.effort} @${path.resolve(promptFile)}`;
-  const wrappedCmd = `sh -c 'echo $$ > ${pidFile}; exec claude ${claudeArgs}'`;
+  // `cd "<cwd>" &&` pins Claude's process cwd to the harness anchor; without it Claude
+  // inherits the tmux pane's shell cwd (wrong in reused-tmux mode) and relative artifact
+  // paths land outside the tree that `validatePhaseArtifacts` scans. `&&` chaining makes
+  // a failed cd abort instead of silently exec'ing claude in the wrong directory.
+  const wrappedCmd = `sh -c 'cd "${cwd}" && echo $$ > ${pidFile} && exec claude ${claudeArgs}'`;
   sendKeysToPane(sessionName, workspacePane, wrappedCmd);
 
   // Capture Claude PID

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -25,11 +25,13 @@ export function sessionExists(name: string): boolean {
 /**
  * Create a new window in an existing session with a command.
  * Returns the tmux window ID (e.g., "@1").
+ * `cwd` pins the window's working directory with `-c` so reused-tmux mode
+ * doesn't inherit the user's shell cwd (which breaks relative artifact paths).
  */
-export function createWindow(session: string, windowName: string, command: string): string {
+export function createWindow(session: string, windowName: string, command: string, cwd: string): string {
   const cmdPart = command ? ` ${esc(command)}` : '';
   const output = execSync(
-    `tmux new-window -t ${esc(session)} -n ${esc(windowName)} -P -F '#{window_id}'${cmdPart}`,
+    `tmux new-window -t ${esc(session)} -n ${esc(windowName)} -c ${esc(cwd)} -P -F '#{window_id}'${cmdPart}`,
     { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
   );
   return output.trim();
@@ -86,17 +88,21 @@ export function sendKeys(session: string, windowTarget: string, keys: string): v
 
 /**
  * Split a pane horizontally or vertically. Returns the new pane ID (e.g., "%5").
+ * `cwd` pins the new pane's working directory with `-c`; without it the split
+ * inherits the target pane's cwd, which in reused-tmux mode is the user's shell
+ * — breaking relative artifact paths Claude writes.
  */
 export function splitPane(
   _session: string,
   targetPane: string,
   direction: 'h' | 'v',
-  percent: number
+  percent: number,
+  cwd: string,
 ): string {
   // Pane IDs (%N) are globally unique in tmux — target directly, no session prefix needed
   const flag = direction === 'h' ? '-h' : '-v';
   const output = execSync(
-    `tmux split-window -t ${escSmart(targetPane)} ${flag} -p ${percent} -P -F '#{pane_id}'`,
+    `tmux split-window -t ${escSmart(targetPane)} ${flag} -p ${percent} -c ${esc(cwd)} -P -F '#{pane_id}'`,
     { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
   );
   return output.trim();

--- a/tests/commands/resume-cmd.test.ts
+++ b/tests/commands/resume-cmd.test.ts
@@ -246,7 +246,12 @@ describe('resumeCommand', () => {
     // Stale cleanup path + recursion + reused Case 3
     expect(vi.mocked(tmux.killWindow)).toHaveBeenCalledWith('harness-reused', '@stale');
     expect(vi.mocked(lock.releaseLock)).toHaveBeenCalled();
-    expect(vi.mocked(tmux.createWindow)).toHaveBeenCalledWith('harness-reused', 'harness-ctrl', '');
+    expect(vi.mocked(tmux.createWindow)).toHaveBeenCalledWith(
+      'harness-reused',
+      'harness-ctrl',
+      '',
+      expect.any(String), // cwd — pins new control window to harness anchor
+    );
     expect(vi.mocked(tmux.createSession)).not.toHaveBeenCalled();
   });
 

--- a/tests/runners/claude.test.ts
+++ b/tests/runners/claude.test.ts
@@ -85,7 +85,7 @@ describe('runClaudeInteractive — argv contract (R8)', () => {
     const ATTEMPT_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
     const state = makeState(5, ATTEMPT_ID);
 
-    const promise = runClaudeInteractive(5, state, PRESET, '/harness', '/rundir', '/prompt.md', true);
+    const promise = runClaudeInteractive(5, state, PRESET, '/harness', '/rundir', '/prompt.md', '/repo/root', true);
     vi.runAllTimers();
     await promise;
 
@@ -103,7 +103,7 @@ describe('runClaudeInteractive — argv contract (R8)', () => {
     const ATTEMPT_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
     const state = makeState(5, ATTEMPT_ID);
 
-    const promise = runClaudeInteractive(5, state, PRESET, '/harness', '/rundir', '/prompt.md', false);
+    const promise = runClaudeInteractive(5, state, PRESET, '/harness', '/rundir', '/prompt.md', '/repo/root', false);
     vi.runAllTimers();
     await promise;
 
@@ -114,5 +114,22 @@ describe('runClaudeInteractive — argv contract (R8)', () => {
     expect(cmd).toContain(`--model ${PRESET.model}`);
     expect(cmd).toContain(`--effort ${PRESET.effort}`);
     expect(cmd).toMatch(/@.*prompt\.md/);
+  });
+
+  it('wrapper pins Claude cwd via `cd "<cwd>" &&` so artifacts land under the harness anchor', async () => {
+    const { runClaudeInteractive } = await import('../../src/runners/claude.js');
+    const ATTEMPT_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+    const state = makeState(5, ATTEMPT_ID);
+
+    const promise = runClaudeInteractive(5, state, PRESET, '/harness', '/rundir', '/prompt.md', '/repo/root', false);
+    vi.runAllTimers();
+    await promise;
+
+    const cmd = getCmdArg(vi.mocked(sendKeysToPane).mock.calls);
+    // Must cd into the harness anchor, fail-loud via `&&`, then exec claude.
+    expect(cmd).toMatch(/cd "\/repo\/root" && .* && exec claude/);
+    // The pre-fix form `echo $$ > pidfile; exec claude` is no longer acceptable:
+    // it would silently exec claude with the wrong cwd if `cd` had failed.
+    expect(cmd).not.toMatch(/;\s*exec claude/);
   });
 });

--- a/tests/tmux.test.ts
+++ b/tests/tmux.test.ts
@@ -39,18 +39,20 @@ describe('tmux utilities', () => {
 
   it('createWindow returns window ID', () => {
     vi.mocked(execSync).mockReturnValue('@42\n');
-    const id = createWindow('sess', 'win', 'echo hi');
+    const id = createWindow('sess', 'win', 'echo hi', '/tmp/repo');
     expect(id).toBe('@42');
   });
 
-  it('createWindow command includes window name and command', () => {
+  it('createWindow command includes window name, command, and -c cwd', () => {
     vi.mocked(execSync).mockReturnValue('@0\n');
-    createWindow('my-session', 'phase-1', 'claude --model opus');
+    createWindow('my-session', 'phase-1', 'claude --model opus', '/repo/root');
     const cmd = vi.mocked(execSync).mock.calls[0][0] as string;
     expect(cmd).toContain('new-window');
     expect(cmd).toContain('my-session');
     expect(cmd).toContain('phase-1');
     expect(cmd).toContain('claude --model opus');
+    expect(cmd).toContain('-c');
+    expect(cmd).toContain('/repo/root');
   });
 
   it('killWindow is best-effort (no throw on error)', () => {
@@ -124,26 +126,30 @@ describe('tmux utilities', () => {
 
   it('splitPane returns new pane ID', () => {
     vi.mocked(execSync).mockReturnValue('%5\n');
-    const id = splitPane('sess', '%0', 'h', 70);
+    const id = splitPane('sess', '%0', 'h', 70, '/tmp/repo');
     expect(id).toBe('%5');
   });
 
-  it('splitPane command includes -h flag for horizontal split', () => {
+  it('splitPane command includes -h flag and -c cwd for horizontal split', () => {
     vi.mocked(execSync).mockReturnValue('%1\n');
-    splitPane('my-session', '%0', 'h', 70);
+    splitPane('my-session', '%0', 'h', 70, '/repo/root');
     const cmd = vi.mocked(execSync).mock.calls[0][0] as string;
     expect(cmd).toContain('split-window');
     expect(cmd).toContain('-h');
     expect(cmd).toContain('70');
+    expect(cmd).toContain('-c');
+    expect(cmd).toContain('/repo/root');
   });
 
-  it('splitPane command includes -v flag for vertical split', () => {
+  it('splitPane command includes -v flag and -c cwd for vertical split', () => {
     vi.mocked(execSync).mockReturnValue('%2\n');
-    splitPane('my-session', '%0', 'v', 30);
+    splitPane('my-session', '%0', 'v', 30, '/another/repo');
     const cmd = vi.mocked(execSync).mock.calls[0][0] as string;
     expect(cmd).toContain('split-window');
     expect(cmd).toContain('-v');
     expect(cmd).toContain('30');
+    expect(cmd).toContain('-c');
+    expect(cmd).toContain('/another/repo');
   });
 
   it('sendKeysToPane sends C-c without Enter', () => {


### PR DESCRIPTION
## Summary

- Reused-tmux mode (`phase-harness start` inside an existing tmux session) caused Phase 1/3/5 to report `failed` even when Claude completed — artifacts landed outside the git root because Claude inherited the tmux pane's shell cwd instead of the harness anchor.
- Pin Claude's process cwd in the `sh -c` wrapper with `cd \"<cwd>\" && … && exec claude` (load-bearing), and pass `-c <cwd>` to `splitPane`/`createWindow` so user-visible panes also anchor correctly (UX).
- Latent since `5e49488` (2026-04-14, pane architecture). Surfaces only when the current pane's cwd ≠ git root.

## Root cause trace

1. `inner.ts:29` → `cwd = options.root ?? getGitRoot()` (validator's anchor).
2. `splitPane`/`createWindow` didn't pass `-c` → workspace pane inherited user's shell cwd in reused-tmux mode.
3. `runClaudeInteractive` typed `sh -c 'echo $$ > pid; exec claude …'` into the pane → Claude ran with the wrong cwd.
4. Claude wrote `.harness/<runId>/decisions.md` relative to the wrong cwd.
5. `validatePhaseArtifacts` (`interactive.ts:132`) resolved against `getGitRoot()` → miss → `failed`.

Codex interactive was unaffected (`spawn(..., { cwd })` already pins cwd). Dedicated-tmux mode was fine because `createSession(..., cwd)` anchored the session.

## Fix (defense in depth)

- **Load-bearing** — `src/runners/claude.ts`: wrapper becomes `sh -c 'cd \"<cwd>\" && echo \$\$ > pid && exec claude …'`. `&&` chaining aborts on failed `cd` instead of silently exec'ing claude in the wrong directory. Also re-anchors stale panes persisted from runs that started before this fix.
- **UX consistency** — `src/tmux.ts`: `splitPane` and `createWindow` now require `cwd` and pass `-c <cwd>` to tmux. Callers (`inner.ts`, `start.ts`, `resume.ts`) thread their already-computed `cwd`.

`state.ts` artifact paths remain relative — correct once Claude's cwd matches the validator's; making them absolute would add migration surface without added safety.

## Test plan

- [x] `pnpm lint` (`tsc --noEmit`) passes.
- [x] `pnpm vitest run` — 881 passed / 1 skipped / 0 failed.
- [x] New assertion in `tests/runners/claude.test.ts` proves the wrapper uses `cd \"<cwd>\" && … && exec claude` (not the pre-fix `;\\s*exec claude` form).
- [x] Updated `splitPane`/`createWindow` assertions in `tests/tmux.test.ts` verify `-c` + cwd are in the tmux command.
- [x] `tests/commands/resume-cmd.test.ts` Case 2 assertion updated for new `createWindow` arity.
- [ ] Dogfood: rerun the original failing scenario (start harness from tmux pane at `~`, confirm Phase 1 artifacts land at `${gitRoot}/.harness/<runId>/decisions.md` and phase transitions to completed).

## Doc sync

`README`/`HOW-IT-WORKS` 검토 결과 문서 변경 불필요 — restores the intended behavior (artifacts anchored at harness cwd); no new user-observable surface.