### PR TITLE
fix(cli): derive version from package.json

### DIFF
--- a/bin/harness.ts
+++ b/bin/harness.ts
@@ -10,13 +10,14 @@ import { innerCommand } from '../src/commands/inner.js';
 import { installSkillsCommand } from '../src/commands/install-skills.js';
 import { uninstallSkillsCommand } from '../src/commands/uninstall-skills.js';
 import { cleanupCommand } from '../src/commands/cleanup.js';
+import { HARNESS_VERSION } from '../src/version.js';
 
 const program = new Command();
 
 program
   .name('phase-harness')
   .description('AI agent harness orchestrator')
-  .version('0.1.0')
+  .version(HARNESS_VERSION)
   .option('--root <dir>', 'explicit .harness/ parent directory');
 
 program

--- a/src/commands/inner.ts
+++ b/src/commands/inner.ts
@@ -13,6 +13,7 @@ import { InputManager } from '../input.js';
 import { runRunnerAwarePreflight } from '../preflight.js';
 import { REQUIRED_PHASE_KEYS, getEffectiveReopenTarget, getRequiredPhaseKeys } from '../config.js';
 import { createSessionLogger } from '../logger.js';
+import { HARNESS_VERSION } from '../version.js';
 import { codexHomeFor } from '../runners/codex-isolation.js';
 import type { SessionLogger, HarnessState } from '../types.js';
 import { promptForTask } from '../task-prompt.js';
@@ -315,7 +316,7 @@ export function buildConfigCancelHandler(args: ConfigCancelHandlerArgs): () => v
         logger.logEvent({ event: 'session_resumed', fromPhase: state.currentPhase, stateStatus: 'paused' });
       } else {
         logger.writeMeta({ task: state.task, codexHome });
-        logger.logEvent({ event: 'session_start', task: state.task, autoMode: state.autoMode, baseCommit: state.baseCommit, harnessVersion: '0.1.0' });
+        logger.logEvent({ event: 'session_start', task: state.task, autoMode: state.autoMode, baseCommit: state.baseCommit, harnessVersion: HARNESS_VERSION });
       }
     }
     logger.logEvent({ event: 'session_end', status: 'paused', totalWallMs: Date.now() - logger.getStartedAt() });
@@ -352,7 +353,7 @@ export async function bootstrapSessionLogger(
     logger.logEvent({ event: 'session_resumed', fromPhase: state.currentPhase, stateStatus: state.status });
   } else {
     logger.writeMeta({ task: state.task, codexHome });
-    logger.logEvent({ event: 'session_start', task: state.task, autoMode: state.autoMode, baseCommit: state.baseCommit, harnessVersion: '0.1.0' });
+    logger.logEvent({ event: 'session_start', task: state.task, autoMode: state.autoMode, baseCommit: state.baseCommit, harnessVersion: HARNESS_VERSION });
   }
   return logger;
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import type { SessionLogger, LogEvent, SessionMeta, HarnessState, DistributiveOmit } from './types.js';
+import { HARNESS_VERSION } from './version.js';
 
 export function computeRepoKey(harnessDir: string): string {
   return createHash('sha1').update(harnessDir).digest('hex').slice(0, 12);
@@ -90,7 +91,7 @@ export class FileSessionLogger implements SessionLogger {
         task: partial.task,
         startedAt: partial.startedAt ?? now,
         autoMode: partial.autoMode ?? this.options.autoMode ?? false,
-        harnessVersion: partial.harnessVersion ?? this.options.harnessVersion ?? '0.1.0',
+        harnessVersion: partial.harnessVersion ?? this.options.harnessVersion ?? HARNESS_VERSION,
         resumedAt: partial.resumedAt ?? [],
         ...(partial.bootstrapOnResume ? { bootstrapOnResume: true } : {}),
         ...(partial.codexHome !== undefined ? { codexHome: partial.codexHome } : {}),
@@ -123,7 +124,7 @@ export class FileSessionLogger implements SessionLogger {
           task: update.task ?? '',
           startedAt: now,
           autoMode: this.options.autoMode ?? false,
-          harnessVersion: this.options.harnessVersion ?? '0.1.0',
+          harnessVersion: this.options.harnessVersion ?? HARNESS_VERSION,
           resumedAt: [],
           bootstrapOnResume: true,
           ...(update.codexHome !== undefined ? { codexHome: update.codexHome } : {}),

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+function loadHarnessVersion(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    // Resolve package.json from both layouts:
+    //   dev/tsx   → src/version.ts        (../package.json)
+    //   built     → dist/src/version.js   (../../package.json)
+    // Published npm tarball mirrors the built layout.
+    for (const rel of ['../package.json', '../../package.json']) {
+      try {
+        const raw = readFileSync(join(here, rel), 'utf-8');
+        const parsed = JSON.parse(raw) as { name?: string; version?: string };
+        if (parsed.name === 'phase-harness' && typeof parsed.version === 'string') {
+          return parsed.version;
+        }
+      } catch {
+        // probe next candidate
+      }
+    }
+  } catch {
+    // fall through to fallback
+  }
+  return '0.0.0';
+}
+
+export const HARNESS_VERSION = loadHarnessVersion();

--- a/tests/integration/lifecycle.test.ts
+++ b/tests/integration/lifecycle.test.ts
@@ -6,6 +6,9 @@ import { createTestRepo } from '../helpers/test-repo.js';
 
 // Use the built CLI
 const CLI_PATH = resolve(process.cwd(), 'dist/bin/harness.js');
+const PKG_VERSION = (JSON.parse(
+  readFileSync(resolve(process.cwd(), 'package.json'), 'utf-8')
+) as { version: string }).version;
 
 function runCli(args: string[], options: { cwd?: string; env?: Record<string, string> } = {}) {
   return spawnSync('node', [CLI_PATH, ...args], {
@@ -40,7 +43,7 @@ describe('CLI lifecycle integration', () => {
   it('harness --version outputs version', () => {
     const result = runCli(['--version']);
     expect(result.status).toBe(0);
-    expect(result.stdout.trim()).toBe('0.1.0');
+    expect(result.stdout.trim()).toBe(PKG_VERSION);
   });
 
   it('harness list shows empty in fresh repo', () => {


### PR DESCRIPTION
## Summary

- `phase-harness --version` printed `0.1.0` regardless of the installed package (currently `0.2.5`) because the version string was hardcoded in five places. The same stale value leaked into session logging (`session_start.harnessVersion`, `meta.json.harnessVersion`), making telemetry unreliable for version-scoped analysis.
- Add `src/version.ts` that reads `package.json` at runtime (probing both dev and built layouts, validating the package name) and exports `HARNESS_VERSION`. Replace all hardcoded sites: `bin/harness.ts:19`, `src/logger.ts:93`, `src/logger.ts:126`, `src/commands/inner.ts:318`, `src/commands/inner.ts:355`.
- Update `tests/integration/lifecycle.test.ts` to compare CLI output against the current `package.json` version instead of a literal, so future version bumps don't require test churn.

## Why this matters

Discovered while investigating why a dogfood run reported `harnessVersion: "0.1.0"` in `events.jsonl` — the CLI has been bumped to `0.2.5` (see `fda17ad chore(release): bump version to 0.2.3` and subsequent commits) but every self-reported version has been frozen since the initial release.

## Test plan

- [x] `pnpm tsc --noEmit` green
- [x] `pnpm vitest run` — 881 passed / 1 skipped (same as baseline); no regressions
- [x] `pnpm build` clean
- [x] Smoke: `node dist/bin/harness.js --version` → `0.2.5` (matches `package.json.version`)
- [ ] CI passes

## Notes

- No change to `0.1.0` values in event schemas themselves (those are just the reported value going forward); historical logs stay as they are.
- `fallback '0.0.0'` only triggers if `package.json` is missing AND mis-named in both layouts — effectively never in a real install.