### PR TITLE
feat(multi-worktree): outer cwd + N tracked repos support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.tsbuildinfo
 .idea/
 .omx/
+.DS_Store

--- a/bin/harness.ts
+++ b/bin/harness.ts
@@ -27,9 +27,11 @@ program
   .option('--enable-logging', 'enable session logging to ~/.harness/sessions')
   .option('--light', 'use the 4-phase light flow (P1 → P5 → P6 → P7)')
   .option('--codex-no-isolate', 'bypass CODEX_HOME isolation for codex subprocesses (not recommended)')
-  .action(async (task: string | undefined, opts: { requireClean?: boolean; auto?: boolean; enableLogging?: boolean; light?: boolean; codexNoIsolate?: boolean }) => {
+  .option('--track <path>', 'explicit tracked repo (repeatable; first = docs home)', (val: string, prev: string[]) => [...prev, val], [] as string[])
+  .option('--exclude <path>', 'exclude path from auto-detect (repeatable)', (val: string, prev: string[]) => [...prev, val], [] as string[])
+  .action(async (task: string | undefined, opts: { requireClean?: boolean; auto?: boolean; enableLogging?: boolean; light?: boolean; codexNoIsolate?: boolean; track?: string[]; exclude?: string[] }) => {
     const globalOpts = program.opts();
-    await startCommand(task, { ...opts, root: globalOpts.root });
+    await startCommand(task, { ...opts, root: globalOpts.root, track: opts.track, exclude: opts.exclude });
   });
 
 program
@@ -40,9 +42,11 @@ program
   .option('--enable-logging', 'enable session logging to ~/.harness/sessions')
   .option('--light', 'use the 4-phase light flow (P1 → P5 → P6 → P7)')
   .option('--codex-no-isolate', 'bypass CODEX_HOME isolation for codex subprocesses (not recommended)')
-  .action(async (task: string | undefined, opts: { requireClean?: boolean; auto?: boolean; enableLogging?: boolean; light?: boolean; codexNoIsolate?: boolean }) => {
+  .option('--track <path>', 'explicit tracked repo (repeatable; first = docs home)', (val: string, prev: string[]) => [...prev, val], [] as string[])
+  .option('--exclude <path>', 'exclude path from auto-detect (repeatable)', (val: string, prev: string[]) => [...prev, val], [] as string[])
+  .action(async (task: string | undefined, opts: { requireClean?: boolean; auto?: boolean; enableLogging?: boolean; light?: boolean; codexNoIsolate?: boolean; track?: string[]; exclude?: string[] }) => {
     const globalOpts = program.opts();
-    await startCommand(task, { ...opts, root: globalOpts.root });
+    await startCommand(task, { ...opts, root: globalOpts.root, track: opts.track, exclude: opts.exclude });
   });
 
 program

--- a/docs/HOW-IT-WORKS.ko.md
+++ b/docs/HOW-IT-WORKS.ko.md
@@ -85,6 +85,43 @@ light flow 특이사항:
 
 ---
 
+## 멀티 워크트리 플로우
+
+`phase-harness start`와 `phase-harness run`은 **외부(non-git) 디렉터리**에서 실행을 지원합니다. 이 디렉터리에는 depth 1에 N개의 git 서브 레포가 있을 수 있습니다.
+
+### 레포 자동 감지
+
+1. **단일 레포 (레거시)**: outer cwd가 git 레포이면 해당 레포가 유일한 tracked repo가 됩니다. 기존 동작과 동일합니다.
+2. **멀티 레포 자동 감지**: outer cwd가 git 레포가 아니면 depth-1 서브디렉터리를 스캔하고, 숨김 디렉터리 및 일반적인 비-레포 디렉터리(`node_modules`, `dist`, `build`, `.harness`)를 제외하여 발견된 모든 git 레포를 알파벳순으로 추적합니다.
+3. **`--track <path>`**: 자동 감지를 명시적인 레포 경로로 재정의합니다. 경로는 outer cwd 내부에 있어야 합니다.
+4. **`--exclude <dir>`**: 자동 감지 중 디렉터리를 건너뜁니다 (반복 가능).
+
+### 상태: `trackedRepos[]`
+
+`state.json`은 `trackedRepos: TrackedRepo[]`를 저장합니다 — tracked 레포마다 하나의 엔트리:
+- `path`: 레포의 절대 경로
+- `baseCommit`, `implRetryBase`: 레포별 커밋 앵커
+- `implHead`: Phase 5 성공 후의 HEAD (완료 전에는 null)
+
+첫 번째 엘리먼트(`trackedRepos[0]`)가 **docs 홈**입니다 — spec, plan, eval 아티팩트가 여기에 커밋됩니다.
+
+레거시 미러(`state.baseCommit`, `state.implRetryBase`, `state.implCommit`)는 단일 레포 소비자가 변경 없이 동작하도록 유지되며, 매 state 쓰기 시 `trackedRepos[0]`으로부터 자동 동기화됩니다(`syncLegacyMirror`).
+
+### Phase 5 성공 기준
+
+tracked 레포 중 **하나 이상**이 `implRetryBase`를 넘어 진행되면 Phase 5가 성공합니다. 수정되지 않은 레포는 `implHead = null`으로 유지됩니다.
+
+### Gate diff (Phase 2/4/7)
+
+- **N=1이고 `trackedRepos[0].path === cwd`**: diff 출력이 멀티 워크트리 이전 형식과 바이트 단위로 동일합니다 (레이블 없음).
+- **N>1 또는 cwd가 아닌 단일 레포**: 각 레포의 diff가 `### repo: <relPath>` 헤딩 아래 출력됩니다. 파일별 트런케이션은 마크다운 래퍼 전에 실행되며, 전체 크기 상한이 concat 후 적용됩니다.
+
+### Codex (outer-cwd gate)
+
+outer cwd가 git 레포가 아니면 gate가 실행될 수 있도록 Codex 호출에 `--skip-git-repo-check`가 자동으로 추가됩니다.
+
+---
+
 ## Phase별 요약
 
 | Phase | 기본 preset | runner 유형 | 주요 산출물 | reject/fail 시 |

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -85,6 +85,43 @@ Light-flow specifics:
 
 ---
 
+## Multi-worktree flow
+
+`phase-harness start` and `phase-harness run` support running from an **outer (non-git) directory** that contains N git sub-repos at depth 1.
+
+### How repos are discovered
+
+1. **Single-repo (legacy)**: if the outer cwd is itself a git repo, that repo becomes the sole tracked repo. Behavior is identical to pre-multi-worktree.
+2. **Multi-repo auto-detect**: if the outer cwd is not a git repo, harness scans depth-1 subdirectories, filters out hidden dirs and common non-repo dirs (`node_modules`, `dist`, `build`, `.harness`), and tracks all git repos found — alphabetically sorted.
+3. **`--track <path>`**: override auto-detection with explicit repo paths. Paths must be inside the outer cwd.
+4. **`--exclude <dir>`**: skip a directory during auto-detect (repeatable).
+
+### State: `trackedRepos[]`
+
+`state.json` stores `trackedRepos: TrackedRepo[]` — one entry per tracked repo:
+- `path`: absolute path to the repo
+- `baseCommit`, `implRetryBase`: per-repo commit anchors
+- `implHead`: the HEAD after a successful Phase 5 (null before completion)
+
+The first element (`trackedRepos[0]`) is the **docs home** — spec, plan, and eval artifacts are committed there.
+
+A legacy mirror (`state.baseCommit`, `state.implRetryBase`, `state.implCommit`) keeps single-repo consumers working unchanged and is auto-synced from `trackedRepos[0]` on every state write (`syncLegacyMirror`).
+
+### Phase 5 success criterion
+
+Phase 5 succeeds when **at least one** tracked repo has advanced past its `implRetryBase`. Repos that were not modified are left with `implHead = null`.
+
+### Gate diff (Phase 2/4/7)
+
+- **N=1 and `trackedRepos[0].path === cwd`**: diff output is byte-identical to the pre-multi-worktree format (no label).
+- **N>1 or non-cwd single repo**: each repo's diff is emitted under a `### repo: <relPath>` heading. Per-file truncation runs before the markdown wrapper; a global size cap applies after concat.
+
+### Codex (outer-cwd gate)
+
+When the outer cwd is not a git repo, `--skip-git-repo-check` is automatically added to the Codex invocation so the gate can still run.
+
+---
+
 ## Phase-by-phase summary
 
 | Phase | Default preset | Runner type | Main outputs | On reject/fail |

--- a/docs/plans/2026-04-20-task-outer-cwd-n-sub-a808.md
+++ b/docs/plans/2026-04-20-task-outer-cwd-n-sub-a808.md
@@ -235,11 +235,11 @@ Expected: All tests pass including the new `trackedRepos` + `syncLegacyMirror` d
 Run: `pnpm tsc --noEmit`
 Expected: Zero errors (or only pre-existing errors unrelated to Task 1).
 
-- [ ] **Step 1.7: Update `readState` callers to pass `cwd` (optional — improves legacy migration accuracy)**
+- [ ] **Step 1.7: Update `readState` callers to pass `cwd` (mandatory — ensures correct legacy migration)**
 
 In `src/commands/inner.ts`, `src/commands/resume.ts`, `src/commands/jump.ts`, `src/commands/skip.ts`, and `src/commands/status.ts`, find each call to `readState(runDir)` and update to `readState(runDir, cwd)` where `cwd` is the outer cwd already determined in those functions. This ensures legacy state migration synthesizes `trackedRepos[0].path = cwd` instead of the `''` fallback.
 
-This step is forward-compatible: `resolveArtifact` already handles the `''` fallback case, so skipping this step doesn't break behavior.
+This step is **mandatory**: spec Invariants require every `trackedRepos[i].path` to be a non-empty cwd-descendant path. The `''` fallback is a compatibility sentinel for in-flight serialized states only; it must not persist as an accepted end state.
 
 - [ ] **Step 1.8: Commit**
 
@@ -641,8 +641,7 @@ Also apply cwd-descendant check for `--exclude` paths (FR-10):
       const resolved = path.resolve(cwd, e);
       const rel = path.relative(cwd, resolved);
       if (rel.startsWith('..') || path.isAbsolute(rel)) {
-        process.stderr.write(`⚠️  --exclude ${e}: path is outside cwd, ignored.\n`);
-        return ''; // won't match anything
+        throw new Error(`--exclude ${e}: must be inside cwd (${cwd})`);
       }
       return resolved;
     }).filter(Boolean)
@@ -778,10 +777,7 @@ Replace the Phase 5 block in `validatePhaseArtifacts` (currently lines ~187-198)
           r.implHead = null;
         }
       }
-      if (!anyAdvanced) {
-        // Fallback: verify-failure reopen path where implCommit already set
-        return state.implCommit !== null;
-      }
+      if (!anyAdvanced) return false;
       syncLegacyMirror(state); // sets state.implCommit = trackedRepos[0].implHead
       return true;
     } catch {
@@ -1024,7 +1020,8 @@ function buildPhase7DiffAndMetadata(state: HarnessState, cwd: string): {
         // Per-repo pre-truncation (ADR-D1)
         d = truncateDiffPerFile(d, PER_FILE_DIFF_LIMIT_KB * 1024);
         const evalCommit = state.evalCommit;
-        if (evalCommit !== null) {
+        if (evalCommit !== null && repo === repos[0]) {
+          // evalCommit exists only in the docs-home repo (trackedRepos[0])
           d += '\n' + runGit(`git diff ${evalCommit}^..${evalCommit}`, repo.path);
         }
         return d;

--- a/docs/plans/2026-04-20-task-outer-cwd-n-sub-a808.md
+++ b/docs/plans/2026-04-20-task-outer-cwd-n-sub-a808.md
@@ -1,0 +1,1795 @@
+# Multi-Worktree Harness Flow — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/specs/2026-04-20-task-outer-cwd-n-sub-a808-design.md`
+**Decisions:** `.harness/2026-04-20-task-outer-cwd-n-sub-a808/decisions.md`
+
+**Goal:** Enable `phase-harness run` from an outer (non-git) directory containing N sub-worktrees (independent git repos), with zero regression on existing single-repo flows.
+
+**Architecture:** The single-model unification: harness always maintains `state.trackedRepos: TrackedRepo[]` (N ≥ 1). When `cwd` is a git repo, `trackedRepos = [{ path: cwd, ... }]`—the degenerate single-repo case. Phase 5 success judgment, gate diff assembly, resume ancestry, and artifact path resolution all iterate `trackedRepos`, so no separate "multi-worktree mode" branch exists anywhere.
+
+**Tech Stack:** TypeScript, Node.js, vitest, `child_process`, `path`, `fs`
+
+---
+
+## Dependency Order
+
+```
+T1 (State schema + helpers)
+  └─ T2 (start.ts scan + preflight)
+  └─ T3 (runner.ts + interactive.ts multi-repo)
+  └─ T4 (assembler multi-repo diff)
+  └─ T5 (codex runner)
+  └─ T6 (resume.ts)         ← needs T3 (syncLegacyMirror)
+  └─ T7 (docs)              ← independent
+T1..T6 ─ T8 (tests)
+```
+
+---
+
+## Inline ADR Blurbs
+
+**ADR-D1 (D-1 resolution — diff truncation for multi-repo)**
+Per-repo raw diff gets `truncateDiffPerFile(rawDiff, PER_FILE_DIFF_LIMIT_KB * 1024)` *before* markdown wrapping. After concatenating all repo sections, if total bytes > `MAX_DIFF_SIZE_KB * 1024`, hard-truncate at that byte boundary and append `\n--- (diff truncated: total exceeds MAX_DIFF_SIZE_KB KB) ---\n`. Rationale: `truncateDiffPerFile` splits on `diff --git` headers, which are absent inside fenced blocks—pre-wrap application is the only correct location.
+
+**ADR-D2 (resolveArtifact — single substitution point)**
+`resolveArtifact(state, relPath, outerCwd)` added to `src/artifact.ts`. Returns `path.join(state.trackedRepos?.[0]?.path || outerCwd, relPath)` for relative paths. All callers that currently do `path.join(cwd, relPath)` for doc artifact reading/writing switch to this helper. Rationale: FR-7 "단일 치환점" requirement; N=1 case is identity-equivalent to current behavior.
+
+**ADR-D3 (migrateState cwd parameter)**
+`migrateState(raw, cwd?)` and `readState(runDir, cwd?)` gain an optional `cwd` parameter. When `trackedRepos` is absent, `trackedRepos[0].path` is set to `cwd ?? ''`. `resolveArtifact` falls back to `outerCwd` argument when `trackedRepos[0].path === ''`. Rationale: spec requires `path: cwd` in migration synthesis, but `migrateState` has no `cwd` today—optional param is the minimal-change solution.
+
+**ADR-D4 (validatePhaseArtifacts Phase 5 mutates state)**
+`validatePhaseArtifacts` for Phase 5 sets `r.implHead` on each `trackedRepos` entry and calls `syncLegacyMirror(state)` before returning `true`. The `runner.ts` block `state.implCommit = getHead(cwd)` is replaced with `syncLegacyMirror(state)` for Phase 5. Rationale: HEAD is observed atomically at sentinel-detection time; re-reading later risks a second getHead call that may fail on outer (non-git) cwd.
+
+---
+
+## Task 1: State Schema + `syncLegacyMirror` + `resolveArtifact`
+
+Foundation for all other tasks. Introduces `TrackedRepo`, `trackedRepos[]` field, migration, and the two shared helpers.
+
+**Files:**
+- Modify: `src/types.ts`
+- Modify: `src/state.ts`
+- Modify: `src/artifact.ts`
+- Test: `tests/state.test.ts` (add new `describe` blocks)
+
+- [ ] **Step 1.1: Add `TrackedRepo` interface and `trackedRepos` field to `HarnessState`**
+
+In `src/types.ts`, add after the `CarryoverFeedback` interface (before `RunStatus`):
+
+```typescript
+export interface TrackedRepo {
+  path: string;          // absolute path; '' for legacy-migrated states
+  baseCommit: string;
+  implRetryBase: string;
+  implHead: string | null;
+}
+```
+
+In `HarnessState` interface (after `implRetryBase: string;`), add:
+
+```typescript
+trackedRepos: TrackedRepo[];
+```
+
+- [ ] **Step 1.2: Write failing tests for `migrateState` + `createInitialState` + `syncLegacyMirror`**
+
+Append to `tests/state.test.ts`:
+
+```typescript
+describe('trackedRepos — migration (FR-2, ADR-N3)', () => {
+  it('migrateState synthesizes trackedRepos[0] from top-level fields when absent', () => {
+    const legacy = JSON.parse(JSON.stringify(makeState()));
+    delete (legacy as any).trackedRepos;
+    legacy.baseCommit = 'abc123';
+    legacy.implRetryBase = 'abc123';
+    legacy.implCommit = null;
+    const migrated = migrateState(legacy, '/outer/cwd');
+    expect(migrated.trackedRepos).toHaveLength(1);
+    expect(migrated.trackedRepos[0]).toEqual({
+      path: '/outer/cwd',
+      baseCommit: 'abc123',
+      implRetryBase: 'abc123',
+      implHead: null,
+    });
+  });
+
+  it('migrateState uses empty string for path when no cwd provided', () => {
+    const legacy = JSON.parse(JSON.stringify(makeState()));
+    delete (legacy as any).trackedRepos;
+    const migrated = migrateState(legacy);
+    expect(migrated.trackedRepos[0].path).toBe('');
+  });
+
+  it('migrateState preserves existing trackedRepos', () => {
+    const state = makeState();
+    (state as any).trackedRepos = [{ path: '/repo', baseCommit: 'abc', implRetryBase: 'abc', implHead: null }];
+    const migrated = migrateState(state as any);
+    expect(migrated.trackedRepos[0].path).toBe('/repo');
+  });
+});
+
+describe('syncLegacyMirror (ADR-N3 mirror invariant)', () => {
+  it('syncLegacyMirror keeps baseCommit in sync with trackedRepos[0]', () => {
+    const state = makeState();
+    state.trackedRepos = [{ path: '/r', baseCommit: 'newbase', implRetryBase: 'newbase', implHead: null }];
+    syncLegacyMirror(state);
+    expect(state.baseCommit).toBe('newbase');
+    expect(state.implRetryBase).toBe('newbase');
+    expect(state.implCommit).toBeNull();
+  });
+
+  it('syncLegacyMirror sets implCommit from trackedRepos[0].implHead', () => {
+    const state = makeState();
+    state.trackedRepos = [{ path: '/r', baseCommit: 'b', implRetryBase: 'b', implHead: 'impl-sha' }];
+    syncLegacyMirror(state);
+    expect(state.implCommit).toBe('impl-sha');
+  });
+});
+```
+
+Run: `pnpm vitest run tests/state.test.ts`
+Expected: FAIL (syncLegacyMirror not exported, trackedRepos not in HarnessState)
+
+- [ ] **Step 1.3: Implement `syncLegacyMirror` in `state.ts` + update `migrateState`**
+
+In `src/state.ts`, add this exported helper (after the imports):
+
+```typescript
+/**
+ * Keep legacy top-level mirror fields in sync with trackedRepos[0].
+ * Must be called before every writeState and after any mutation of trackedRepos[0].
+ */
+export function syncLegacyMirror(state: HarnessState): void {
+  if (!state.trackedRepos || state.trackedRepos.length === 0) return;
+  const r0 = state.trackedRepos[0];
+  state.baseCommit = r0.baseCommit;
+  state.implRetryBase = r0.implRetryBase;
+  state.implCommit = r0.implHead;
+}
+```
+
+Update `migrateState` signature to `export function migrateState(raw: any, cwd?: string): HarnessState`.
+
+Add before `return raw as HarnessState` (at the end of `migrateState`):
+
+```typescript
+  if (!raw.trackedRepos || !Array.isArray(raw.trackedRepos) || raw.trackedRepos.length === 0) {
+    raw.trackedRepos = [{
+      path: cwd ?? '',
+      baseCommit: raw.baseCommit,
+      implRetryBase: raw.implRetryBase,
+      implHead: raw.implCommit ?? null,
+    }];
+  }
+```
+
+Update `readState` to forward `cwd` to `migrateState`:
+
+```typescript
+export function readState(runDir: string, cwd?: string): HarnessState | null {
+  // ... existing file load logic unchanged ...
+  try {
+    return migrateState(JSON.parse(raw), cwd);  // ← pass cwd
+  } catch {
+    throw new Error('state.json is corrupted. Manual recovery required.');
+  }
+}
+```
+
+Update `writeState` to call `syncLegacyMirror` before serialization:
+
+```typescript
+export function writeState(runDir: string, state: HarnessState): void {
+  syncLegacyMirror(state);   // ← add this line at the top of writeState
+  const statePath = path.join(runDir, STATE_FILE);
+  // ... rest unchanged ...
+}
+```
+
+Update `createInitialState` to set `trackedRepos`:
+
+```typescript
+// At the end of createInitialState, before the return statement, add:
+  const trackedRepos: import('./types.js').TrackedRepo[] = [{
+    path: '',  // caller (start.ts) overwrites this
+    baseCommit,
+    implRetryBase: baseCommit,
+    implHead: null,
+  }];
+
+  return {
+    // ... existing fields ...
+    trackedRepos,
+  };
+```
+
+- [ ] **Step 1.4: Add `resolveArtifact` to `artifact.ts`**
+
+In `src/artifact.ts`, add this export after existing imports (before `normalizeArtifactCommit`):
+
+```typescript
+import path from 'path';
+import type { HarnessState } from './types.js';
+
+/**
+ * Resolve an artifact's relative path to an absolute path.
+ * Uses trackedRepos[0].path as the docs root (FR-7).
+ * Falls back to outerCwd when trackedRepos[0].path is '' (legacy migrated state).
+ */
+export function resolveArtifact(state: HarnessState, relPath: string, outerCwd: string): string {
+  if (path.isAbsolute(relPath)) return relPath;
+  const docsRoot = state.trackedRepos?.[0]?.path || outerCwd;
+  return path.join(docsRoot, relPath);
+}
+```
+
+- [ ] **Step 1.5: Run tests to verify passing**
+
+Run: `pnpm vitest run tests/state.test.ts`
+Expected: All tests pass including the new `trackedRepos` + `syncLegacyMirror` describes.
+
+- [ ] **Step 1.6: Typecheck**
+
+Run: `pnpm tsc --noEmit`
+Expected: Zero errors (or only pre-existing errors unrelated to Task 1).
+
+- [ ] **Step 1.7: Update `readState` callers to pass `cwd` (optional — improves legacy migration accuracy)**
+
+In `src/commands/inner.ts`, `src/commands/resume.ts`, `src/commands/jump.ts`, `src/commands/skip.ts`, and `src/commands/status.ts`, find each call to `readState(runDir)` and update to `readState(runDir, cwd)` where `cwd` is the outer cwd already determined in those functions. This ensures legacy state migration synthesizes `trackedRepos[0].path = cwd` instead of the `''` fallback.
+
+This step is forward-compatible: `resolveArtifact` already handles the `''` fallback case, so skipping this step doesn't break behavior.
+
+- [ ] **Step 1.8: Commit**
+
+```bash
+git add src/types.ts src/state.ts src/artifact.ts tests/state.test.ts
+git commit -m "feat(state): add TrackedRepo schema, trackedRepos[], syncLegacyMirror, resolveArtifact"
+```
+
+---
+
+## Task 2: CLI `start.ts` — scan logic, `--track`/`--exclude`, per-repo preflight
+
+Wires `trackedRepos` into the run-start path. Depends on Task 1.
+
+**Files:**
+- Modify: `src/commands/start.ts`
+- Test: `tests/commands/start.test.ts` (new file)
+
+- [ ] **Step 2.1: Write failing tests**
+
+Create `tests/commands/start.test.ts`:
+
+```typescript
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execSync } from 'child_process';
+import { detectTrackedRepos } from '../../src/commands/start.js';
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true });
+  tmpDirs.length = 0;
+});
+
+function makeTmp(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'start-test-'));
+  tmpDirs.push(d);
+  return d;
+}
+
+function initGitRepo(dir: string): string {
+  fs.mkdirSync(dir, { recursive: true });
+  execSync('git init', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.email "t@t.com"', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.name "T"', { cwd: dir, stdio: 'pipe' });
+  fs.writeFileSync(path.join(dir, 'init.txt'), 'x');
+  execSync('git add .', { cwd: dir, stdio: 'pipe' });
+  execSync('git commit -m "init"', { cwd: dir, stdio: 'pipe' });
+  return execSync('git rev-parse HEAD', { cwd: dir, encoding: 'utf-8' }).trim();
+}
+
+describe('detectTrackedRepos — auto-detect depth=1 (ADR-N2)', () => {
+  it('returns [cwd] single-entry when cwd is a git repo', () => {
+    const outer = makeTmp();
+    initGitRepo(outer);
+    const result = detectTrackedRepos(outer);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe(outer);
+  });
+
+  it('auto-detects depth=1 git repos when cwd is not a git repo', () => {
+    const outer = makeTmp();
+    const repoA = path.join(outer, 'repo-a');
+    const repoB = path.join(outer, 'repo-b');
+    initGitRepo(repoA);
+    initGitRepo(repoB);
+    const result = detectTrackedRepos(outer);
+    expect(result).toHaveLength(2);
+    const paths = result.map(r => r.path).sort();
+    expect(paths).toEqual([repoA, repoB].sort());
+  });
+
+  it('skips hidden dirs, node_modules, dist, build, .harness in auto-detect', () => {
+    const outer = makeTmp();
+    for (const skip of ['.hidden', 'node_modules', 'dist', 'build', '.harness']) {
+      initGitRepo(path.join(outer, skip));
+    }
+    initGitRepo(path.join(outer, 'real-repo'));
+    const result = detectTrackedRepos(outer);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe(path.join(outer, 'real-repo'));
+  });
+
+  it('throws when no repos found and no --track', () => {
+    const outer = makeTmp();
+    expect(() => detectTrackedRepos(outer)).toThrow(
+      'No tracked git repos found under cwd.'
+    );
+  });
+});
+
+describe('detectTrackedRepos — --track / --exclude (FR-10)', () => {
+  it('--track overrides auto-detect entirely', () => {
+    const outer = makeTmp();
+    const repoA = path.join(outer, 'repo-a');
+    const repoB = path.join(outer, 'repo-b');
+    initGitRepo(repoA);
+    initGitRepo(repoB);
+    // only track repoA
+    const result = detectTrackedRepos(outer, [repoA]);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe(repoA);
+  });
+
+  it('--exclude removes from auto-detect result', () => {
+    const outer = makeTmp();
+    const repoA = path.join(outer, 'repo-a');
+    const repoB = path.join(outer, 'repo-b');
+    initGitRepo(repoA);
+    initGitRepo(repoB);
+    const result = detectTrackedRepos(outer, undefined, [repoB]);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe(repoA);
+  });
+
+  it('--track with out-of-tree path throws (cwd-descendant rule)', () => {
+    const outer = makeTmp();
+    const outside = makeTmp();
+    initGitRepo(outside);
+    expect(() => detectTrackedRepos(outer, [outside])).toThrow(
+      'must be inside cwd'
+    );
+  });
+
+  it('--track with non-existent path throws', () => {
+    const outer = makeTmp();
+    expect(() => detectTrackedRepos(outer, [path.join(outer, 'nonexistent')])).toThrow(
+      'path not found'
+    );
+  });
+
+  it('--track with non-git path throws', () => {
+    const outer = makeTmp();
+    const notGit = path.join(outer, 'notgit');
+    fs.mkdirSync(notGit);
+    expect(() => detectTrackedRepos(outer, [notGit])).toThrow(
+      'not a git repo'
+    );
+  });
+
+  it('result is alphabetically sorted (deterministic)', () => {
+    const outer = makeTmp();
+    for (const name of ['z-repo', 'a-repo', 'm-repo']) {
+      initGitRepo(path.join(outer, name));
+    }
+    const result = detectTrackedRepos(outer);
+    const names = result.map(r => path.basename(r.path));
+    expect(names).toEqual(['a-repo', 'm-repo', 'z-repo']);
+  });
+});
+```
+
+Run: `pnpm vitest run tests/commands/start.test.ts`
+Expected: FAIL (`detectTrackedRepos` not exported)
+
+- [ ] **Step 2.2: Implement `detectTrackedRepos` in `start.ts`**
+
+Add `export` before the function (it will be called from `startCommand` and imported by tests).
+
+Add to `src/commands/start.ts` imports:
+
+```typescript
+import path from 'path';
+import { readdirSync, statSync } from 'fs';
+import type { TrackedRepo } from '../types.js';
+```
+
+Add the `detectTrackedRepos` function (export it for testability):
+
+```typescript
+const SKIP_DIRS = new Set(['.harness', 'node_modules', 'dist', 'build']);
+
+/**
+ * Determine tracked repos for a run.
+ * - If cwd is a git repo → single-repo mode (returns [{path: cwd, ...}]).
+ * - Otherwise auto-detect depth=1 git children, filtered by --track/--exclude.
+ * Throws on validation errors or empty result.
+ */
+export function detectTrackedRepos(
+  cwd: string,
+  track?: string[],
+  exclude?: string[],
+): TrackedRepo[] {
+  // Single-repo fast path: cwd is itself a git repo
+  if (isInGitRepo(cwd)) {
+    let head = '';
+    try { head = getHead(cwd); } catch { /* no commits */ }
+    return [{ path: cwd, baseCommit: head, implRetryBase: head, implHead: null }];
+  }
+
+  // Multi-repo path
+  if (track && track.length > 0) {
+    // Validate each --track path and build list
+    const repos: TrackedRepo[] = [];
+    for (const raw of track) {
+      const resolved = path.resolve(cwd, raw);
+      const rel = path.relative(cwd, resolved);
+      if (rel.startsWith('..') || path.isAbsolute(rel)) {
+        throw new Error(`--track ${raw}: must be inside cwd (${cwd})`);
+      }
+      if (!existsSync(resolved)) {
+        throw new Error(`--track ${raw}: path not found`);
+      }
+      if (!isInGitRepo(resolved)) {
+        throw new Error(`--track ${raw}: not a git repo`);
+      }
+      let head = '';
+      try { head = getHead(resolved); } catch { /* no commits */ }
+      repos.push({ path: resolved, baseCommit: head, implRetryBase: head, implHead: null });
+    }
+    return repos;
+  }
+
+  // Auto-detect: depth=1 scan
+  const excludeSet = new Set(
+    (exclude ?? []).map(e => path.resolve(cwd, e))
+  );
+
+  let entries: string[];
+  try {
+    entries = readdirSync(cwd, { withFileTypes: true })
+      .filter(d => {
+        if (!d.isDirectory()) return false;
+        if (d.name.startsWith('.')) return false;
+        if (SKIP_DIRS.has(d.name)) return false;
+        return true;
+      })
+      .map(d => path.join(cwd, d.name))
+      .filter(p => !excludeSet.has(p) && isInGitRepo(p))
+      .sort();
+  } catch {
+    entries = [];
+  }
+
+  if (entries.length === 0) {
+    throw new Error(
+      'No tracked git repos found under cwd. Pass --track <path> or run from a git repo.'
+    );
+  }
+
+  return entries.map(p => {
+    let head = '';
+    try { head = getHead(p); } catch { /* no commits */ }
+    return { path: p, baseCommit: head, implRetryBase: head, implHead: null };
+  });
+}
+```
+
+- [ ] **Step 2.3: Wire `detectTrackedRepos` into `startCommand`**
+
+Update `startCommand` in `src/commands/start.ts`.
+
+Add `track` and `exclude` to `StartOptions`:
+
+```typescript
+export interface StartOptions {
+  requireClean?: boolean;
+  auto?: boolean;
+  root?: string;
+  enableLogging?: boolean;
+  light?: boolean;
+  codexNoIsolate?: boolean;
+  track?: string[];     // ← new
+  exclude?: string[];   // ← new
+}
+```
+
+In `startCommand`, replace the `cwd` determination block and directory creation with:
+
+```typescript
+  let cwd: string;
+  try {
+    cwd = options.root ?? getGitRoot();
+  } catch {
+    cwd = options.root ?? process.cwd();
+  }
+
+  // Detect tracked repos (throws on validation failure / empty result)
+  let trackedRepos: import('../types.js').TrackedRepo[];
+  try {
+    trackedRepos = detectTrackedRepos(cwd, options.track, options.exclude);
+  } catch (err) {
+    process.stderr.write(`Error: ${(err as Error).message}\n`);
+    process.exit(1);
+  }
+
+  // Print detection summary when multi-repo
+  if (trackedRepos.length > 1) {
+    const paths = trackedRepos.map(r => r.path).join(', ');
+    process.stderr.write(`Detected ${trackedRepos.length} tracked repos: [${paths}]\n`);
+  }
+
+  // Per-repo preflight (git + head checks)
+  for (const repo of trackedRepos) {
+    try {
+      runPreflight(['git', 'head'], repo.path);
+    } catch (err) {
+      process.stderr.write(`Error: ${(err as Error).message} (repo: ${repo.path})\n`);
+      process.exit(1);
+    }
+  }
+```
+
+Replace directory creation to use `trackedRepos[0].path` as docs root:
+
+```typescript
+    const docsRoot = trackedRepos[0].path;
+    mkdirSync(join(docsRoot, 'docs/specs'), { recursive: true });
+    mkdirSync(join(docsRoot, 'docs/plans'), { recursive: true });
+    mkdirSync(join(docsRoot, 'docs/process/evals'), { recursive: true });
+```
+
+Remove the old `inGitRepo`-gated `baseCommit` capture. Instead derive from `trackedRepos`:
+
+```typescript
+    // baseCommit from trackedRepos[0] (already captured by detectTrackedRepos)
+    const baseCommit = trackedRepos[0].baseCommit;
+```
+
+After `createInitialState(...)`, set `trackedRepos` on state:
+
+```typescript
+    state.trackedRepos = trackedRepos;
+    // syncLegacyMirror is called inside writeState — no explicit call needed here
+```
+
+Also update `ensureGitignore` caller to use `trackedRepos[0].path` or `cwd` (outer git):
+
+```typescript
+    // .gitignore handling: commit in each tracked git repo that is also the outer cwd
+    // (outer non-git dirs don't have .gitignore to commit)
+    if (inGitRepo) {
+      await ensureGitignore(cwd);
+    } else if (trackedRepos[0].path !== cwd) {
+      // outer dir is not git — no .gitignore commit needed
+    }
+```
+
+- [ ] **Step 2.4: Update `preflight.ts` error messages to include repo path (FR-3)**
+
+In `src/preflight.ts`, update the `git` and `head` cases to include `cwd` in the error message:
+
+```typescript
+case 'git':
+  try {
+    execSync('git rev-parse --show-toplevel', { cwd, stdio: 'pipe' });
+  } catch {
+    const suffix = cwd ? ` in: ${cwd}` : '.';
+    throw new Error(`harness requires a git repository${suffix}`);
+  }
+  return {};
+
+case 'head':
+  try {
+    execSync('git rev-parse HEAD', { cwd, stdio: 'pipe' });
+  } catch {
+    const suffix = cwd ? ` in: ${cwd}` : '.';
+    throw new Error(`harness requires at least one commit${suffix}`);
+  }
+  return {};
+```
+
+- [ ] **Step 2.6: Add `--track`/`--exclude` options to `bin/harness.ts`**
+
+In `bin/harness.ts`, add to both the `start` and `run` command definitions (after `--codex-no-isolate` option):
+
+```typescript
+.option('--track <path>', 'explicit tracked repo (repeatable; first = docs home)', (val, prev: string[]) => [...prev, val], [] as string[])
+.option('--exclude <path>', 'exclude path from auto-detect (repeatable)', (val, prev: string[]) => [...prev, val], [] as string[])
+```
+
+Update the `.action` handler type annotation and body for both `start` and `run` commands to pass the new options:
+
+```typescript
+.action(async (task, opts: { requireClean?: boolean; auto?: boolean; enableLogging?: boolean; light?: boolean; codexNoIsolate?: boolean; track?: string[]; exclude?: string[] }) => {
+  const globalOpts = program.opts();
+  await startCommand(task, { ...opts, root: globalOpts.root, track: opts.track, exclude: opts.exclude });
+});
+```
+
+Also add a `--exclude` + `--track` combination warning in `detectTrackedRepos` when both are provided:
+
+```typescript
+  if (track && track.length > 0) {
+    if (exclude && exclude.length > 0) {
+      process.stderr.write('⚠️  --exclude has no effect when --track is specified.\n');
+    }
+    // ... existing validation logic ...
+  }
+```
+
+Also apply cwd-descendant check for `--exclude` paths (FR-10):
+
+```typescript
+  const excludeSet = new Set(
+    (exclude ?? []).map(e => {
+      const resolved = path.resolve(cwd, e);
+      const rel = path.relative(cwd, resolved);
+      if (rel.startsWith('..') || path.isAbsolute(rel)) {
+        process.stderr.write(`⚠️  --exclude ${e}: path is outside cwd, ignored.\n`);
+        return ''; // won't match anything
+      }
+      return resolved;
+    }).filter(Boolean)
+  );
+```
+
+- [ ] **Step 2.5: Run tests to verify passing**
+
+Run: `pnpm vitest run tests/commands/start.test.ts`
+Expected: All new tests pass.
+
+- [ ] **Step 2.7: Run tests**
+
+Run: `pnpm vitest run tests/commands/start.test.ts`
+Expected: All tests pass.
+
+- [ ] **Step 2.8: Typecheck**
+
+Run: `pnpm tsc --noEmit`
+Expected: Zero errors.
+
+- [ ] **Step 2.9: Commit**
+
+```bash
+git add src/commands/start.ts src/preflight.ts bin/harness.ts tests/commands/start.test.ts
+git commit -m "feat(start): detectTrackedRepos, --track/--exclude flags, per-repo preflight, FR-3 messages"
+```
+
+---
+
+## Task 3: `runner.ts` + `interactive.ts` — multi-repo Phase 5 + artifact paths
+
+Updates Phase 5 judgment to iterate `trackedRepos`, updates artifact path resolution to use `resolveArtifact`. Depends on Task 1.
+
+**Files:**
+- Modify: `src/phases/interactive.ts`
+- Modify: `src/phases/runner.ts`
+- Test: `tests/phases/interactive.test.ts` (add describe block)
+
+- [ ] **Step 3.1: Write failing tests for multi-repo Phase 5 judgment**
+
+Append to `tests/phases/interactive.test.ts` (after existing describes):
+
+```typescript
+describe('validatePhaseArtifacts — Phase 5 multi-repo (FR-6, ADR-D4)', () => {
+  it('returns true when any repo advanced; sets implHead on advanced repos only', () => {
+    const outer = makeTmpDir();
+    const repoA = makeTmpDir('repoA-');
+    const repoB = makeTmpDir('repoB-');
+
+    // Init both repos with an initial commit
+    for (const d of [repoA, repoB]) {
+      execSync('git init', { cwd: d, stdio: 'pipe' });
+      execSync('git config user.email "t@t.com"', { cwd: d, stdio: 'pipe' });
+      execSync('git config user.name "T"', { cwd: d, stdio: 'pipe' });
+      fs.writeFileSync(path.join(d, 'a.txt'), 'x');
+      execSync('git add .', { cwd: d, stdio: 'pipe' });
+      execSync('git commit -m "init"', { cwd: d, stdio: 'pipe' });
+    }
+
+    const headA = execSync('git rev-parse HEAD', { cwd: repoA, encoding: 'utf-8' }).trim();
+    const headB = execSync('git rev-parse HEAD', { cwd: repoB, encoding: 'utf-8' }).trim();
+
+    // Advance only repoA
+    fs.writeFileSync(path.join(repoA, 'new.txt'), 'y');
+    execSync('git add .', { cwd: repoA, stdio: 'pipe' });
+    execSync('git commit -m "impl"', { cwd: repoA, stdio: 'pipe' });
+    const newHeadA = execSync('git rev-parse HEAD', { cwd: repoA, encoding: 'utf-8' }).trim();
+
+    const state = createInitialState('run-x', 'task', headA, false);
+    state.trackedRepos = [
+      { path: repoA, baseCommit: headA, implRetryBase: headA, implHead: null },
+      { path: repoB, baseCommit: headB, implRetryBase: headB, implHead: null },
+    ];
+
+    const runDir = makeTmpDir('rundir-');
+    const result = validatePhaseArtifacts(5, state, outer, runDir);
+
+    expect(result).toBe(true);
+    expect(state.trackedRepos[0].implHead).toBe(newHeadA);
+    expect(state.trackedRepos[1].implHead).toBeNull(); // not advanced
+    expect(state.implCommit).toBe(newHeadA); // legacy mirror from trackedRepos[0]
+  });
+
+  it('returns false when no repo advanced and implCommit is null', () => {
+    const outer = makeTmpDir();
+    const repoA = makeTmpDir('repoA2-');
+    execSync('git init', { cwd: repoA, stdio: 'pipe' });
+    execSync('git config user.email "t@t.com"', { cwd: repoA, stdio: 'pipe' });
+    execSync('git config user.name "T"', { cwd: repoA, stdio: 'pipe' });
+    fs.writeFileSync(path.join(repoA, 'a.txt'), 'x');
+    execSync('git add .', { cwd: repoA, stdio: 'pipe' });
+    execSync('git commit -m "init"', { cwd: repoA, stdio: 'pipe' });
+    const head = execSync('git rev-parse HEAD', { cwd: repoA, encoding: 'utf-8' }).trim();
+
+    const state = createInitialState('run-y', 'task', head, false);
+    state.trackedRepos = [
+      { path: repoA, baseCommit: head, implRetryBase: head, implHead: null },
+    ];
+    state.implCommit = null;
+
+    const runDir = makeTmpDir('rundir2-');
+    const result = validatePhaseArtifacts(5, state, outer, runDir);
+    expect(result).toBe(false);
+  });
+});
+```
+
+Run: `pnpm vitest run tests/phases/interactive.test.ts`
+Expected: FAIL (new tests reference multi-repo behavior not yet implemented)
+
+- [ ] **Step 3.2: Update `validatePhaseArtifacts` Phase 5 in `interactive.ts`**
+
+In `src/phases/interactive.ts`, add import:
+
+```typescript
+import { syncLegacyMirror } from '../state.js';
+```
+
+Replace the Phase 5 block in `validatePhaseArtifacts` (currently lines ~187-198):
+
+```typescript
+  if (phase === 5) {
+    void runDir;
+    try {
+      let anyAdvanced = false;
+      for (const r of state.trackedRepos) {
+        const h = getHead(r.path);
+        if (h !== r.implRetryBase) {
+          r.implHead = h;
+          anyAdvanced = true;
+        } else {
+          r.implHead = null;
+        }
+      }
+      if (!anyAdvanced) {
+        // Fallback: verify-failure reopen path where implCommit already set
+        return state.implCommit !== null;
+      }
+      syncLegacyMirror(state); // sets state.implCommit = trackedRepos[0].implHead
+      return true;
+    } catch {
+      return false;
+    }
+  }
+```
+
+- [ ] **Step 3.3: Update `preparePhase` Phase 5 in `interactive.ts`**
+
+In `preparePhase`, replace the Phase 5 block (currently ~lines 83-85):
+
+```typescript
+  // Phase 5: update implRetryBase for each tracked repo to current HEAD
+  if (phase === 5) {
+    for (const r of state.trackedRepos) {
+      try { r.implRetryBase = getHead(r.path); } catch { /* no git */ }
+      r.implHead = null;
+    }
+    syncLegacyMirror(state);
+  }
+```
+
+Also update `preparePhase` artifact deletion to use `resolveArtifact`:
+
+In the `if (!isReopen)` block for Phase 1/3 artifacts, replace `path.join(cwd, relPath)`:
+
+```typescript
+import { resolveArtifact } from '../artifact.js';
+
+// In preparePhase, artifact deletion block:
+const absPath = resolveArtifact(state, relPath, cwd);
+```
+
+Similarly update `validatePhaseArtifacts` Phases 1/3 artifact reading:
+
+```typescript
+// Replace: const absPath = path.isAbsolute(relPath) ? relPath : path.join(cwd, relPath);
+const absPath = resolveArtifact(state, relPath, cwd);
+```
+
+And for the checklist + spec path resolutions in `validatePhaseArtifacts`:
+
+```typescript
+// Replace: path.isAbsolute(state.artifacts.checklist) ? state.artifacts.checklist : path.join(cwd, state.artifacts.checklist)
+// With:
+resolveArtifact(state, state.artifacts.checklist, cwd)
+// and:
+resolveArtifact(state, state.artifacts.spec, cwd)
+```
+
+- [ ] **Step 3.4: Update `runner.ts` Phase 5 implCommit handling**
+
+In `src/phases/runner.ts`, add import:
+
+```typescript
+import { syncLegacyMirror } from '../state.js';
+import { resolveArtifact } from '../artifact.js';
+```
+
+In `handleInteractivePhase`, find the block after successful completion (around line 449):
+
+```typescript
+      const head = getHead(cwd);
+      if (phase === 1) state.specCommit = head;
+      if (phase === 3) state.planCommit = head;
+      if (phase === 5) state.implCommit = head;
+```
+
+Replace with:
+
+```typescript
+      const docsRoot = state.trackedRepos?.[0]?.path || cwd;
+      const head = getHead(docsRoot);
+      if (phase === 1) state.specCommit = head;
+      if (phase === 3) state.planCommit = head;
+      if (phase === 5) syncLegacyMirror(state); // implHead already set by validatePhaseArtifacts
+```
+
+In `commitArtifacts` (the local helper in runner.ts that calls `normalizeArtifactCommit`), update the `cwd` argument:
+
+```typescript
+// Find the function commitArtifacts(phase, state, runDir, cwd) — currently uses `cwd` for normalizeArtifactCommit
+// Change to use docsRoot for artifact commits:
+const docsRoot = state.trackedRepos?.[0]?.path || cwd;
+normalizeArtifactCommit(relPath, message, docsRoot);
+```
+
+Also update `handleVerifyPhase` where `commitEvalReport(state, cwd)` is called:
+
+```typescript
+// Replace: commitEvalReport(state, cwd)
+const docsRoot = state.trackedRepos?.[0]?.path || cwd;
+commitEvalReport(state, docsRoot);
+```
+
+And the `getHead(cwd)` calls in verify phase for `evalCommit`/`verifiedAtHead`:
+
+```typescript
+// Replace getHead(cwd) with getHead(docsRoot) in the verify phase completion block
+const docsRoot = state.trackedRepos?.[0]?.path || cwd;
+const head = getHead(docsRoot);
+state.evalCommit = head;
+state.verifiedAtHead = head;
+```
+
+- [ ] **Step 3.5: Run tests**
+
+Run: `pnpm vitest run tests/phases/interactive.test.ts`
+Expected: All pass including new Phase 5 multi-repo tests.
+
+Run: `pnpm vitest run tests/phases/runner.test.ts`
+Expected: All existing tests pass (no regressions).
+
+- [ ] **Step 3.6: Typecheck**
+
+Run: `pnpm tsc --noEmit`
+Expected: Zero errors.
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add src/phases/interactive.ts src/phases/runner.ts src/artifact.ts tests/phases/interactive.test.ts
+git commit -m "feat(interactive,runner): multi-repo Phase 5 judgment + artifact path via resolveArtifact"
+```
+
+---
+
+## Task 4: Assembler — multi-repo gate diff + N=1 backward path
+
+Updates `buildPhase7DiffAndMetadata` to iterate `trackedRepos`, resolves D-1, updates artifact reading to use `resolveArtifact`. Depends on Task 1.
+
+**Files:**
+- Modify: `src/context/assembler.ts`
+- Test: `tests/context/assembler.test.ts` (add describe blocks)
+
+- [ ] **Step 4.1: Write failing tests for multi-repo diff + N=1 backward path**
+
+Append to `tests/context/assembler.test.ts`:
+
+```typescript
+describe('buildPhase7DiffAndMetadata — multi-repo concat (FR-5, ADR-N7, ADR-D1)', () => {
+  it('N=1 trackedRepos[0].path===cwd → raw diff (no ### repo: label)', () => {
+    const dir = makeTmpDir();
+    // ... (setup git repo, make state with trackedRepos[0].path = dir)
+    // Call assembleGatePrompt(7, state, '', dir) and verify no '### repo:' label in output
+    const state = makeFullEvalState({
+      trackedRepos: [{ path: dir, baseCommit: 'abc', implRetryBase: 'abc', implHead: null }],
+    });
+    writeEvalFixtures(dir);
+    const prompt = assembleGatePrompt(7, state, '', dir);
+    if (typeof prompt !== 'string') return;
+    expect(prompt).not.toContain('### repo:');
+  });
+
+  it('N=2 → concat with ### repo: label for each repo', () => {
+    const outer = makeTmpDir();
+    const repoA = path.join(outer, 'repo-a');
+    const repoB = path.join(outer, 'repo-b');
+    // init both repos
+    for (const d of [repoA, repoB]) {
+      fs.mkdirSync(d, { recursive: true });
+      execSync('git init', { cwd: d, stdio: 'pipe' });
+      execSync('git config user.email "t@t.com"', { cwd: d, stdio: 'pipe' });
+      execSync('git config user.name "T"', { cwd: d, stdio: 'pipe' });
+      fs.writeFileSync(path.join(d, 'a.txt'), 'x');
+      execSync('git add .', { cwd: d, stdio: 'pipe' });
+      execSync('git commit -m "init"', { cwd: d, stdio: 'pipe' });
+    }
+    const headA = execSync('git rev-parse HEAD', { cwd: repoA, encoding: 'utf-8' }).trim();
+    const headB = execSync('git rev-parse HEAD', { cwd: repoB, encoding: 'utf-8' }).trim();
+
+    const state = makeFullEvalState({
+      baseCommit: headA,
+      implCommit: 'impl-sha',
+      trackedRepos: [
+        { path: repoA, baseCommit: headA, implRetryBase: headA, implHead: 'impl-sha' },
+        { path: repoB, baseCommit: headB, implRetryBase: headB, implHead: null },
+      ],
+    });
+
+    fs.mkdirSync(path.join(repoA, 'docs/specs'), { recursive: true });
+    fs.mkdirSync(path.join(repoA, 'docs/plans'), { recursive: true });
+    fs.mkdirSync(path.join(repoA, 'docs/process/evals'), { recursive: true });
+    fs.writeFileSync(path.join(repoA, 'docs/specs/my-run-design.md'), '# spec');
+    fs.writeFileSync(path.join(repoA, 'docs/plans/my-run.md'), '# plan');
+    fs.writeFileSync(path.join(repoA, 'docs/process/evals/my-run-eval.md'), '# eval');
+
+    const prompt = assembleGatePrompt(7, state, '', outer);
+    if (typeof prompt !== 'string') return;
+    expect(prompt).toContain('### repo: repo-a');
+    expect(prompt).toContain('### repo: repo-b');
+  });
+
+  it('N>1 metadata block uses "Harness implementation ranges (per tracked repo):" format', () => {
+    // State with N=2, trackedRepos[0].implHead set, [1].implHead null
+    const state = makeFullEvalState({
+      trackedRepos: [
+        { path: '/outer/repo-a', baseCommit: 'base-a', implRetryBase: 'base-a', implHead: 'impl-a' },
+        { path: '/outer/repo-b', baseCommit: 'base-b', implRetryBase: 'base-b', implHead: null },
+      ],
+    });
+    // We can't call the private function directly, so we test via assembleGatePrompt
+    // This is a metadata format test, so we just verify the string shape
+    // (implementation will inject this into the prompt)
+    // For unit test isolation, we can export buildPhase7DiffAndMetadata and test it directly
+    // For now, rely on integration test coverage in T8
+  });
+});
+```
+
+Run: `pnpm vitest run tests/context/assembler.test.ts`
+Expected: New test about N=1 backward path passes structure-check; N=2 test fails.
+
+- [ ] **Step 4.2: Update `buildPhase7DiffAndMetadata` for multi-repo**
+
+In `src/context/assembler.ts`, add import at top:
+
+```typescript
+import { resolveArtifact } from '../artifact.js';
+import type { TrackedRepo } from '../types.js';
+```
+
+Replace `buildPhase7DiffAndMetadata(state, cwd)` entirely:
+
+```typescript
+function buildPhase7DiffAndMetadata(state: HarnessState, cwd: string): {
+  diffSection: string;
+  externalSummary: string;
+  metadata: string;
+} {
+  const repos = state.trackedRepos ?? [{ path: cwd, baseCommit: state.baseCommit, implRetryBase: state.implRetryBase, implHead: state.implCommit }];
+  const isSingleRepoCwd = repos.length === 1 && repos[0].path === cwd;
+
+  function buildRepoDiff(repo: TrackedRepo): string {
+    if (state.externalCommitsDetected) {
+      // Use implHead if available, otherwise fall back to HEAD
+      if (repo.implHead !== null) {
+        let d = runGit(`git diff ${repo.baseCommit}...${repo.implHead}`, repo.path);
+        // Per-repo pre-truncation (ADR-D1)
+        d = truncateDiffPerFile(d, PER_FILE_DIFF_LIMIT_KB * 1024);
+        const evalCommit = state.evalCommit;
+        if (evalCommit !== null) {
+          d += '\n' + runGit(`git diff ${evalCommit}^..${evalCommit}`, repo.path);
+        }
+        return d;
+      } else {
+        // repo has no impl anchor — diff base...HEAD (cannot separate external)
+        let d = runGit(`git diff ${repo.baseCommit}...HEAD`, repo.path);
+        d = truncateDiffPerFile(d, PER_FILE_DIFF_LIMIT_KB * 1024);
+        return d;
+      }
+    } else {
+      let d = runGit(`git diff ${repo.baseCommit}...HEAD`, repo.path);
+      d = truncateDiffPerFile(d, PER_FILE_DIFF_LIMIT_KB * 1024);
+      return d;
+    }
+  }
+
+  let combinedDiff: string;
+  if (isSingleRepoCwd) {
+    // N=1 backward path: raw diff, no ### repo: label (ADR-N7, FR-5 invariant)
+    combinedDiff = buildRepoDiff(repos[0]);
+  } else {
+    // Multi-repo: concat with ### repo: labels
+    const sections: string[] = [];
+    for (const repo of repos) {
+      const relOrAbs = path.relative(cwd, repo.path) || repo.path;
+      const rawDiff = buildRepoDiff(repo);
+      sections.push(`### repo: ${relOrAbs}\n\`\`\`diff\n${rawDiff}\n\`\`\``);
+    }
+    combinedDiff = sections.join('\n\n');
+  }
+
+  // Global size cap after concat (ADR-D1)
+  const maxDiffBytes = MAX_DIFF_SIZE_KB * 1024;
+  if (combinedDiff.length > maxDiffBytes) {
+    combinedDiff = combinedDiff.slice(0, maxDiffBytes) +
+      '\n--- (diff truncated: total exceeds ' + MAX_DIFF_SIZE_KB + 'KB) ---\n';
+  }
+
+  const diffSection = combinedDiff ? `<diff>\n${combinedDiff}\n</diff>\n` : '';
+
+  // External commits summary (per-repo for multi, single-repo for N=1)
+  let externalSummary = '';
+  if (state.externalCommitsDetected) {
+    if (isSingleRepoCwd) {
+      const anchor = state.evalCommit ?? state.implCommit ?? state.baseCommit;
+      const externalLog = runGit(`git log ${anchor}..HEAD --oneline`, cwd);
+      if (externalLog.trim().length > 0) {
+        externalSummary = `\n## External Commits (not reviewed)\n\n\`\`\`\n${externalLog}\n\`\`\`\n`;
+      }
+    } else {
+      const sections: string[] = [];
+      for (const repo of repos) {
+        const anchor = repo.implHead ?? repo.implRetryBase ?? repo.baseCommit;
+        const externalLog = runGit(`git log ${anchor}..HEAD --oneline`, repo.path);
+        if (externalLog.trim().length > 0) {
+          const relOrAbs = path.relative(cwd, repo.path) || repo.path;
+          sections.push(`### ${relOrAbs}\n\`\`\`\n${externalLog}\n\`\`\``);
+        }
+      }
+      if (sections.length > 0) {
+        externalSummary = `\n## External Commits (not reviewed)\n\n${sections.join('\n\n')}\n`;
+      }
+    }
+  }
+
+  // Metadata block: N=1 single-repo vs N>1 multi-repo (FR-5, gate-2 P1)
+  const externalNote = state.externalCommitsDetected
+    ? `Note: External commits detected. See '## External Commits (not reviewed)' section below.\nPrimary diff covers harness implementation range only.\n`
+    : '';
+
+  let implRange: string;
+  if (isSingleRepoCwd) {
+    // N=1: preserve existing format exactly (backward compat)
+    implRange = state.implCommit !== null
+      ? `Harness implementation range: ${state.baseCommit}..${state.implCommit} (Phase 1–5 commits).`
+      : `Phase 5 skipped; no implementation commit anchor.`;
+  } else {
+    // N>1: per-repo format
+    const lines = repos.map(repo => {
+      const relOrAbs = path.relative(cwd, repo.path) || repo.path;
+      return repo.implHead !== null
+        ? `  - ${relOrAbs}: ${repo.baseCommit}..${repo.implHead}`
+        : `  - ${relOrAbs}: no change (baseCommit=${repo.baseCommit})`;
+    });
+    implRange = `Harness implementation ranges (per tracked repo):\n${lines.join('\n')}`;
+  }
+
+  const metadata =
+    `<metadata>\n${externalNote}${implRange}\n` +
+    `Harness eval report commit: ${state.evalCommit ?? '(none)'} (the commit that last modified the eval report).\n` +
+    `Verified at HEAD: ${state.verifiedAtHead ?? '(none)'} (most recent Phase 6 run).\n` +
+    `Focus review on changes within the harness ranges above.\n` +
+    `</metadata>\n`;
+
+  return { diffSection, externalSummary, metadata };
+}
+```
+
+- [ ] **Step 4.3: Update artifact reading in assembler to use `resolveArtifact`**
+
+In `resolveArtifactPath` (or update each caller), change to use `trackedRepos[0]`:
+
+Replace `resolveArtifactPath(filePath: string, cwd: string)` usage. The cleanest approach: update the `cwd` passed to `readArtifactContent` calls in `buildGatePromptPhase2/4/7` to use `docsRoot`:
+
+In each of `buildGatePromptPhase2(state, cwd)`, `buildGatePromptPhase4(state, cwd)`, `buildGatePromptPhase7(state, cwd)`, add at the top:
+
+```typescript
+  const docsRoot = state.trackedRepos?.[0]?.path || cwd;
+```
+
+Then replace every `readArtifactContent(..., cwd)` in those three functions with `readArtifactContent(..., docsRoot)`.
+
+- [ ] **Step 4.4: Run tests**
+
+Run: `pnpm vitest run tests/context/assembler.test.ts`
+Expected: All pass including new multi-repo describe.
+
+Run: `pnpm vitest run tests/context/assembler-resume.test.ts`
+Expected: All existing tests still pass (N=1 backward path verified).
+
+- [ ] **Step 4.5: Typecheck**
+
+Run: `pnpm tsc --noEmit`
+Expected: Zero errors.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add src/context/assembler.ts tests/context/assembler.test.ts
+git commit -m "feat(assembler): multi-repo gate diff concat, N=1 backward path, D-1 resolution"
+```
+
+---
+
+## Task 5: Codex Runner — `--skip-git-repo-check` + stderr tail
+
+Independent of Tasks 2–4. Depends only on Task 1 (types).
+
+**Files:**
+- Modify: `src/runners/codex.ts`
+- Test: `tests/runners/codex.test.ts` (add describe blocks)
+
+- [ ] **Step 5.1: Write failing tests**
+
+Append to `tests/runners/codex.test.ts`:
+
+```typescript
+describe('runCodexExecRaw — --skip-git-repo-check (FR-4, ADR-N5)', () => {
+  it('does NOT add --skip-git-repo-check when cwd is a git repo', async () => {
+    // Mock spawn to capture argv
+    // Expect args does NOT contain '--skip-git-repo-check'
+    // (mock isInGitRepo to return true)
+  });
+
+  it('adds --skip-git-repo-check when cwd is not a git repo', async () => {
+    // Mock isInGitRepo to return false
+    // Expect args contains '--skip-git-repo-check'
+  });
+});
+
+describe('rawToResult — stderr tail in error message (FR-4)', () => {
+  it('includes last 20 lines of stderr in nonzero_exit_other error message', () => {
+    const lines = Array.from({ length: 30 }, (_, i) => `line-${i}`);
+    const stderr = lines.join('\n');
+    // Construct a raw result with category 'nonzero_exit_other'
+    // Verify error message contains the last 20 lines
+    const last20 = lines.slice(-20).join('\n');
+    // The error message format: "Gate subprocess exited with code 1\n--- stderr (tail) ---\n<...>\n---"
+    // Call rawToResult with mock data and verify output
+  });
+});
+```
+
+Run: `pnpm vitest run tests/runners/codex.test.ts`
+Expected: New tests fail; existing pass.
+
+- [ ] **Step 5.2: Add `--skip-git-repo-check` to gate spawn**
+
+In `src/runners/codex.ts`, add import:
+
+```typescript
+import { isInGitRepo } from '../git.js';
+```
+
+In `runCodexExecRaw`, find the `args` construction and add the flag:
+
+```typescript
+  const skipGitFlag = !isInGitRepo(input.cwd) ? ['--skip-git-repo-check'] : [];
+
+  const args = input.mode === 'resume'
+    ? ['exec', 'resume', input.sessionId!,
+       ...skipGitFlag,
+       '--model', input.preset.model,
+       '-c', `model_reasoning_effort="${input.preset.effort}"`,
+       '-']
+    : ['exec',
+       ...skipGitFlag,
+       '--model', input.preset.model,
+       '-c', `model_reasoning_effort="${input.preset.effort}"`,
+       '-'];
+```
+
+- [ ] **Step 5.3: Add stderr tail to error messages**
+
+Add a helper function (above `rawToResult`):
+
+```typescript
+function stderrTail(stderr: string, maxLines: number = 20): string {
+  const clean = stderr.replace(/\x1B\[[0-9;]*m/g, ''); // strip ANSI escapes
+  const lines = clean.split('\n').filter(l => l.trim().length > 0);
+  return lines.slice(-maxLines).join('\n');
+}
+```
+
+In `rawToResult`, update the `nonzero_exit_other` case:
+
+```typescript
+  const errorMessage =
+    raw.category === 'timeout' ? `Codex gate timed out after ${GATE_TIMEOUT_MS}ms` :
+    raw.category === 'spawn_error' ? `Codex gate error: ${raw.spawnError ?? 'unknown spawn failure'}` :
+    raw.category === 'success_no_verdict' ? 'Gate output missing ## Verdict header' :
+    raw.category === 'session_missing' ? `Codex resume failed: session not found (stderr: ${raw.stderr.trim().slice(0, 200)})` :
+    (() => {
+      const tail = stderrTail(raw.stderr);
+      return tail.length > 0
+        ? `Gate subprocess exited with code ${raw.exitCode ?? 'null'}\n--- stderr (tail) ---\n${tail}\n---`
+        : `Gate subprocess exited with code ${raw.exitCode ?? 'null'}`;
+    })();
+```
+
+- [ ] **Step 5.4: Run tests**
+
+Run: `pnpm vitest run tests/runners/codex.test.ts`
+Expected: All tests pass including new ones.
+
+- [ ] **Step 5.5: Typecheck**
+
+Run: `pnpm tsc --noEmit`
+Expected: Zero errors.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add src/runners/codex.ts tests/runners/codex.test.ts
+git commit -m "feat(codex): auto-add --skip-git-repo-check for non-git cwd, stderr tail in error messages"
+```
+
+---
+
+## Task 6: `resume.ts` — multi-repo ancestry + external commits + Phase 5 fresh-sentinel
+
+Depends on Tasks 1 and 3 (for `syncLegacyMirror` in `completeInteractivePhaseFromFreshSentinel`).
+
+**Files:**
+- Modify: `src/resume.ts`
+- Test: `tests/resume.test.ts` (add describe block)
+
+- [ ] **Step 6.1: Write failing tests**
+
+Append to `tests/resume.test.ts`:
+
+```typescript
+describe('validateAncestry — multi-repo null-safe (FR-8)', () => {
+  it('skips ancestry check for repos with implHead=null', () => {
+    // State: phase 5 completed, trackedRepos[0].implHead = 'sha', trackedRepos[1].implHead = null
+    // With git repos set up: trackedRepos[0] is ancestor, trackedRepos[1] has no anchor
+    // Expect: no error thrown (trackedRepos[1] skipped)
+  });
+
+  it('errors when trackedRepos[0].implHead is not an ancestor of HEAD', () => {
+    // Diverged repo: implHead not in history
+    // Expect: process.exit(1) called with repo path in message
+  });
+});
+
+describe('updateExternalCommitsDetected — multi-repo (FR-8)', () => {
+  it('uses implHead ?? implRetryBase ?? baseCommit as anchor per repo', () => {
+    // Two repos: one with implHead set, one without
+    // Only repo with external commits sets externalCommitsDetected = true
+  });
+});
+
+describe('completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo', () => {
+  it('returns true and sets implHead when any repo advanced', () => {
+    // Same logic as interactive.test.ts Phase 5 multi-repo test
+  });
+});
+```
+
+Run: `pnpm vitest run tests/resume.test.ts`
+Expected: New tests fail.
+
+- [ ] **Step 6.2: Update `validateAncestry` in `resume.ts`**
+
+In `src/resume.ts`, add import:
+
+```typescript
+import { syncLegacyMirror } from './state.js';
+```
+
+Replace the `if (state.phases['5'] === 'completed')` block in `validateAncestry`:
+
+```typescript
+    if (state.phases['5'] === 'completed') {
+      // Per-repo ancestry check: only for repos where implHead is set (non-null)
+      const allNull = state.trackedRepos.every(r => r.implHead === null);
+      if (allNull) {
+        // Internal invariant violation: phase 5 complete but no repo advanced
+        // state_anomaly is emitted by caller — just exit here
+        process.stderr.write(
+          `Phase 5 completed but all trackedRepos[*].implHead are null — state anomaly.\n` +
+          `Manual recovery required.\n`
+        );
+        process.exit(1);
+      }
+      for (const repo of state.trackedRepos) {
+        if (repo.implHead === null) continue; // no anchor → skip
+        if (!isAncestor(repo.implHead, 'HEAD', repo.path)) {
+          process.stderr.write(
+            `Implementation commit is no longer in git history (repo: ${repo.path}).\n` +
+            `Manual recovery required.\n`
+          );
+          process.exit(1);
+        }
+      }
+    }
+```
+
+- [ ] **Step 6.3: Update `updateExternalCommitsDetected` in `resume.ts`**
+
+Replace `updateExternalCommitsDetected`:
+
+```typescript
+function updateExternalCommitsDetected(state: HarnessState, cwd: string, runDir: string): void {
+  try {
+    for (const repo of state.trackedRepos) {
+      const anchor = repo.implHead ?? repo.implRetryBase ?? repo.baseCommit;
+      const knownAnchors = [state.specCommit, state.planCommit, repo.implHead, state.evalCommit];
+      const implRange = repo.implHead
+        ? { from: repo.baseCommit, to: repo.implHead }
+        : null;
+      const external = detectExternalCommits(anchor, knownAnchors, implRange, repo.path);
+      if (external.length > 0) {
+        process.stderr.write(`⚠️  External commits detected in ${repo.path} (${external.length} commits).\n`);
+        state.externalCommitsDetected = true;
+        writeState(runDir, state);
+      }
+    }
+  } catch {
+    // Non-fatal
+  }
+}
+```
+
+- [ ] **Step 6.4: Update `completeInteractivePhaseFromFreshSentinel` Phase 5 in `resume.ts`**
+
+Replace the `if (phase === 5)` block in `completeInteractivePhaseFromFreshSentinel`:
+
+```typescript
+    if (phase === 5) {
+      void runDir;
+      let anyAdvanced = false;
+      for (const r of state.trackedRepos) {
+        const h = getHead(r.path);
+        if (h !== r.implRetryBase) {
+          r.implHead = h;
+          anyAdvanced = true;
+        } else {
+          r.implHead = null;
+        }
+      }
+      if (!anyAdvanced) return false;
+      syncLegacyMirror(state);
+      return true;
+    }
+```
+
+Also update `validateCompletedArtifacts` artifact paths to use `resolveArtifact`:
+
+```typescript
+import { resolveArtifact, normalizeArtifactCommit } from './artifact.js';
+
+// In validateCompletedArtifacts:
+// Replace: join(cwd, state.artifacts.spec)  → resolveArtifact(state, state.artifacts.spec, cwd)
+// Replace: join(cwd, state.artifacts.plan)  → resolveArtifact(state, state.artifacts.plan, cwd)
+// Replace: join(cwd, state.artifacts.evalReport) → resolveArtifact(state, state.artifacts.evalReport, cwd)
+```
+
+In `completeInteractivePhaseFromFreshSentinel` for Phase 1/3:
+
+```typescript
+// Replace: join(cwd, relPath) → resolveArtifact(state, relPath, cwd)
+// Replace: normalizeArtifactCommit(relPath, message, cwd) → normalizeArtifactCommit(relPath, message, resolveArtifactRoot(state, cwd))
+```
+
+Add helper:
+
+```typescript
+function resolveArtifactRoot(state: HarnessState, outerCwd: string): string {
+  return state.trackedRepos?.[0]?.path || outerCwd;
+}
+```
+
+- [ ] **Step 6.5: Run tests**
+
+Run: `pnpm vitest run tests/resume.test.ts`
+Expected: All tests pass including new multi-repo describes.
+
+Run: `pnpm vitest run tests/resume-light.test.ts`
+Expected: All pass (no regressions).
+
+- [ ] **Step 6.6: Typecheck**
+
+Run: `pnpm tsc --noEmit`
+Expected: Zero errors.
+
+- [ ] **Step 6.7: Commit**
+
+```bash
+git add src/resume.ts tests/resume.test.ts
+git commit -m "feat(resume): multi-repo ancestry check, external commits detection, Phase 5 fresh-sentinel"
+```
+
+---
+
+## Task 7: HOW-IT-WORKS docs update
+
+Independent of all code tasks. Can be done in parallel with T2–T6.
+
+**Files:**
+- Modify: `docs/HOW-IT-WORKS.md`
+- Modify: `docs/HOW-IT-WORKS.ko.md`
+
+- [ ] **Step 7.1: Add multi-worktree section to HOW-IT-WORKS.md**
+
+In `docs/HOW-IT-WORKS.md`, find the "Architecture" section. Add a new subsection after the existing architecture overview:
+
+```markdown
+### Multi-Worktree (outer cwd) Layout
+
+When `phase-harness start` is invoked from a directory that is **not** itself a git repo (an "outer cwd"), harness automatically detects git repos at depth=1 beneath that directory. These become the **tracked repos** for the run.
+
+```
+outer-dir/           ← harness cwd (not a git repo)
+  repo-a/            ← auto-detected tracked repo
+  repo-b/            ← auto-detected tracked repo
+  .harness/<runId>/  ← state + artifacts (gitignored)
+```
+
+**Key behaviors:**
+- `state.trackedRepos[]` holds each repo's path, baseCommit, implRetryBase, and implHead.
+- `trackedRepos[0]` is the **docs home**: spec/plan/eval artifacts are committed into this repo.
+- Phase 5 success = "any tracked repo advanced past its `implRetryBase`".
+- Gate diff = per-repo sections concatenated with `### repo: <path>` labels (N>1 only).
+- Codex gate spawns from outer cwd with `--skip-git-repo-check` added automatically.
+- Single-repo flow (`cwd` is a git repo) produces identical output — `trackedRepos = [cwd]` is the degenerate case.
+
+**CLI flags:**
+- `--track <path>` (repeatable): explicit repo list, overrides auto-detect. First path = docs home.
+- `--exclude <path>` (repeatable): remove a path from auto-detect results.
+
+All `--track` paths must be under outer cwd (cwd-descendant rule).
+```
+
+- [ ] **Step 7.2: Add multi-worktree section to HOW-IT-WORKS.ko.md**
+
+Add a Korean-language equivalent section at the same location in `docs/HOW-IT-WORKS.ko.md`:
+
+```markdown
+### 멀티 워크트리 (outer cwd) 레이아웃
+
+`phase-harness start`를 git 저장소가 **아닌** 디렉토리(outer cwd)에서 실행하면, harness는 해당 디렉토리의 depth=1 하위 git 저장소들을 자동 탐지합니다. 이 저장소들이 런의 **tracked repos**가 됩니다.
+
+```
+outer-dir/           ← harness cwd (git 저장소 아님)
+  repo-a/            ← 자동 탐지된 tracked repo
+  repo-b/            ← 자동 탐지된 tracked repo
+  .harness/<runId>/  ← state + artifacts (.gitignore)
+```
+
+**주요 동작:**
+- `state.trackedRepos[]`에 각 저장소의 path, baseCommit, implRetryBase, implHead가 저장됩니다.
+- `trackedRepos[0]`이 **docs home**: spec/plan/eval 아티팩트가 이 저장소에 커밋됩니다.
+- Phase 5 성공 = "어떤 tracked repo든 자신의 `implRetryBase`에서 진전했는가".
+- Gate diff = repo별 섹션을 `### repo: <path>` 레이블로 concat (N>1인 경우만).
+- Codex gate는 항상 outer cwd에서 실행, 필요시 `--skip-git-repo-check` 자동 추가.
+- 단일 저장소 플로우(`cwd`가 git 저장소)는 동일한 결과를 생성합니다 — `trackedRepos = [cwd]`가 기본 케이스입니다.
+
+**CLI 플래그:**
+- `--track <path>` (반복 가능): 명시적 저장소 목록, 자동 탐지를 대체. 첫 번째 경로 = docs home.
+- `--exclude <path>` (반복 가능): 자동 탐지 결과에서 특정 경로 제거.
+
+모든 `--track` 경로는 outer cwd 하위여야 합니다 (cwd-descendant 규칙).
+```
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add docs/HOW-IT-WORKS.md docs/HOW-IT-WORKS.ko.md
+git commit -m "docs: add multi-worktree layout section to HOW-IT-WORKS"
+```
+
+---
+
+## Task 8: Multi-worktree integration tests
+
+Comprehensive test coverage for all NFR test scenarios. Depends on T1–T6.
+
+**Files:**
+- Create: `tests/multi-worktree.test.ts`
+
+- [ ] **Step 8.1: Write integration tests**
+
+Create `tests/multi-worktree.test.ts`:
+
+```typescript
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execSync } from 'child_process';
+import { migrateState, createInitialState, syncLegacyMirror } from '../src/state.js';
+import { detectTrackedRepos } from '../src/commands/start.js';
+import { validatePhaseArtifacts } from '../src/phases/interactive.js';
+import { resolveArtifact } from '../src/artifact.js';
+import type { HarnessState } from '../src/types.js';
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true });
+  tmpDirs.length = 0;
+});
+
+function makeTmp(prefix = 'mwt-'): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(d);
+  return d;
+}
+
+function initRepo(dir: string): string {
+  fs.mkdirSync(dir, { recursive: true });
+  execSync('git init', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.email "t@t.com"', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.name "T"', { cwd: dir, stdio: 'pipe' });
+  fs.writeFileSync(path.join(dir, 'init.txt'), 'x');
+  execSync('git add .', { cwd: dir, stdio: 'pipe' });
+  execSync('git commit -m "init"', { cwd: dir, stdio: 'pipe' });
+  return execSync('git rev-parse HEAD', { cwd: dir, encoding: 'utf-8' }).trim();
+}
+
+// (a) depth=1 scan: cwd not a git repo, depth=1 has 2 git repos
+describe('(a) depth=1 auto-detect — non-git outer cwd', () => {
+  it('detects exactly depth=1 git repos, skips non-git dirs', () => {
+    const outer = makeTmp();
+    const repoA = path.join(outer, 'repo-a');
+    const repoB = path.join(outer, 'repo-b');
+    const notGit = path.join(outer, 'not-git');
+    fs.mkdirSync(notGit);
+    initRepo(repoA);
+    initRepo(repoB);
+    const repos = detectTrackedRepos(outer);
+    const paths = repos.map(r => r.path).sort();
+    expect(paths).toEqual([repoA, repoB].sort());
+  });
+});
+
+// (b) --track / --exclude
+describe('(b) --track / --exclude flag combinations', () => {
+  it('--track replaces auto-detect', () => {
+    const outer = makeTmp();
+    const repoA = path.join(outer, 'a');
+    const repoB = path.join(outer, 'b');
+    initRepo(repoA); initRepo(repoB);
+    const result = detectTrackedRepos(outer, [repoA]);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe(repoA);
+  });
+
+  it('--exclude removes from auto-detect', () => {
+    const outer = makeTmp();
+    const repoA = path.join(outer, 'a');
+    const repoB = path.join(outer, 'b');
+    initRepo(repoA); initRepo(repoB);
+    const result = detectTrackedRepos(outer, undefined, [repoB]);
+    expect(result.map(r => r.path)).not.toContain(repoB);
+    expect(result.map(r => r.path)).toContain(repoA);
+  });
+});
+
+// (c) N=2 tracked repos assembler diff concat
+describe('(c) assembler diff concat for N=2 repos', () => {
+  it('includes ### repo: label for each repo in N=2 case', async () => {
+    const { assembleGatePrompt } = await import('../src/context/assembler.js');
+    const outer = makeTmp();
+    const repoA = path.join(outer, 'repo-a');
+    const repoB = path.join(outer, 'repo-b');
+    const baseA = initRepo(repoA);
+    const baseB = initRepo(repoB);
+
+    // Create docs in repoA (trackedRepos[0])
+    fs.mkdirSync(path.join(repoA, 'docs/specs'), { recursive: true });
+    fs.mkdirSync(path.join(repoA, 'docs/plans'), { recursive: true });
+    fs.mkdirSync(path.join(repoA, 'docs/process/evals'), { recursive: true });
+    fs.writeFileSync(path.join(repoA, 'docs/specs/run-design.md'), '# spec\n## Complexity\nMedium');
+    fs.writeFileSync(path.join(repoA, 'docs/plans/run.md'), '# plan');
+    fs.writeFileSync(path.join(repoA, 'docs/process/evals/run-eval.md'), '# eval');
+
+    const state = createInitialState('run', 'task', baseA, false);
+    state.trackedRepos = [
+      { path: repoA, baseCommit: baseA, implRetryBase: baseA, implHead: null },
+      { path: repoB, baseCommit: baseB, implRetryBase: baseB, implHead: null },
+    ];
+    state.artifacts = {
+      spec: 'docs/specs/run-design.md',
+      plan: 'docs/plans/run.md',
+      decisionLog: '.harness/run/decisions.md',
+      checklist: '.harness/run/checklist.json',
+      evalReport: 'docs/process/evals/run-eval.md',
+    };
+    state.phases['5'] = 'completed';
+    state.phases['6'] = 'completed';
+    state.implCommit = baseA;
+    state.evalCommit = baseA;
+
+    const prompt = assembleGatePrompt(7, state, '', outer);
+    expect(typeof prompt).toBe('string');
+    if (typeof prompt === 'string') {
+      expect(prompt).toContain('### repo: repo-a');
+      expect(prompt).toContain('### repo: repo-b');
+    }
+  });
+
+  it('N=1 trackedRepos[0].path===cwd → no ### repo: label (backward compat)', async () => {
+    const { assembleGatePrompt } = await import('../src/context/assembler.js');
+    const cwd = makeTmp();
+    const base = initRepo(cwd);
+    fs.mkdirSync(path.join(cwd, 'docs/specs'), { recursive: true });
+    fs.mkdirSync(path.join(cwd, 'docs/plans'), { recursive: true });
+    fs.mkdirSync(path.join(cwd, 'docs/process/evals'), { recursive: true });
+    fs.writeFileSync(path.join(cwd, 'docs/specs/run-design.md'), '# spec\n## Complexity\nMedium');
+    fs.writeFileSync(path.join(cwd, 'docs/plans/run.md'), '# plan');
+    fs.writeFileSync(path.join(cwd, 'docs/process/evals/run-eval.md'), '# eval');
+
+    const state = createInitialState('run', 'task', base, false);
+    state.trackedRepos = [{ path: cwd, baseCommit: base, implRetryBase: base, implHead: null }];
+    state.phases['5'] = 'completed';
+    state.phases['6'] = 'completed';
+    state.implCommit = base;
+    state.evalCommit = base;
+
+    const prompt = assembleGatePrompt(7, state, '', cwd);
+    if (typeof prompt === 'string') {
+      expect(prompt).not.toContain('### repo:');
+    }
+  });
+});
+
+// (d) Phase 5 judgment: "any repo advanced" = success
+describe('(d) Phase 5 success: one-of-N advanced', () => {
+  it('returns true when only repo-a advanced in a 2-repo setup', () => {
+    const outer = makeTmp();
+    const repoA = path.join(outer, 'a');
+    const repoB = path.join(outer, 'b');
+    const headA = initRepo(repoA);
+    const headB = initRepo(repoB);
+
+    // Advance repoA
+    fs.writeFileSync(path.join(repoA, 'new.txt'), 'impl');
+    execSync('git add .', { cwd: repoA, stdio: 'pipe' });
+    execSync('git commit -m "impl"', { cwd: repoA, stdio: 'pipe' });
+    const newHeadA = execSync('git rev-parse HEAD', { cwd: repoA, encoding: 'utf-8' }).trim();
+
+    const state = createInitialState('r', 't', headA, false);
+    state.trackedRepos = [
+      { path: repoA, baseCommit: headA, implRetryBase: headA, implHead: null },
+      { path: repoB, baseCommit: headB, implRetryBase: headB, implHead: null },
+    ];
+    const runDir = makeTmp('rundir-');
+    const result = validatePhaseArtifacts(5, state, outer, runDir);
+
+    expect(result).toBe(true);
+    expect(state.trackedRepos[0].implHead).toBe(newHeadA);
+    expect(state.trackedRepos[1].implHead).toBeNull();
+    expect(state.implCommit).toBe(newHeadA);
+  });
+});
+
+// (e) state migration: legacy state.json → trackedRepos synthesis
+describe('(e) state migration: legacy → trackedRepos', () => {
+  it('synthesizes trackedRepos[0] from top-level fields with provided cwd', () => {
+    const legacy = {
+      runId: 'run-1',
+      baseCommit: 'deadbeef',
+      implRetryBase: 'deadbeef',
+      implCommit: null,
+      flow: 'full',
+    };
+    const migrated = migrateState(legacy, '/outer/my-repo');
+    expect(migrated.trackedRepos).toHaveLength(1);
+    expect(migrated.trackedRepos[0].path).toBe('/outer/my-repo');
+    expect(migrated.trackedRepos[0].baseCommit).toBe('deadbeef');
+    expect(migrated.trackedRepos[0].implHead).toBeNull();
+  });
+
+  it('syncLegacyMirror keeps top-level fields in sync with trackedRepos[0]', () => {
+    const state = createInitialState('r', 't', 'old', false);
+    state.trackedRepos = [
+      { path: '/repo', baseCommit: 'new', implRetryBase: 'new', implHead: 'impl' },
+    ];
+    syncLegacyMirror(state);
+    expect(state.baseCommit).toBe('new');
+    expect(state.implRetryBase).toBe('new');
+    expect(state.implCommit).toBe('impl');
+  });
+});
+
+// resolveArtifact: uses trackedRepos[0].path
+describe('resolveArtifact (FR-7)', () => {
+  it('resolves relative path against trackedRepos[0].path', () => {
+    const state = createInitialState('r', 't', 'abc', false);
+    state.trackedRepos = [{ path: '/repo-a', baseCommit: 'abc', implRetryBase: 'abc', implHead: null }];
+    const result = resolveArtifact(state, 'docs/specs/foo.md', '/outer');
+    expect(result).toBe('/repo-a/docs/specs/foo.md');
+  });
+
+  it('falls back to outerCwd when trackedRepos[0].path is empty string (legacy)', () => {
+    const state = createInitialState('r', 't', 'abc', false);
+    state.trackedRepos = [{ path: '', baseCommit: 'abc', implRetryBase: 'abc', implHead: null }];
+    const result = resolveArtifact(state, 'docs/specs/foo.md', '/outer');
+    expect(result).toBe('/outer/docs/specs/foo.md');
+  });
+});
+```
+
+- [ ] **Step 8.2: Run all new integration tests**
+
+Run: `pnpm vitest run tests/multi-worktree.test.ts`
+Expected: All pass.
+
+- [ ] **Step 8.3: Run full test suite (regression check)**
+
+Run: `pnpm vitest run`
+Expected: All existing tests pass. Zero regressions.
+
+- [ ] **Step 8.4: Build**
+
+Run: `pnpm build`
+Expected: Build succeeds. `dist/` populated.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add tests/multi-worktree.test.ts
+git commit -m "test(multi-worktree): integration tests for all NFR scenarios"
+```
+
+---
+
+## Eval Checklist
+
+See `.harness/2026-04-20-task-outer-cwd-n-sub-a808/checklist.json` for the machine-readable version.
+
+| # | Name | Command |
+|---|------|---------|
+| 1 | typecheck | `pnpm tsc --noEmit` |
+| 2 | tests | `pnpm vitest run` |
+| 3 | build | `pnpm build` |
+| 4 | multi-worktree tests | `pnpm vitest run tests/multi-worktree.test.ts` |

--- a/docs/plans/2026-04-20-task-outer-cwd-n-sub-a808.md
+++ b/docs/plans/2026-04-20-task-outer-cwd-n-sub-a808.md
@@ -1359,7 +1359,10 @@ function updateExternalCommitsDetected(state: HarnessState, cwd: string, runDir:
   try {
     for (const repo of state.trackedRepos) {
       const anchor = repo.implHead ?? repo.implRetryBase ?? repo.baseCommit;
-      const knownAnchors = [state.specCommit, state.planCommit, repo.implHead, state.evalCommit];
+      const isDocsHome = repo === state.trackedRepos[0];
+      const knownAnchors = isDocsHome
+        ? [state.specCommit, state.planCommit, repo.implHead, state.evalCommit]
+        : [repo.implHead];
       const implRange = repo.implHead
         ? { from: repo.baseCommit, to: repo.implHead }
         : null;
@@ -1790,3 +1793,7 @@ See `.harness/2026-04-20-task-outer-cwd-n-sub-a808/checklist.json` for the machi
 | 2 | tests | `pnpm vitest run` |
 | 3 | build | `pnpm build` |
 | 4 | multi-worktree tests | `pnpm vitest run tests/multi-worktree.test.ts` |
+
+## Deferred
+
+- **gate-4 retry-1 P2 (Task 4/8 Phase 7 N>1 metadata assertions)**: Explicit test assertions for `"Harness implementation ranges (per tracked repo):"` block and per-repo `<base>..<implHead>` / `no change (baseCommit=...)` shapes not yet added to Task 4 (Step 4.1) or Task 8 (Step 8.1). Needs integration test fixture expansion; deferred to implementation phase.

--- a/docs/process/evals/2026-04-20-task-outer-cwd-n-sub-a808-eval.md
+++ b/docs/process/evals/2026-04-20-task-outer-cwd-n-sub-a808-eval.md
@@ -51,103 +51,103 @@
 
  RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/code1
 
- ✓ tests/state.test.ts (50 tests) 62ms
- ✓ tests/logger.test.ts (32 tests) 143ms
- ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 87ms
- ✓ tests/context/skills-rendering.test.ts (45 tests) 157ms
- ✓ tests/phases/gate.test.ts (27 tests) 166ms
+ ✓ tests/state.test.ts (50 tests) 56ms
+ ✓ tests/context/skills-rendering.test.ts (45 tests) 94ms
+ ✓ tests/logger.test.ts (32 tests) 107ms
+ ✓ tests/phases/gate.test.ts (27 tests) 103ms
+ ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 47ms
+ ✓ tests/commands/inner.test.ts (22 tests) 251ms
  ✓ tests/runners/claude-usage.test.ts (17 tests) 162ms
- ✓ tests/commands/inner.test.ts (22 tests) 344ms
- ✓ tests/integration/logging.test.ts (15 tests) 353ms
- ✓ tests/commands/footer-ticker.test.ts (10 tests) 178ms
-[2J[H ✓ tests/phases/gate-resume.test.ts (13 tests) 219ms
- ✓ tests/signal.test.ts (16 tests) 552ms
-[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/lock.test.ts (20 tests) 310ms
- ✓ tests/phases/terminal-ui.test.ts (17 tests) 120ms
- ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 7ms
- ✓ tests/phases/runner.test.ts (76 tests) 684ms
+ ✓ tests/integration/logging.test.ts (15 tests) 344ms
+ ✓ tests/commands/footer-ticker.test.ts (10 tests) 174ms
+[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/phases/gate-resume.test.ts (13 tests) 225ms
+[2J[H ✓ tests/signal.test.ts (16 tests) 536ms
+[2J[H[2J[H ✓ tests/phases/terminal-ui.test.ts (17 tests) 125ms
+ ✓ tests/lock.test.ts (20 tests) 308ms
+ ✓ tests/phases/runner.test.ts (76 tests) 599ms
+ ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 23ms
  ✓ tests/runners/codex.test.ts (17 tests) 81ms
- ✓ tests/orphan-cleanup.test.ts (20 tests) 24ms
- ✓ tests/preflight.test.ts (27 tests | 1 skipped) 277ms
- ✓ tests/integration/codex-session-resume.test.ts (6 tests) 104ms
- ✓ tests/integration/light-flow.test.ts (4 tests) 255ms
- ✓ tests/resume-light.test.ts (10 tests) 20ms
- ✓ tests/phases/runner-token-capture.test.ts (6 tests) 9ms
- ✓ tests/commands/inner-footer.test.ts (2 tests) 25ms
- ✓ tests/runners/codex-resume.test.ts (8 tests) 62ms
- ✓ tests/phases/verify.test.ts (12 tests) 15ms
- ✓ tests/tmux.test.ts (33 tests) 815ms
+ ✓ tests/orphan-cleanup.test.ts (20 tests) 61ms
+ ✓ tests/preflight.test.ts (27 tests | 1 skipped) 175ms
+ ✓ tests/integration/light-flow.test.ts (4 tests) 202ms
+ ✓ tests/integration/codex-session-resume.test.ts (6 tests) 76ms
+ ✓ tests/resume-light.test.ts (10 tests) 16ms
+ ✓ tests/phases/runner-token-capture.test.ts (6 tests) 11ms
+ ✓ tests/commands/inner-footer.test.ts (2 tests) 12ms
+ ✓ tests/tmux.test.ts (33 tests) 811ms
    ✓ pollForPidFile > returns null on timeout when file never appears 403ms
    ✓ pollForPidFile > returns null when file contains non-numeric content 403ms
- ✓ tests/context/assembler.test.ts (67 tests) 1835ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 446ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 604ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 501ms
- ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 9ms
- ✓ tests/context/assembler-resume.test.ts (9 tests) 94ms
- ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 56ms
- ✓ tests/runners/codex-isolation.test.ts (8 tests) 36ms
-[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui.test.ts (8 tests) 4ms
- ✓ tests/state-invalidation.test.ts (5 tests) 8ms
- ✓ tests/commands/resume-cmd.test.ts (12 tests) 2001ms
- ✓ tests/runners/claude.test.ts (4 tests) 8ms
+ ✓ tests/context/assembler.test.ts (67 tests) 1798ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 471ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 570ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 585ms
+ ✓ tests/runners/codex-resume.test.ts (8 tests) 87ms
+ ✓ tests/phases/verify.test.ts (12 tests) 12ms
+ ✓ tests/context/assembler-resume.test.ts (9 tests) 84ms
+ ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 7ms
+ ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 103ms
+ ✓ tests/runners/codex-isolation.test.ts (8 tests) 46ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui.test.ts (8 tests) 5ms
+ ✓ tests/state-invalidation.test.ts (5 tests) 11ms
+ ✓ tests/runners/claude.test.ts (4 tests) 5ms
+ ✓ tests/commands/resume-cmd.test.ts (12 tests) 2086ms
  ✓ tests/phases/verdict.test.ts (16 tests) 3ms
- ✓ tests/root.test.ts (10 tests) 157ms
- ✓ tests/resume.test.ts (11 tests) 2667ms
-   ✓ resumeRun > exits with code 1 and non-interactive message on paused run with null pendingAction (D4b) 306ms
-   ✓ resumeRun > skip_phase Phase 6 with gitignored eval report: skips commit and leaves evalCommit null 347ms
- ✓ tests/context/reviewer-contract.test.ts (4 tests) 69ms
- ✓ tests/commands/status-list.test.ts (7 tests) 635ms
- ✓ tests/phases/gate-resume-escalation.test.ts (1 test) 51ms
- ✓ tests/ui-footer.test.ts (9 tests) 4ms
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-2JIWts/.claude/skills:
+ ✓ tests/root.test.ts (10 tests) 156ms
+ ✓ tests/resume.test.ts (11 tests) 2795ms
+   ✓ resumeRun > exits with code 1 and non-interactive message on paused run with null pendingAction (D4b) 378ms
+   ✓ resumeRun > skip_phase Phase 6 with gitignored eval report: skips commit and leaves evalCommit null 335ms
+   ✓ completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8) > returns true and sets implHead when any repo advanced 322ms
+ ✓ tests/context/reviewer-contract.test.ts (4 tests) 66ms
+ ✓ tests/commands/status-list.test.ts (7 tests) 630ms
+ ✓ tests/phases/gate-resume-escalation.test.ts (1 test) 35ms
+ ✓ tests/ui-footer.test.ts (9 tests) 3ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-8DgmUV/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-2JIWts/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-aqNvh6/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-udHKFt/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-RZzK3k/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-DHnQkK/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-ZwzxG2/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-DHnQkK/.claude/skills:
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-RZzK3k/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-mOFi6z/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-UkHP5q/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-B01P0T/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-VybS4v/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-B01P0T/.claude/skills:
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-VybS4v/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-G8vGIc/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-70l9iT/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-GjLWgA/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-94wzec/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-BoZSUq/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-94wzec/.claude/skills:
   phase-harness-codex-gate-review
-No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-CUwuQn/.claude/skills. Nothing to uninstall.
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-BoZSUq/.claude/skills:
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-70l9iT/.claude/skills:
   phase-harness-codex-gate-review
- ✓ tests/uninstall-skills.test.ts (6 tests) 41ms
+No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-d1k6nb/.claude/skills. Nothing to uninstall.
  ✓ tests/install-skills.test.ts (7 tests) 32ms
- ✓ tests/commands/jump.test.ts (6 tests) 756ms
+ ✓ tests/uninstall-skills.test.ts (6 tests) 26ms
+ ✓ tests/git.test.ts (20 tests) 1981ms
+ ✓ tests/input.test.ts (12 tests) 3ms
  ✓ tests/task-prompt.test.ts (7 tests) 2ms
- ✓ tests/input.test.ts (12 tests) 7ms
- ✓ tests/integration/lifecycle.test.ts (11 tests) 1376ms
- ✓ tests/git.test.ts (20 tests) 1904ms
- ✓ tests/multi-worktree.test.ts (10 tests) 2731ms
-   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 527ms
-   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 557ms
-   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 415ms
-   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 429ms
-   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 551ms
- ✓ tests/terminal.test.ts (5 tests) 3ms
-[2J[H[2J[H ✓ tests/phases/interactive.test.ts (47 tests) 4134ms
-   ✓ runInteractivePhase — Claude dispatch command shape > sendKeysToPane command includes --dangerously-skip-permissions and --effort 1587ms
-   ✓ validatePhaseArtifacts — Phase 5 multi-repo (FR-6, ADR-D4) > returns true when any repo advanced; sets implHead on advanced repos only 523ms
-[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui-prompt-model-config.test.ts (3 tests) 32ms
- ✓ tests/preflight-claude-at-file.test.ts (2 tests) 3ms
+ ✓ tests/multi-worktree.test.ts (11 tests) 2861ms
+   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 635ms
+   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 516ms
+   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 476ms
+   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 426ms
+   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 539ms
+ ✓ tests/integration/lifecycle.test.ts (11 tests) 1431ms
+ ✓ tests/commands/jump.test.ts (6 tests) 810ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui-prompt-model-config.test.ts (3 tests) 3ms
+ ✓ tests/terminal.test.ts (5 tests) 5ms
  ✓ tests/conformance/phase-models.test.ts (9 tests) 3ms
- ✓ tests/process.test.ts (6 tests) 132ms
- ✓ tests/artifact.test.ts (14 tests) 3528ms
-   ✓ normalizeArtifactCommit > creates commit for new untracked file 344ms
+ ✓ tests/phases/interactive.test.ts (47 tests) 4174ms
+   ✓ runInteractivePhase — Claude dispatch command shape > sendKeysToPane command includes --dangerously-skip-permissions and --effort 1609ms
+   ✓ validatePhaseArtifacts — Phase 5 multi-repo (FR-6, ADR-D4) > returns true when any repo advanced; sets implHead on advanced repos only 537ms
+ ✓ tests/preflight-claude-at-file.test.ts (2 tests) 4ms
+ ✓ tests/process.test.ts (6 tests) 78ms
+ ✓ tests/ui-separator.test.ts (5 tests) 1ms
 ```
 
 </details>
@@ -158,11 +158,11 @@ Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install
 ```
 ⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
 ⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
+⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-bTZyfu/phase-5-carryover-missing.md
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: jsonl missing
-⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-ZtLbUv/phase-5-carryover-missing.md
 ⚠️  claude session resume fallback: jsonl missing
 ⚠️  claude session resume fallback: jsonl missing
 ⚠️  claude session resume fallback: jsonl missing
@@ -174,38 +174,38 @@ Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: no prior attempt id
 fatal: not a git repository (or any of the parent directories): .git
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
 ℹ Received control signal (SIGUSR1). Applying pending action...
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
 ✓ Applied: skip. Phase loop re-entering.
-ℹ Received control signal (SIGUSR1). Applying pending action...
-✓ Applied: jump → phase 3. Phase loop re-entering.
 
 Recent events:
 (events.jsonl not present — logging disabled)
 
 Working tree:
 (git not available)
-
-[R] Resume   [J] Jump to phase   [Q] Quit
-ℹ Received control signal (SIGUSR1). Applying pending action...
-
-Recent events:
-(events.jsonl not present — logging disabled)
-
-Working tree:
-(git not available)
-
-[R] Resume   [J] Jump to phase   [Q] Quit
-
-Recent events:
-(events.jsonl not present — logging disabled)
-
-Working tree:
-(git not available)
-
-[R] Resume   [J] Jump to phase   [Q] Quit
-
-Recent events:
-(events.jsonl not present — logging disabled)
 ```
 
 </details>
@@ -251,12 +251,12 @@ Recent events:
 
  RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/code1
 
- ✓ tests/multi-worktree.test.ts (10 tests) 1251ms
+ ✓ tests/multi-worktree.test.ts (11 tests) 1208ms
 
  Test Files  1 passed (1)
-      Tests  10 passed (10)
-   Start at  23:16:54
-   Duration  1.52s (transform 77ms, setup 0ms, collect 99ms, tests 1.25s, environment 0ms, prepare 30ms)
+      Tests  11 passed (11)
+   Start at  23:23:36
+   Duration  1.45s (transform 78ms, setup 0ms, collect 96ms, tests 1.21s, environment 0ms, prepare 30ms)
 ```
 
 </details>

--- a/docs/process/evals/2026-04-20-task-outer-cwd-n-sub-a808-eval.md
+++ b/docs/process/evals/2026-04-20-task-outer-cwd-n-sub-a808-eval.md
@@ -1,0 +1,271 @@
+# Auto Verification Report
+- Date: 2026-04-20
+- Related Spec: N/A
+- Related Plan: N/A
+
+## Results
+| Check | Status | Detail |
+|-------|--------|--------|
+| typecheck | pass |  |
+| tests | pass |  |
+| build | pass |  |
+| multi-worktree tests | pass |  |
+
+## Summary
+- Total: 4 checks
+- Pass: 4
+- Fail: 0
+
+## Raw Output
+
+### typecheck
+**Command:** `pnpm tsc --noEmit`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>
+
+### tests
+**Command:** `pnpm vitest run`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+ RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/code1
+
+ ✓ tests/state.test.ts (50 tests) 62ms
+ ✓ tests/logger.test.ts (32 tests) 143ms
+ ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 87ms
+ ✓ tests/context/skills-rendering.test.ts (45 tests) 157ms
+ ✓ tests/phases/gate.test.ts (27 tests) 166ms
+ ✓ tests/runners/claude-usage.test.ts (17 tests) 162ms
+ ✓ tests/commands/inner.test.ts (22 tests) 344ms
+ ✓ tests/integration/logging.test.ts (15 tests) 353ms
+ ✓ tests/commands/footer-ticker.test.ts (10 tests) 178ms
+[2J[H ✓ tests/phases/gate-resume.test.ts (13 tests) 219ms
+ ✓ tests/signal.test.ts (16 tests) 552ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/lock.test.ts (20 tests) 310ms
+ ✓ tests/phases/terminal-ui.test.ts (17 tests) 120ms
+ ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 7ms
+ ✓ tests/phases/runner.test.ts (76 tests) 684ms
+ ✓ tests/runners/codex.test.ts (17 tests) 81ms
+ ✓ tests/orphan-cleanup.test.ts (20 tests) 24ms
+ ✓ tests/preflight.test.ts (27 tests | 1 skipped) 277ms
+ ✓ tests/integration/codex-session-resume.test.ts (6 tests) 104ms
+ ✓ tests/integration/light-flow.test.ts (4 tests) 255ms
+ ✓ tests/resume-light.test.ts (10 tests) 20ms
+ ✓ tests/phases/runner-token-capture.test.ts (6 tests) 9ms
+ ✓ tests/commands/inner-footer.test.ts (2 tests) 25ms
+ ✓ tests/runners/codex-resume.test.ts (8 tests) 62ms
+ ✓ tests/phases/verify.test.ts (12 tests) 15ms
+ ✓ tests/tmux.test.ts (33 tests) 815ms
+   ✓ pollForPidFile > returns null on timeout when file never appears 403ms
+   ✓ pollForPidFile > returns null when file contains non-numeric content 403ms
+ ✓ tests/context/assembler.test.ts (67 tests) 1835ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 446ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 604ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 501ms
+ ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 9ms
+ ✓ tests/context/assembler-resume.test.ts (9 tests) 94ms
+ ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 56ms
+ ✓ tests/runners/codex-isolation.test.ts (8 tests) 36ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui.test.ts (8 tests) 4ms
+ ✓ tests/state-invalidation.test.ts (5 tests) 8ms
+ ✓ tests/commands/resume-cmd.test.ts (12 tests) 2001ms
+ ✓ tests/runners/claude.test.ts (4 tests) 8ms
+ ✓ tests/phases/verdict.test.ts (16 tests) 3ms
+ ✓ tests/root.test.ts (10 tests) 157ms
+ ✓ tests/resume.test.ts (11 tests) 2667ms
+   ✓ resumeRun > exits with code 1 and non-interactive message on paused run with null pendingAction (D4b) 306ms
+   ✓ resumeRun > skip_phase Phase 6 with gitignored eval report: skips commit and leaves evalCommit null 347ms
+ ✓ tests/context/reviewer-contract.test.ts (4 tests) 69ms
+ ✓ tests/commands/status-list.test.ts (7 tests) 635ms
+ ✓ tests/phases/gate-resume-escalation.test.ts (1 test) 51ms
+ ✓ tests/ui-footer.test.ts (9 tests) 4ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-2JIWts/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-2JIWts/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-udHKFt/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-DHnQkK/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-DHnQkK/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-mOFi6z/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-B01P0T/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-B01P0T/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-G8vGIc/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-GjLWgA/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-BoZSUq/.claude/skills:
+  phase-harness-codex-gate-review
+No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-CUwuQn/.claude/skills. Nothing to uninstall.
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-BoZSUq/.claude/skills:
+  phase-harness-codex-gate-review
+ ✓ tests/uninstall-skills.test.ts (6 tests) 41ms
+ ✓ tests/install-skills.test.ts (7 tests) 32ms
+ ✓ tests/commands/jump.test.ts (6 tests) 756ms
+ ✓ tests/task-prompt.test.ts (7 tests) 2ms
+ ✓ tests/input.test.ts (12 tests) 7ms
+ ✓ tests/integration/lifecycle.test.ts (11 tests) 1376ms
+ ✓ tests/git.test.ts (20 tests) 1904ms
+ ✓ tests/multi-worktree.test.ts (10 tests) 2731ms
+   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 527ms
+   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 557ms
+   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 415ms
+   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 429ms
+   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 551ms
+ ✓ tests/terminal.test.ts (5 tests) 3ms
+[2J[H[2J[H ✓ tests/phases/interactive.test.ts (47 tests) 4134ms
+   ✓ runInteractivePhase — Claude dispatch command shape > sendKeysToPane command includes --dangerously-skip-permissions and --effort 1587ms
+   ✓ validatePhaseArtifacts — Phase 5 multi-repo (FR-6, ADR-D4) > returns true when any repo advanced; sets implHead on advanced repos only 523ms
+[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui-prompt-model-config.test.ts (3 tests) 32ms
+ ✓ tests/preflight-claude-at-file.test.ts (2 tests) 3ms
+ ✓ tests/conformance/phase-models.test.ts (9 tests) 3ms
+ ✓ tests/process.test.ts (6 tests) 132ms
+ ✓ tests/artifact.test.ts (14 tests) 3528ms
+   ✓ normalizeArtifactCommit > creates commit for new untracked file 344ms
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
+⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: jsonl missing
+⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-ZtLbUv/phase-5-carryover-missing.md
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+fatal: not a git repository (or any of the parent directories): .git
+ℹ Received control signal (SIGUSR1). Applying pending action...
+✓ Applied: skip. Phase loop re-entering.
+ℹ Received control signal (SIGUSR1). Applying pending action...
+✓ Applied: jump → phase 3. Phase loop re-entering.
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+ℹ Received control signal (SIGUSR1). Applying pending action...
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+
+Recent events:
+(events.jsonl not present — logging disabled)
+```
+
+</details>
+
+### build
+**Command:** `pnpm build`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+> phase-harness@0.2.5 build /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/code1
+> tsc -p tsconfig.build.json && node scripts/copy-assets.mjs
+
+[copy-assets] copied src/context/prompts -> dist/src/context/prompts
+[copy-assets] copied src/context/skills -> dist/src/context/skills
+[copy-assets] copied src/context/skills-standalone -> dist/src/context/skills-standalone
+[copy-assets] copied src/context/playbooks -> dist/src/context/playbooks
+[copy-assets] copied scripts/harness-verify.sh -> dist/scripts/harness-verify.sh
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>
+
+### multi-worktree tests
+**Command:** `pnpm vitest run tests/multi-worktree.test.ts`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+ RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/code1
+
+ ✓ tests/multi-worktree.test.ts (10 tests) 1251ms
+
+ Test Files  1 passed (1)
+      Tests  10 passed (10)
+   Start at  23:16:54
+   Duration  1.52s (transform 77ms, setup 0ms, collect 99ms, tests 1.25s, environment 0ms, prepare 30ms)
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>

--- a/docs/specs/2026-04-20-task-outer-cwd-n-sub-a808-design.md
+++ b/docs/specs/2026-04-20-task-outer-cwd-n-sub-a808-design.md
@@ -1,0 +1,271 @@
+# Multi-Worktree Harness Flow — Design Spec
+
+- Date: 2026-04-20
+- Status: Draft (Phase 1 output, pending Codex gate at Phase 2)
+- Related Task: `.harness/2026-04-20-task-outer-cwd-n-sub-a808/task.md`
+- Related Decisions: `.harness/2026-04-20-task-outer-cwd-n-sub-a808/decisions.md`
+
+---
+
+## Context & Decisions
+
+### 문제
+
+`harness-cli`는 현재 "cwd = 단일 git repo"를 전제로 동작한다. 실무에서 자주 쓰이는 **grove mission 레이아웃** — outer 디렉토리에 `.gitignore`와 N개의 sub-worktree(독립 git repo)가 놓이고 **outer 자체는 git이 아닌** 구조 — 에서 `phase-harness run`을 돌리면 Phase 2에서 `Not inside a trusted directory` 에러로 즉시 실패한다. 또한 outer를 빈 git으로 만들어도 Phase 5 HEAD는 sub-worktree들 안에서 움직이므로 outer 기준 판정이 영구 false가 되고, gate에 주입되는 `git diff`도 빈 문자열이 된다. 장애가 preflight가 아닌 Phase 2에서야 드러나 디버깅 비용도 크다.
+
+### 목표
+
+outer + N sub-worktree 레이아웃에서 Phase 1~6이 자연스럽게 흐르도록 하고, **기존 "cwd = 단일 git repo" 플로우는 동작·성능·테스트 전부 regression 0**으로 유지한다.
+
+### 핵심 결정 요약 (rationale)
+
+**[ADR-N1] "N≥1 tracked repos" 단일 모델로 통합 — "single vs multi 모드" 분기 기각**
+- single-repo와 multi-worktree를 별도 코드 경로로 나누지 않는다. 대신 harness는 항상 **`state.trackedRepos: Array<{path, baseCommit, implRetryBase}>` 순회 모델** (N≥1)로 동작한다. cwd가 git이면 `trackedRepos = [{ path: cwd, ... }]` 1원소로 자동 채워지고, cwd가 git이 아니면 depth=1 auto-detect 결과로 N원소가 된다.
+- 이유: assembler, Phase 5 판정, preflight, resume ancestry 체크 등 다수 모듈이 "두 모드 분기문"을 두면 regression 표면이 커지고 테스트 매트릭스가 2배로 늘어난다. 반면 "항상 순회, N=1이 degenerate case"는 기존 동작을 그대로 포함한다.
+
+**[ADR-N2] cwd depth=1 auto-detect (cwd가 git 아닐 때만)**
+- cwd가 git이면 기존 single-repo 경로 (trackedRepos 자동 합성, 스캔 안 함).
+- cwd가 git이 아니면 cwd 바로 아래 depth=1에서 git repo인 디렉토리를 자동 수집. 숨김 dir (`.*`), `node_modules`, `dist`, `build`, `.harness`는 skip. 결과는 경로 알파벳 정렬로 결정론화.
+- `--track <path>` (repeatable): 명시 리스트 — auto-detect를 완전히 대체. 전달된 순서를 유지 (첫 인자 = docs home).
+- `--exclude <path>` (repeatable): auto-detect 결과에서 제거.
+- preflight 때 "Detected N tracked repos: [...]" 한 줄 출력. Y/n 프롬프트 없음.
+- 0개 수집 + `--track` 없음 → preflight fail-fast: `"No tracked git repos found under cwd. Pass --track <path> or run from a git repo."`
+- 기각: 재귀 스캔 (오탐 위험, node_modules 내부 구멍); `.gitignore` "Nested project worktrees" 섹션 파싱 (grove 전용 컨벤션).
+
+**[ADR-N3] `state.trackedRepos` 도입, 기존 top-level 필드는 mirror**
+- state 스키마에 `trackedRepos: Array<{path, baseCommit, implRetryBase, implHead}>` 추가.
+- 기존 `state.baseCommit` / `state.implRetryBase` top-level 필드는 항상 `trackedRepos[0]`의 거울로 유지 — 기존 코드가 두 필드를 읽는 모든 지점에서 동작 불변.
+- state migration: 기존 state.json 로드 시 top-level 두 필드로부터 `trackedRepos` 1원소를 합성 (`trackedRepos` 부재 시).
+- 이유: 소비자 코드를 한꺼번에 바꾸지 않아도 되며 backward compat가 깨끗하다.
+
+**[ADR-N4] Docs/artifacts 저장 위치 = `trackedRepos[0]`**
+- 별도 `--docs-repo` 플래그 없음.
+- single-repo: `cwd/docs/...` (= `trackedRepos[0]/docs`). 기존과 동일.
+- multi: `trackedRepos[0]/docs/...`. 첫 번째 tracked repo에 spec/plan/eval artifact가 커밋된다.
+- 사용자가 docs home을 제어하려면 `--track <docs-home>` 을 첫 인자로 명시.
+- 이유: 플래그 추가는 YAGNI. `--track` 순서 규칙이 override 역할을 겸한다.
+
+**[ADR-N5] Gate codex spawn = 항상 outer cwd. cwd가 git 아니면 `--skip-git-repo-check` 자동**
+- `src/runners/codex.ts` gate spawn은 항상 outer cwd에서 실행.
+- cwd가 git이면 기존 동작 (skip 플래그 없음).
+- cwd가 git이 아니면 codex에 `--skip-git-repo-check` 자동 부착.
+- diff는 어느 경우든 harness가 `assembler.ts`에서 tracked repos를 순회하여 조립한 뒤 prompt `<diff>` 블록에 주입. codex는 git을 직접 건드리지 않는다.
+- codex 샌드박스는 outer cwd 하위 전체에 걸쳐 있어 tracked repos에 대한 read 접근이 자연스럽게 커버된다.
+- 기각: "docs repo에서 스폰" — runner가 경로 선택 로직을 떠안게 돼 코드 경로가 늘어난다.
+
+**[ADR-N6] Phase 5 성공 판정 = "tracked repos 중 하나라도 advanced"**
+- `src/phases/interactive.ts`의 Phase 5 판정을 단일 HEAD 비교에서 `trackedRepos` 순회로 교체: "어떤 tracked repo든 현재 HEAD가 해당 repo의 `implRetryBase`에서 전진했는가?"
+- N=1 (single-repo)일 때 기존 의미와 동일.
+- 기각: "전부 전진" — 한 repo만 건드리는 task에도 빈 ceremonial 커밋을 강요.
+- Phase 5 reopen 시 각 `trackedRepos[i].implRetryBase`를 해당 시점 HEAD로 리셋.
+
+**[ADR-N7] Gate diff 조립 = repo별 label + concat, 전체 size cap**
+- `assembler.ts`가 `trackedRepos.forEach(repo => ...)` 로 `### repo: <path>\n\`\`\`diff\n<git diff base...HEAD>\n\`\`\`\n` 형태 섹션을 concat.
+- 기존 `MAX_DIFF_SIZE_KB` 상한은 concat 전체 길이에 적용. 초과 시 기존 `truncateDiffPerFile` per-file 절단 규칙을 concat 결과에 그대로 적용.
+- N=1이면 기존 단일 diff와 동일한 출력을 내도록 유지 (label 섹션 포맷이 기존 테스트 fixture를 깨지 않는 방식으로 도입 — 상세는 Invariants 참조).
+
+**[ADR-N8] Phase 6 verify는 변경 없음 (checklist-level 책임)**
+- `scripts/harness-verify.sh`는 건드리지 않는다. multi-repo 타깃이 필요한 명령은 Phase 3 plan 작성 시 checklist에 `cd <repo-path> && <cmd>` 형태로 저자가 직접 쓴다.
+- eval report artifact 커밋은 기존과 동일하게 `trackedRepos[0]/docs/process/evals/` 아래 생성 (ADR-N4 룰에 따름).
+
+**[ADR-N9] Preflight에 per-repo git+head 체크 활성화, codex 에러 메시지에 stderr 프리뷰 포함**
+- `src/commands/start.ts`가 현재 호출하지 않는 `git` / `head` 항목을 **`trackedRepos` 순회**로 호출. single은 1회, multi는 N회. 실패 시 Phase 2 전에 친절한 메시지로 중단.
+- `src/runners/codex.ts`의 "Gate subprocess exited with code 1" 에러 메시지에 codex stderr 마지막 ~20줄을 포함. 모드 무관 UX 버그 수정.
+
+**[ADR-N10] Resume 다중 repo는 동일 순회 패턴으로 자연 파생 (별도 설계 불필요)**
+- `src/resume.ts`의 ancestry 체크, Phase 5 fresh-sentinel 재판정, external commits 감지, implRetryBase 리셋을 전부 `trackedRepos` 순회로 교체.
+- N=1일 때 기존 동작과 동일하므로 별도 마이그레이션 없음.
+- 본 spec에 구현 범위로 포함 (task.md §"성공 기준"의 "Phase 1~6이 에러 없이 진행"은 resume을 포함한 iterative 사용이 성립해야만 의미가 있음).
+
+---
+
+## Complexity
+
+Large — state schema 마이그레이션 + assembler, interactive(phase 5 판정), preflight, codex runner, resume, harness-verify(간접), 그리고 ADR/HOW-IT-WORKS 문서까지 다모듈 touched. 단일 파일·수백 LoC 범위가 아님.
+
+---
+
+## 아키텍처 개요
+
+```
+outer cwd (git 일 수도, 아닐 수도)
+  ├── docs/                    ← trackedRepos[0] 가 git 이어야 함 (artifact 커밋 대상)
+  ├── repo-a/                  ← auto-detect / --track 으로 참여
+  ├── repo-b/                  ← 〃
+  └── .harness/<runId>/
+        ├── state.json         ← trackedRepos[] 포함
+        └── ...
+
+harness process
+  ├── start.ts
+  │   ├── (cwd가 git?) → trackedRepos = [{ cwd, HEAD, HEAD }]
+  │   └── (아니면)    → depth=1 scan + --track/--exclude 반영 → trackedRepos[]
+  │   └── per-repo preflight (git+head) → fail-fast on miss
+  │
+  ├── phases/interactive.ts
+  │   └── Phase 5 판정: trackedRepos.some(r => currentHEAD(r.path) !== r.implRetryBase)
+  │
+  ├── context/assembler.ts
+  │   └── Gate diff: trackedRepos.map(r => "### repo: …\n```diff\n git diff r.base...HEAD```") 로 concat
+  │
+  ├── runners/codex.ts
+  │   └── gate spawn: cwd = outer, cwd가 git 아니면 --skip-git-repo-check
+  │   └── error path: exit≠0 시 stderr 마지막 ~20줄을 에러 메시지에 포함
+  │
+  └── resume.ts
+      └── ancestry / external-commit / Phase 5 재판정: 전부 trackedRepos 순회
+```
+
+---
+
+## Functional Requirements
+
+### FR-1 모드 진입 규칙
+
+- `phase-harness start` / `run` / `start --light` 가 호출되면:
+  1. cwd가 git repo인지 확인.
+  2. git이면 → `trackedRepos = [{ path: cwd, baseCommit: HEAD, implRetryBase: HEAD }]`. 스캔·플래그 무시. 기존 플로우와 완전히 동일한 경로.
+  3. git이 아니면 → auto-detect 또는 `--track` 리스트로 `trackedRepos`를 만든다. 결과가 비어 있으면 start 중단 (fail-fast).
+- `--track <path>` 가 하나라도 주어지면 auto-detect는 **완전히 무시**되고 명시 리스트만 사용된다.
+- `--exclude <path>` 는 auto-detect 결과에서 경로 일치(정규화 후) 제거. `--track` 과 조합 시 `--exclude` 는 노옵(explicit list에는 적용 안 함).
+
+### FR-2 State 스키마
+
+- `state.trackedRepos: Array<{ path: string; baseCommit: string; implRetryBase: string; implHead: string | null }>` 신규 필드.
+  - `path`: cwd 기준 정규화된 절대경로.
+  - `baseCommit`: run 시작 시점의 해당 repo HEAD.
+  - `implRetryBase`: 해당 repo에서 Phase 5 재시도 기준 HEAD (초기값 = baseCommit, reopen 시 현재 HEAD로 갱신).
+  - `implHead`: Phase 5 완료 시점 해당 repo HEAD (미완료 시 null).
+- 기존 top-level `state.baseCommit` / `state.implRetryBase` 는 **항상 `trackedRepos[0]`의 거울**로 유지된다 (state 쓰기 시 동기화).
+- state migration: `state.json` 로드 시 `trackedRepos` 가 undefined 또는 빈 배열이면 `[{ path: cwd, baseCommit: state.baseCommit, implRetryBase: state.implRetryBase, implHead: state.implCommit }]` 로 합성.
+
+### FR-3 Preflight
+
+- `start.ts` 가 `runPreflight(['node','tmux','tty','platform','verifyScript','jq'], cwd)` 에 추가로 `trackedRepos` 확정 직후 `for (const repo of trackedRepos) runPreflight(['git','head'], repo.path)` 를 호출.
+- 현재 `src/preflight.ts` 의 `'git'` / `'head'` 케이스는 변경 없이 재사용된다 (message는 repo.path context를 포함하도록 경량 수정 — 메시지 문자열에 `repo: <path>` 접미).
+- 실패 시 종료 메시지: `"harness requires a git repository in: <path>"` 또는 `"harness requires at least one commit in: <path>"`.
+
+### FR-4 Gate (Phase 2/4/7) codex 스폰
+
+- `src/runners/codex.ts` 의 gate spawn 경로에서 cwd 판정:
+  - outer cwd가 git repo → 기존 동작 (argv 변화 없음).
+  - outer cwd가 git 아님 → codex argv 에 `--skip-git-repo-check` 자동 추가.
+- spawn `cwd` 는 항상 outer cwd (프로세스 `process.cwd()` 또는 harness 가 들고 있는 cwd 값). 어떤 tracked repo로도 바뀌지 않는다.
+- codex 에러 경로 (`runners/codex.ts:305` 근처) 에서 exit code ≠ 0 시, captured stderr 의 마지막 ~20줄을 에러 message 에 포함 (`"Gate subprocess exited with code 1\n--- stderr (tail) ---\n<...>\n---"`). 20줄 제한과 ANSI escape stripping 적용.
+
+### FR-5 Gate diff 조립
+
+- `src/context/assembler.ts` 의 gate 프롬프트 조립 지점(§Phase 4, §Phase 7, 그리고 buildPhase7DiffAndMetadata)에서 단일 `runGit("git diff …", cwd)` 호출을 `trackedRepos` 순회로 교체.
+- 각 repo 의 diff 는 다음 포맷으로 concat:
+
+  ```
+  ### repo: <path relative to cwd if possible, else absolute>
+  ```diff
+  <git diff ${baseCommit}...HEAD in that repo>
+  ```
+  ```
+
+- `trackedRepos.length === 1` **and** `trackedRepos[0].path === cwd` 인 경우 (= 기존 single-repo 케이스) **label 섹션 없이 기존 raw diff 포맷을 그대로 출력**한다. 기존 gate prompt golden fixture 가 깨지지 않도록 하는 의도적 N=1 백워드 경로다.
+- `MAX_DIFF_SIZE_KB` 상한은 concat 전체에 적용. 초과 시 `truncateDiffPerFile(concat, PER_FILE_DIFF_LIMIT_KB * 1024)` 를 그대로 호출.
+- Phase 7 의 `externalCommitsDetected` 경로 및 `buildPhase7DiffAndMetadata` 의 `primary` diff 구성도 동일한 per-repo 순회로 일반화. metadata block 의 `Harness implementation range: baseCommit..implCommit` 은 `trackedRepos[0]` 기준 값(현행 top-level 거울)을 유지한다.
+
+### FR-6 Phase 5 성공 판정
+
+- `src/phases/interactive.ts:187-196` 의 Phase 5 sentinel 후속 판정 및 `src/resume.ts:580-588` 의 fresh-sentinel 판정에서 `getHead(cwd) === state.implRetryBase` 단일 비교를 다음으로 교체:
+
+  ```
+  const anyAdvanced = state.trackedRepos.some(r => getHead(r.path) !== r.implRetryBase);
+  if (!anyAdvanced) return false;
+  state.implCommit = getHead(trackedRepos[0].path);  // top-level 거울 유지
+  for (const r of state.trackedRepos) r.implHead = getHead(r.path);
+  return true;
+  ```
+
+- Phase 5 reopen 경로 (`src/phases/interactive.ts` preparePhase / resume 의 reopen 계열) 에서는 `for (const r of trackedRepos) r.implRetryBase = getHead(r.path)` 를 수행하고 top-level `state.implRetryBase` 도 `trackedRepos[0].implRetryBase` 로 갱신.
+
+### FR-7 Artifact 경로 해석 (docs home)
+
+- spec / plan / eval report / decisions 등 artifact 의 상대 경로는 모두 `trackedRepos[0].path` 를 root로 해석한다.
+- 현재 `artifacts.spec = "docs/specs/…md"` 와 같은 상대 표기는 단일 치환점 (새로운 헬퍼 `resolveArtifact(state, rel)` 또는 기존 `isAbsolute ? rel : join(cwd, rel)` 지점을 `join(state.trackedRepos[0].path, rel)` 로 교체) 을 통해 리라우팅.
+- N=1 + trackedRepos[0].path === cwd 일 때 기존 경로와 완전히 동일하므로 single-repo 테스트·dogfood 동작 불변.
+- artifact commit (기존 `normalizeArtifactCommit`) 는 `trackedRepos[0].path` 에서 실행.
+
+### FR-8 Resume 다중 repo 동작
+
+- `src/resume.ts`
+  - `ancestry check` (현재 `isAncestor(state.implCommit, 'HEAD', cwd)` 계열): `trackedRepos` 순회해 각 repo 별로 `isAncestor(r.implHead, 'HEAD', r.path)` 검사. 하나라도 실패하면 manual recovery 메시지에 실패한 repo.path 명시.
+  - `updateExternalCommitsDetected`: `trackedRepos` 순회로 per-repo external commit 감지. 어느 하나라도 발견되면 `state.externalCommitsDetected = true`.
+  - Phase 5 fresh-sentinel 재판정: FR-6 규칙 그대로 사용.
+
+### FR-9 Phase 6 verify (변경 범위)
+
+- `scripts/harness-verify.sh` 소스 변경 없음.
+- Phase 3 plan 작성 시 multi-repo target 이 필요한 checklist command 는 `cd <repo-path> && <cmd>` 형태로 작성하도록 Phase 3 wrapper skill / 문서에 안내만 추가 (행동 변화는 plan 저자의 책임).
+- eval report artifact commit 은 FR-7 에 의해 `trackedRepos[0]` 내부에 착지.
+
+### FR-10 CLI 플래그
+
+- `phase-harness start|run|start --light` 에 다음 반복 플래그 추가:
+  - `--track <path>` — 경로는 절대/상대 허용. 존재하지 않거나 git repo가 아니면 start 시 fail-fast (메시지: `"--track <path>: not a git repo"`).
+  - `--exclude <path>` — auto-detect 결과에서만 효력.
+- 기존 플래그·의미 변경 없음.
+
+---
+
+## Non-functional Requirements
+
+- 기존 vitest suite **전체 통과** 를 regression gate 로 둔다. single-repo 코드 경로의 모든 기존 테스트는 변경 없이 통과해야 한다.
+- multi-worktree 신규 테스트: (a) cwd 가 git 아닐 때 depth=1 scan fixture (b) `--track`/`--exclude` 조합 (c) N=2 tracked repos 에서 assembler diff concat (d) Phase 5 판정에서 "하나만 advanced" 시 success (e) state migration (legacy state.json 로드→trackedRepos 합성).
+- harness-cli 자체 dogfood (cwd = harness-cli worktree, git repo) 경로에서 `phase-harness run` 동작이 코드 수정 전후 완전히 동일해야 한다.
+- state 파일 크기 증가: `trackedRepos` 배열 추가로 single-repo 에서도 수십 바이트 증가. 수용 가능.
+
+---
+
+## Success Criteria
+
+- 문서:
+  1. 본 spec doc 존재, 경로 `docs/specs/2026-04-20-task-outer-cwd-n-sub-a808-design.md`.
+  2. `docs/HOW-IT-WORKS.md` 및 `.ko.md` 의 "Architecture" / "Lifecycle" 해당 섹션에 multi-worktree 모델 설명 추가 (Phase 3 plan 에서 구현 범위로 포함).
+- 코드:
+  3. state schema migration 포함 `trackedRepos[]` 도입, 기존 top-level 필드 mirror 유지.
+  4. 기존 vitest 통과 + 신규 multi-worktree 테스트 통과.
+  5. cwd 가 grove mission 레이아웃 (git 아님 + depth=1 에 git sub-repos) 일 때 `phase-harness run` 실행 시 Phase 1~6 이 에러 없이 진행 (수동 dogfood 기준).
+  6. cwd 가 git 아님 + tracked repo 0 개인 상태에서 `phase-harness run` 호출 시 Phase 2 가 아닌 start 시점에 명시적 메시지와 함께 exit 1.
+  7. codex gate subprocess 실패 시 에러 메시지에 stderr tail 이 포함된다.
+
+---
+
+## Invariants
+
+- `state.trackedRepos.length >= 1` 이 run 전 구간에서 항상 참.
+- `state.baseCommit === state.trackedRepos[0].baseCommit` 이 run 전 구간에서 항상 참 (write 시 동기화).
+- `state.implRetryBase === state.trackedRepos[0].implRetryBase` 이 run 전 구간에서 항상 참.
+- `trackedRepos.length === 1 && trackedRepos[0].path === cwd` 인 경우 gate diff 출력 바이트, Phase 5 판정 결과, artifact 경로, state.json 의 legacy 필드가 **구현 전과 byte-identical**.
+- auto-detect 는 cwd 가 git repo 일 때 **수행되지 않는다** (short-circuit).
+- `--track` 이 있으면 auto-detect 결과와 `--exclude` 는 모두 무시된다.
+- Phase 5 성공 판정은 `trackedRepos.some(r => currentHEAD(r) !== r.implRetryBase)` 로 표현 가능한 한 가지 규칙만 사용한다 (단일 HEAD 비교 금지).
+- codex gate spawn 은 **항상 outer cwd** 에서 실행된다. 어떤 tracked repo 로도 chdir 하지 않는다.
+- FR-5 의 `### repo:` label 섹션은 N=1 + trackedRepos[0].path === cwd 케이스에서 **출력되지 않는다** (기존 golden fixture 보호).
+
+---
+
+## Non-goals
+
+- 3+ depth 중첩 repo / submodule 자동 처리 — 지원 안 함. 필요 시 `--track` 명시.
+- tracked repos 간 cross-repo 변경을 atomic commit 으로 묶는 기능.
+- docs-repo 전용 전담 플래그 (`--docs-repo`) — YAGNI 처리.
+- `--multi-worktree` 명시 플래그 — `trackedRepos.length >= 1` 단일 모델로 대체.
+- `scripts/harness-verify.sh` 의 multi-repo 인식 — checklist 저자 책임으로 이전.
+- grove mission 외의 레이아웃(예: monorepo + submodule 혼합) 튜닝.
+
+---
+
+## Open issues resolved during brainstorming
+
+(이 섹션은 gate reviewer 참고용. 실구현이 끝나면 제거 가능.)
+
+- "per-repo tracking 이 정말 필요한가?" → 필요. `baseCommit` 은 run 시작 시점 스냅샷이며 "세션 동안 뭐가 바뀌었는가" 를 나중에 재구성하려면 시작 HEAD 기록 필수.
+- "single vs multi 두 모드로 분기?" → 기각. "N≥1 단일 모델" 로 통합해 regression 표면 축소.
+- "docs-repo 플래그 추가?" → 기각 (YAGNI). `--track` 순서 규칙이 override 겸용.
+- "codex gate 스폰을 docs repo로?" → 기각. 항상 outer cwd, cwd 가 git 아니면 `--skip-git-repo-check` 자동.
+- "resume 다중 repo 는 후속 spec?" → 거부. Phase 5 reopen 이 resume 경로와 직결돼 있어 분리 불가능. 본 spec 범위에 포함.

--- a/docs/specs/2026-04-20-task-outer-cwd-n-sub-a808-design.md
+++ b/docs/specs/2026-04-20-task-outer-cwd-n-sub-a808-design.md
@@ -1,7 +1,7 @@
 # Multi-Worktree Harness Flow — Design Spec
 
 - Date: 2026-04-20
-- Status: Draft (Phase 1 output, pending Codex gate at Phase 2)
+- Status: Draft (Phase 1 rev 2 — gate-2 P1 feedback incorporated)
 - Related Task: `.harness/2026-04-20-task-outer-cwd-n-sub-a808/task.md`
 - Related Decisions: `.harness/2026-04-20-task-outer-cwd-n-sub-a808/decisions.md`
 
@@ -51,7 +51,9 @@ outer + N sub-worktree 레이아웃에서 Phase 1~6이 자연스럽게 흐르도
 - cwd가 git이 아니면 codex에 `--skip-git-repo-check` 자동 부착.
 - diff는 어느 경우든 harness가 `assembler.ts`에서 tracked repos를 순회하여 조립한 뒤 prompt `<diff>` 블록에 주입. codex는 git을 직접 건드리지 않는다.
 - codex 샌드박스는 outer cwd 하위 전체에 걸쳐 있어 tracked repos에 대한 read 접근이 자연스럽게 커버된다.
+- **샌드박스-tracked repo 일관성 규칙 (gate-2 P1 반영)**: **모든 tracked repo 는 outer cwd 의 하위 경로(cwd-descendant) 여야 한다**. 이 전제 하에서만 codex 샌드박스(= outer cwd 트리)가 자동으로 tracked repos 를 읽기 범위에 포함한다. out-of-tree 경로 (`--track` 이 cwd 밖을 가리키는 경우) 는 start 시점 fail-fast. 상세 규칙은 FR-10. 본 spec 범위에서는 out-of-tree tracked repo 지원을 non-goal 로 둔다.
 - 기각: "docs repo에서 스폰" — runner가 경로 선택 로직을 떠안게 돼 코드 경로가 늘어난다.
+- 기각: "sandbox 를 out-of-tree 경로까지 확장" — codex CLI per-path whitelist 옵션 튜닝 + 에러 경로 확장이 필요. grove mission 실사용 레이아웃은 항상 cwd-descendant 이므로 이번 범위 제외.
 
 **[ADR-N6] Phase 5 성공 판정 = "tracked repos 중 하나라도 advanced"**
 - `src/phases/interactive.ts`의 Phase 5 판정을 단일 HEAD 비교에서 `trackedRepos` 순회로 교체: "어떤 tracked repo든 현재 HEAD가 해당 repo의 `implRetryBase`에서 전진했는가?"
@@ -124,20 +126,25 @@ harness process
 
 - `phase-harness start` / `run` / `start --light` 가 호출되면:
   1. cwd가 git repo인지 확인.
-  2. git이면 → `trackedRepos = [{ path: cwd, baseCommit: HEAD, implRetryBase: HEAD }]`. 스캔·플래그 무시. 기존 플로우와 완전히 동일한 경로.
+  2. git이면 → `trackedRepos = [{ path: cwd, baseCommit: HEAD, implRetryBase: HEAD, implHead: null }]`. 스캔·플래그 무시. 기존 플로우와 완전히 동일한 경로.
   3. git이 아니면 → auto-detect 또는 `--track` 리스트로 `trackedRepos`를 만든다. 결과가 비어 있으면 start 중단 (fail-fast).
+- **cwd-descendant 제약 (gate-2 P1)**: 채택된 모든 tracked repo 경로는 `path.resolve(cwd, …)` 후 `path.relative(cwd, resolved)` 가 `..` 로 시작하지 않아야 한다 (= cwd 트리 내부). auto-detect 는 cwd 직속 child 만 보므로 자동 만족. `--track` 이 위반하면 start 시점에 fail-fast (상세: FR-10).
 - `--track <path>` 가 하나라도 주어지면 auto-detect는 **완전히 무시**되고 명시 리스트만 사용된다.
 - `--exclude <path>` 는 auto-detect 결과에서 경로 일치(정규화 후) 제거. `--track` 과 조합 시 `--exclude` 는 노옵(explicit list에는 적용 안 함).
 
 ### FR-2 State 스키마
 
 - `state.trackedRepos: Array<{ path: string; baseCommit: string; implRetryBase: string; implHead: string | null }>` 신규 필드.
-  - `path`: cwd 기준 정규화된 절대경로.
+  - `path`: cwd 기준 정규화된 절대경로. **cwd-descendant 여야 한다** (FR-1 / ADR-N5).
   - `baseCommit`: run 시작 시점의 해당 repo HEAD.
   - `implRetryBase`: 해당 repo에서 Phase 5 재시도 기준 HEAD (초기값 = baseCommit, reopen 시 현재 HEAD로 갱신).
-  - `implHead`: Phase 5 완료 시점 해당 repo HEAD (미완료 시 null).
-- 기존 top-level `state.baseCommit` / `state.implRetryBase` 는 **항상 `trackedRepos[0]`의 거울**로 유지된다 (state 쓰기 시 동기화).
-- state migration: `state.json` 로드 시 `trackedRepos` 가 undefined 또는 빈 배열이면 `[{ path: cwd, baseCommit: state.baseCommit, implRetryBase: state.implRetryBase, implHead: state.implCommit }]` 로 합성.
+  - `implHead`: 해당 repo 에서 Phase 5 성공 판정 시점에 관찰된 HEAD. Phase 5 미완료 또는 해당 repo 가 advanced 되지 않은 경우 `null`.
+- **legacy top-level 필드 미러링 규칙 (gate-2 P1 명시화)**:
+  - `state.baseCommit ≡ state.trackedRepos[0].baseCommit` — 항상 mirror (write 시 동기화).
+  - `state.implRetryBase ≡ state.trackedRepos[0].implRetryBase` — 항상 mirror.
+  - `state.implCommit ≡ state.trackedRepos[0].implHead` — mirror. **`trackedRepos[0]` 이 advanced 되지 않아 `implHead = null` 이면 `state.implCommit = null`**.
+  - 따라서 N=1 single-repo 케이스(= trackedRepos[0] 가 cwd) 에서 legacy 소비자(`state.implCommit` 을 단일 구현 anchor 로 읽는 모든 경로)는 기존 의미가 그대로 유지된다. N>1 multi-repo 에서 repo 0 만 변경 안 된 경우 `state.implCommit` 이 `null` 로 떨어지므로, 단일 anchor 전제 소비자는 **null-safe 경로를 타야 한다** (상세: FR-5, FR-8).
+- state migration: `state.json` 로드 시 `trackedRepos` 가 undefined 또는 빈 배열이면 `[{ path: cwd, baseCommit: state.baseCommit, implRetryBase: state.implRetryBase, implHead: state.implCommit }]` 로 합성 (`state.implCommit` 이 null 이면 `implHead` 도 null).
 
 ### FR-3 Preflight
 
@@ -166,22 +173,34 @@ harness process
   ```
 
 - `trackedRepos.length === 1` **and** `trackedRepos[0].path === cwd` 인 경우 (= 기존 single-repo 케이스) **label 섹션 없이 기존 raw diff 포맷을 그대로 출력**한다. 기존 gate prompt golden fixture 가 깨지지 않도록 하는 의도적 N=1 백워드 경로다.
-- `MAX_DIFF_SIZE_KB` 상한은 concat 전체에 적용. 초과 시 `truncateDiffPerFile(concat, PER_FILE_DIFF_LIMIT_KB * 1024)` 를 그대로 호출.
-- Phase 7 의 `externalCommitsDetected` 경로 및 `buildPhase7DiffAndMetadata` 의 `primary` diff 구성도 동일한 per-repo 순회로 일반화. metadata block 의 `Harness implementation range: baseCommit..implCommit` 은 `trackedRepos[0]` 기준 값(현행 top-level 거울)을 유지한다.
+- `MAX_DIFF_SIZE_KB` 상한은 concat 전체에 적용. 초과 시 `truncateDiffPerFile(concat, PER_FILE_DIFF_LIMIT_KB * 1024)` 를 그대로 호출 (단, multi-repo 포맷에서 per-file 절단 경계가 repo 섹션과 맞물리는 세부 규칙은 **Deferred §D-1** 로 이월 — gate-2 P2).
+- **Phase 7 metadata block — multi-repo 분기 규칙 (gate-2 P1 반영)**:
+  - N=1 single-repo 케이스 (= `trackedRepos.length === 1 && trackedRepos[0].path === cwd`): 기존 포맷 그대로. `"Harness implementation range: ${state.baseCommit}..${state.implCommit}"` 한 줄. `state.implCommit = null` 이면 `"Phase 5 skipped; no implementation commit anchor."` (기존 동작과 동일).
+  - N>1 multi-repo 케이스: 단일 `baseCommit..implCommit` 라인을 **출력하지 않고**, 대신 `"Harness implementation ranges (per tracked repo):"` 블록을 출력한다. 각 repo 별로 `"  - <path>: <baseCommit>..<implHead>"` (해당 repo 가 advanced). `implHead === null` 인 repo 는 `"  - <path>: no change (baseCommit=<baseCommit>)"` 로 출력. 이로써 "top-level `implCommit` 이 null 이어도 metadata 가 정보 손실 없이 gate reviewer 에게 전달됨".
+- Phase 7 의 `externalCommitsDetected` 경로 및 `buildPhase7DiffAndMetadata` 의 `primary` diff 구성도 동일한 per-repo 순회로 일반화. 기존 코드에서 `state.implCommit` / `state.evalCommit` 을 단일 anchor 로 쓰는 외부-커밋 주석 로직은 **`trackedRepos[0]` 기준** 으로 유지하되 (`implCommit` 이 null 일 수 있으므로 null-guard 추가), 각 tracked repo 의 external commit log 는 repo 별로 수집해 `"## External Commits (not reviewed)"` 섹션에 repo 헤더와 함께 append.
 
 ### FR-6 Phase 5 성공 판정
 
-- `src/phases/interactive.ts:187-196` 의 Phase 5 sentinel 후속 판정 및 `src/resume.ts:580-588` 의 fresh-sentinel 판정에서 `getHead(cwd) === state.implRetryBase` 단일 비교를 다음으로 교체:
+- `src/phases/interactive.ts:187-196` 의 Phase 5 sentinel 후속 판정 및 `src/resume.ts:580-588` 의 fresh-sentinel 판정에서 `getHead(cwd) === state.implRetryBase` 단일 비교를 다음으로 교체 (gate-2 P1 반영 — `implHead`/`implCommit` 을 advance 여부에 따라 조건부로 기록):
 
   ```
-  const anyAdvanced = state.trackedRepos.some(r => getHead(r.path) !== r.implRetryBase);
+  let anyAdvanced = false;
+  for (const r of state.trackedRepos) {
+    const h = getHead(r.path);
+    if (h !== r.implRetryBase) {
+      r.implHead = h;                 // advance 한 repo 에만 implHead 를 설정
+      anyAdvanced = true;
+    } else {
+      r.implHead = null;              // 변경 없음 repo 는 implHead 를 null 로 남김
+    }
+  }
   if (!anyAdvanced) return false;
-  state.implCommit = getHead(trackedRepos[0].path);  // top-level 거울 유지
-  for (const r of state.trackedRepos) r.implHead = getHead(r.path);
+  state.implCommit = state.trackedRepos[0].implHead;   // legacy mirror: repo 0 advance 안 했으면 null
   return true;
   ```
 
-- Phase 5 reopen 경로 (`src/phases/interactive.ts` preparePhase / resume 의 reopen 계열) 에서는 `for (const r of trackedRepos) r.implRetryBase = getHead(r.path)` 를 수행하고 top-level `state.implRetryBase` 도 `trackedRepos[0].implRetryBase` 로 갱신.
+- 따라서 N=1 케이스에서는 `state.implCommit = getHead(cwd)` 와 동치 (기존 동작 보존). N>1 에서 repo 0 이 advance 안 한 경우 `state.implCommit = null` 이 되고, 이 값의 의미는 "legacy anchor 없음; 구현 결과는 `trackedRepos[*].implHead` 를 순회해 확인" 이다.
+- Phase 5 reopen 경로 (`src/phases/interactive.ts` preparePhase / resume 의 reopen 계열) 에서는 `for (const r of trackedRepos) { r.implRetryBase = getHead(r.path); r.implHead = null; }` 을 수행하고 top-level `state.implRetryBase` 도 `trackedRepos[0].implRetryBase` 로 갱신, `state.implCommit` 도 `null` 로 리셋.
 
 ### FR-7 Artifact 경로 해석 (docs home)
 
@@ -193,9 +212,12 @@ harness process
 ### FR-8 Resume 다중 repo 동작
 
 - `src/resume.ts`
-  - `ancestry check` (현재 `isAncestor(state.implCommit, 'HEAD', cwd)` 계열): `trackedRepos` 순회해 각 repo 별로 `isAncestor(r.implHead, 'HEAD', r.path)` 검사. 하나라도 실패하면 manual recovery 메시지에 실패한 repo.path 명시.
-  - `updateExternalCommitsDetected`: `trackedRepos` 순회로 per-repo external commit 감지. 어느 하나라도 발견되면 `state.externalCommitsDetected = true`.
-  - Phase 5 fresh-sentinel 재판정: FR-6 규칙 그대로 사용.
+  - **`ancestry check` (gate-2 P1 반영, null-safe)**: `trackedRepos` 순회해 각 repo 별로 다음 규칙을 적용한다 —
+    - `r.implHead !== null` 이면 `isAncestor(r.implHead, 'HEAD', r.path)` 검사. 실패 시 manual recovery 메시지에 실패한 `r.path` 를 명시하고 exit.
+    - `r.implHead === null` 이면 해당 repo 는 아직 Phase 5 가 commit 을 남기지 않은 상태 (미완료 run 또는 "advance 안 함" repo). ancestry 체크 **skip** — 검사할 anchor 가 없다.
+    - 추가적으로, `state.phases['5'] === 'completed'` 인데 모든 `r.implHead === null` 인 경우는 내부 불변식 위반 — `state_anomaly` 로그 emit 후 manual recovery.
+  - **`updateExternalCommitsDetected` (null-safe)**: `trackedRepos` 순회로 per-repo external commit 감지. 각 repo 의 anchor 는 `r.implHead ?? r.implRetryBase ?? r.baseCommit` 순으로 fallback. 어느 하나라도 external commit 발견 시 `state.externalCommitsDetected = true` 로 설정하고 emit 시 repo.path 를 로그 메시지에 포함.
+  - Phase 5 fresh-sentinel 재판정: FR-6 규칙 그대로 사용 (이미 null-safe — advance 하지 않은 repo 는 `implHead = null` 로 기록되므로 후속 ancestry/external 체크가 자동으로 skip/fallback 경로를 탄다).
 
 ### FR-9 Phase 6 verify (변경 범위)
 
@@ -206,8 +228,12 @@ harness process
 ### FR-10 CLI 플래그
 
 - `phase-harness start|run|start --light` 에 다음 반복 플래그 추가:
-  - `--track <path>` — 경로는 절대/상대 허용. 존재하지 않거나 git repo가 아니면 start 시 fail-fast (메시지: `"--track <path>: not a git repo"`).
-  - `--exclude <path>` — auto-detect 결과에서만 효력.
+  - `--track <path>` — 경로는 절대/상대 모두 입력 가능하나, **최종 해석 결과는 반드시 outer cwd 의 하위 경로여야 한다 (cwd-descendant)**. 검증 규칙 (순서대로):
+    1. `path.resolve(cwd, <path>)` 로 절대화.
+    2. `path.relative(cwd, resolved)` 가 `..` 로 시작하거나 절대경로면 fail-fast (메시지: `"--track ${path}: must be inside cwd (${cwd})"`). 이 규칙으로 ADR-N5 의 샌드박스-범위 일관성이 보장됨.
+    3. 존재하지 않으면 fail-fast (`"--track ${path}: path not found"`).
+    4. git repo (`.git` 디렉토리 또는 gitdir 파일) 가 아니면 fail-fast (`"--track ${path}: not a git repo"`).
+  - `--exclude <path>` — auto-detect 결과에서만 효력. `--track` 과 조합되면 no-op (warning 표시). `--exclude` 도 cwd-descendant 검증을 동일하게 받음 (밖 경로는 의미 없음).
 - 기존 플래그·의미 변경 없음.
 
 ---
@@ -240,18 +266,23 @@ harness process
 - `state.trackedRepos.length >= 1` 이 run 전 구간에서 항상 참.
 - `state.baseCommit === state.trackedRepos[0].baseCommit` 이 run 전 구간에서 항상 참 (write 시 동기화).
 - `state.implRetryBase === state.trackedRepos[0].implRetryBase` 이 run 전 구간에서 항상 참.
-- `trackedRepos.length === 1 && trackedRepos[0].path === cwd` 인 경우 gate diff 출력 바이트, Phase 5 판정 결과, artifact 경로, state.json 의 legacy 필드가 **구현 전과 byte-identical**.
+- `state.implCommit === state.trackedRepos[0].implHead` 가 run 전 구간에서 항상 참 (둘 다 null 허용; write 시 동기화) — gate-2 P1 반영.
+- **모든 `trackedRepos[i].path` 는 outer cwd 의 하위 경로여야 한다** (`path.relative(cwd, path).startsWith('..')` 금지) — gate-2 P1 반영.
+- `trackedRepos.length === 1 && trackedRepos[0].path === cwd` 인 경우 gate diff 출력 바이트, Phase 5 판정 결과 (`implCommit = getHead(cwd)`), artifact 경로, state.json 의 legacy 필드가 **구현 전과 byte-identical**.
 - auto-detect 는 cwd 가 git repo 일 때 **수행되지 않는다** (short-circuit).
-- `--track` 이 있으면 auto-detect 결과와 `--exclude` 는 모두 무시된다.
-- Phase 5 성공 판정은 `trackedRepos.some(r => currentHEAD(r) !== r.implRetryBase)` 로 표현 가능한 한 가지 규칙만 사용한다 (단일 HEAD 비교 금지).
+- `--track` 이 있으면 auto-detect 결과와 `--exclude` 는 모두 무시된다 (`--exclude` 단독 경고).
+- Phase 5 성공 판정은 `trackedRepos` 순회로 "어떤 repo 든 `currentHEAD(r) !== r.implRetryBase`" 에 해당하는 단일 규칙만 사용한다 (단일 HEAD 비교 금지).
+- Phase 5 성공 후 각 `r.implHead` 는 advance 한 repo 만 `getHead(r.path)` 로 설정되고, 변경 없는 repo 는 `null` 로 남는다. 이 `null` 값은 FR-8 resume ancestry 체크에서 skip 신호로 사용된다 — gate-2 P1 반영.
 - codex gate spawn 은 **항상 outer cwd** 에서 실행된다. 어떤 tracked repo 로도 chdir 하지 않는다.
 - FR-5 의 `### repo:` label 섹션은 N=1 + trackedRepos[0].path === cwd 케이스에서 **출력되지 않는다** (기존 golden fixture 보호).
+- Phase 7 metadata 의 `Harness implementation range: ${baseCommit}..${implCommit}` 단일 라인 포맷은 **N=1 single-repo 케이스에서만** 출력된다. N>1 에서는 `"Harness implementation ranges (per tracked repo):"` 블록으로 교체된다 — gate-2 P1 반영.
 
 ---
 
 ## Non-goals
 
-- 3+ depth 중첩 repo / submodule 자동 처리 — 지원 안 함. 필요 시 `--track` 명시.
+- 3+ depth 중첩 repo / submodule 자동 처리 — 지원 안 함. 필요 시 `--track` 명시 (단 cwd-descendant 여야 함).
+- **out-of-tree tracked repo** (cwd 밖의 path) — gate-2 P1 반영. codex 샌드박스 확장이 필요한 설계라 non-goal.
 - tracked repos 간 cross-repo 변경을 atomic commit 으로 묶는 기능.
 - docs-repo 전용 전담 플래그 (`--docs-repo`) — YAGNI 처리.
 - `--multi-worktree` 명시 플래그 — `trackedRepos.length >= 1` 단일 모델로 대체.
@@ -269,3 +300,14 @@ harness process
 - "docs-repo 플래그 추가?" → 기각 (YAGNI). `--track` 순서 규칙이 override 겸용.
 - "codex gate 스폰을 docs repo로?" → 기각. 항상 outer cwd, cwd 가 git 아니면 `--skip-git-repo-check` 자동.
 - "resume 다중 repo 는 후속 spec?" → 거부. Phase 5 reopen 이 resume 경로와 직결돼 있어 분리 불가능. 본 spec 범위에 포함.
+- **gate-2 P1 — `--track` 절대경로 허용 vs 샌드박스 일관성** → cwd-descendant 제약으로 해결. out-of-tree tracked repo 지원은 non-goal.
+- **gate-2 P1 — multi-repo 에서 `state.implCommit` 의미 손상** → `state.implCommit ≡ trackedRepos[0].implHead` 로 재정의 (null 허용). Phase 7 metadata 는 N=1/N>1 분기해서 포맷 변경. 소비자는 null-safe 경로 준수.
+- **gate-2 P1 — resume ancestry 체크 null 처리 부재** → `r.implHead !== null` 에서만 ancestry 검사. external-commit anchor 는 `implHead ?? implRetryBase ?? baseCommit` fallback.
+
+---
+
+## Deferred
+
+(gate-2 리뷰 피드백 중 본 pass 에서 ≤2 line 수정으로 해결할 수 없는 항목. Phase 3 plan 에서 세부 구현 설계.)
+
+- **D-1 (gate-2 P2)** — Diff size cap / `truncateDiffPerFile` 계약과 새 multi-repo `### repo:` 헤더 + fenced code block 래핑의 상호작용 미명세. 옵션: (i) raw per-repo diff 를 먼저 `truncateDiffPerFile` 한 뒤 markdown 래핑, (ii) `truncateDiffPerFile` 을 fenced block 인식하도록 확장, (iii) 전체 concat 바이트 초과 시 wholesale 버림. Phase 3 plan 에서 세부 규칙 확정 + 유닛테스트 시나리오 정의.

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -1,8 +1,18 @@
 import { execSync } from 'child_process';
 import { existsSync, unlinkSync } from 'fs';
-import { join } from 'path';
+import { join, isAbsolute } from 'path';
 import { getStagedFiles, getFileStatus, isStagedDeletion, isPathGitignored } from './git.js';
 import type { HarnessState } from './types.js';
+
+/**
+ * Resolve a (potentially relative) artifact path to an absolute path.
+ * Uses trackedRepos[0].path as the doc root (falling back to outerCwd).
+ */
+export function resolveArtifact(state: HarnessState, relPath: string, outerCwd: string): string {
+  if (isAbsolute(relPath)) return relPath;
+  const docsRoot = state.trackedRepos?.[0]?.path || outerCwd;
+  return join(docsRoot, relPath);
+}
 
 function exec(cmd: string, cwd?: string): string {
   return execSync(cmd, { cwd, encoding: 'utf-8' }).trim();

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -10,6 +10,10 @@ import type { HarnessState } from './types.js';
  */
 export function resolveArtifact(state: HarnessState, relPath: string, outerCwd: string): string {
   if (isAbsolute(relPath)) return relPath;
+  // .harness/... artifacts are system files anchored to the outer cwd, not the docs-home repo
+  if (relPath.startsWith('.harness/') || relPath.startsWith('.harness\\')) {
+    return join(outerCwd, relPath);
+  }
   const docsRoot = state.trackedRepos?.[0]?.path || outerCwd;
   return join(docsRoot, relPath);
 }

--- a/src/commands/inner.ts
+++ b/src/commands/inner.ts
@@ -30,7 +30,7 @@ export async function innerCommand(runId: string, options: InnerOptions = {}): P
   const runDir = join(harnessDir, runId);
 
   // 1. Load state
-  const state = readState(runDir);
+  const state = readState(runDir, cwd);
   if (state === null) {
     process.stderr.write(`Run '${runId}' has no state.\n`);
     process.exit(1);

--- a/src/commands/jump.ts
+++ b/src/commands/jump.ts
@@ -29,7 +29,9 @@ export async function jumpCommand(phaseArg: string, options: JumpOptions = {}): 
   }
 
   const runDir = join(harnessDir, runId);
-  const state = readState(runDir);
+  let cwd: string;
+  try { cwd = options.root ?? getGitRoot(); } catch { cwd = options.root ?? process.cwd(); }
+  const state = readState(runDir, cwd);
   if (state === null) {
     process.stderr.write(`Run '${runId}' has no state. Manual recovery required.\n`);
     process.exit(1);
@@ -51,9 +53,6 @@ export async function jumpCommand(phaseArg: string, options: JumpOptions = {}): 
     );
     process.exit(1);
   }
-
-  let cwd: string;
-  try { cwd = options.root ?? getGitRoot(); } catch { cwd = options.root ?? process.cwd(); }
 
   // Check if inner process is running (tmux architecture)
   const lock = readLock(harnessDir);

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -50,7 +50,7 @@ export async function listCommand(options: ListOptions = {}): Promise<void> {
     const stateJsonPath = join(entryPath, 'state.json');
     let state: HarnessState | null;
     try {
-      state = readState(entryPath);
+      state = readState(entryPath, process.cwd());
     } catch {
       continue;
     }

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -61,7 +61,7 @@ export async function resumeCommand(runId?: string, options: ResumeOptions = {})
 
   let state;
   try {
-    state = readState(runDir);
+    state = readState(runDir, cwd);
   } catch (err) {
     process.stderr.write(
       `state.json for run '${targetRunId}' is corrupted: ${(err as Error).message}\n`

--- a/src/commands/skip.ts
+++ b/src/commands/skip.ts
@@ -20,7 +20,9 @@ export async function skipCommand(options: SkipOptions = {}): Promise<void> {
   }
 
   const runDir = join(harnessDir, runId);
-  const state = readState(runDir);
+  let cwd: string;
+  try { cwd = options.root ?? getGitRoot(); } catch { cwd = options.root ?? process.cwd(); }
+  const state = readState(runDir, cwd);
   if (state === null) {
     process.stderr.write(`Run '${runId}' has no state. Manual recovery required.\n`);
     process.exit(1);
@@ -35,8 +37,6 @@ export async function skipCommand(options: SkipOptions = {}): Promise<void> {
     process.stderr.write(`Cannot skip: run is completed. Use 'harness jump N' to re-run a phase.\n`);
     process.exit(1);
   }
-
-  const cwd = options.root ?? getGitRoot();
 
   // Check if inner process is running (tmux architecture)
   const lock = readLock(harnessDir);

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,7 +1,8 @@
 import { execSync } from 'child_process';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync, appendFileSync } from 'fs';
-import { join } from 'path';
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync, appendFileSync } from 'fs';
+import path, { join } from 'path';
 import { getGitRoot, getHead, generateRunId, hasStagedChanges, isWorkingTreeClean, isInGitRepo } from '../git.js';
+import type { TrackedRepo } from '../types.js';
 import { acquireLock, releaseLock, setLockHandoff, pollForHandoffComplete } from '../lock.js';
 import { runPreflight } from '../preflight.js';
 import { findHarnessRoot, setCurrentRun } from '../root.js';
@@ -19,6 +20,88 @@ export interface StartOptions {
   enableLogging?: boolean;
   light?: boolean;
   codexNoIsolate?: boolean;
+  track?: string[];    // explicit tracked repos (overrides auto-detect)
+  exclude?: string[];  // paths to exclude from auto-detect
+}
+
+const SKIP_DIRS = new Set(['.harness', 'node_modules', 'dist', 'build']);
+
+export function detectTrackedRepos(
+  cwd: string,
+  track?: string[],
+  exclude?: string[],
+): TrackedRepo[] {
+  // Single-repo fast path: cwd is itself a git repo
+  if (isInGitRepo(cwd)) {
+    let head = '';
+    try { head = getHead(cwd); } catch { /* no commits */ }
+    return [{ path: cwd, baseCommit: head, implRetryBase: head, implHead: null }];
+  }
+
+  // Multi-repo path
+  if (track && track.length > 0) {
+    if (exclude && exclude.length > 0) {
+      process.stderr.write('⚠️  --exclude has no effect when --track is specified.\n');
+    }
+    const repos: TrackedRepo[] = [];
+    for (const raw of track) {
+      const resolved = path.resolve(cwd, raw);
+      const rel = path.relative(cwd, resolved);
+      if (rel.startsWith('..') || path.isAbsolute(rel)) {
+        throw new Error(`--track ${raw}: must be inside cwd (${cwd})`);
+      }
+      if (!existsSync(resolved)) {
+        throw new Error(`--track ${raw}: path not found`);
+      }
+      if (!isInGitRepo(resolved)) {
+        throw new Error(`--track ${raw}: not a git repo`);
+      }
+      let head = '';
+      try { head = getHead(resolved); } catch { /* no commits */ }
+      repos.push({ path: resolved, baseCommit: head, implRetryBase: head, implHead: null });
+    }
+    return repos;
+  }
+
+  // Auto-detect: depth=1 scan
+  const excludeSet = new Set(
+    (exclude ?? []).map(e => {
+      const resolved = path.resolve(cwd, e);
+      const rel = path.relative(cwd, resolved);
+      if (rel.startsWith('..') || path.isAbsolute(rel)) {
+        throw new Error(`--exclude ${e}: must be inside cwd (${cwd})`);
+      }
+      return resolved;
+    })
+  );
+
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(cwd, { withFileTypes: true })
+      .filter(d => {
+        if (!d.isDirectory()) return false;
+        if (d.name.startsWith('.')) return false;
+        if (SKIP_DIRS.has(d.name)) return false;
+        return true;
+      })
+      .map(d => path.join(cwd, d.name))
+      .filter(p => !excludeSet.has(p) && isInGitRepo(p))
+      .sort();
+  } catch {
+    entries = [];
+  }
+
+  if (entries.length === 0) {
+    throw new Error(
+      'No tracked git repos found under cwd. Pass --track <path> or run from a git repo.'
+    );
+  }
+
+  return entries.map(p => {
+    let head = '';
+    try { head = getHead(p); } catch { /* no commits */ }
+    return { path: p, baseCommit: head, implRetryBase: head, implHead: null };
+  });
 }
 
 export async function startCommand(task: string | undefined, options: StartOptions = {}): Promise<void> {
@@ -75,6 +158,31 @@ export async function startCommand(task: string | undefined, options: StartOptio
     }
   }
 
+  // 5b. Detect tracked repos (fail-fast before any side effects)
+  let trackedRepos: TrackedRepo[];
+  try {
+    trackedRepos = detectTrackedRepos(cwd, options.track, options.exclude);
+  } catch (err) {
+    process.stderr.write(`Error: ${(err as Error).message}\n`);
+    process.exit(1);
+  }
+
+  // Print detection summary when multi-repo
+  if (trackedRepos.length > 1) {
+    const paths = trackedRepos.map(r => r.path).join(', ');
+    process.stderr.write(`Detected ${trackedRepos.length} tracked repos: [${paths}]\n`);
+  }
+
+  // Per-repo preflight (git + head checks)
+  for (const repo of trackedRepos) {
+    try {
+      runPreflight(['git', 'head'], repo.path);
+    } catch (err) {
+      process.stderr.write(`Error: ${(err as Error).message}\n`);
+      process.exit(1);
+    }
+  }
+
   // 6. Generate runId
   const runId = generateRunId(normalizedTask, harnessDir);
   const runDir = join(harnessDir, runId);
@@ -96,19 +204,25 @@ export async function startCommand(task: string | undefined, options: StartOptio
   try {
     // 9. Create directories
     mkdirSync(runDir, { recursive: true });
-    mkdirSync(join(cwd, 'docs/specs'), { recursive: true });
-    mkdirSync(join(cwd, 'docs/plans'), { recursive: true });
-    mkdirSync(join(cwd, 'docs/process/evals'), { recursive: true });
+    const docsRoot = trackedRepos[0].path;
+    mkdirSync(join(docsRoot, 'docs/specs'), { recursive: true });
+    mkdirSync(join(docsRoot, 'docs/plans'), { recursive: true });
+    mkdirSync(join(docsRoot, 'docs/process/evals'), { recursive: true });
 
     // 10. .gitignore handling (skip if not in git repo)
     if (inGitRepo) {
       await ensureGitignore(cwd);
     }
 
-    // 11. Capture baseCommit after .gitignore commit (empty string if no git)
-    let baseCommit = '';
+    // 11. Capture baseCommit from trackedRepos[0] (already captured by detectTrackedRepos)
+    // Re-read HEAD after .gitignore commit (which may have advanced HEAD)
+    let baseCommit = trackedRepos[0].baseCommit;
     if (inGitRepo) {
-      try { baseCommit = getHead(cwd); } catch { /* no commits yet */ }
+      try {
+        const updatedHead = getHead(trackedRepos[0].path);
+        baseCommit = updatedHead;
+        trackedRepos[0] = { ...trackedRepos[0], baseCommit: updatedHead, implRetryBase: updatedHead };
+      } catch { /* no commits yet */ }
     }
 
     // 12. Create initial state
@@ -121,6 +235,9 @@ export async function startCommand(task: string | undefined, options: StartOptio
       options.light ? 'light' : 'full',
       options.codexNoIsolate ?? false,
     );
+
+    // Inject detected tracked repos (overrides the placeholder set by createInitialState)
+    state.trackedRepos = trackedRepos;
 
     if (options.codexNoIsolate) {
       // BUG-C risk surface: user explicitly bypassed isolation.

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process';
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync, appendFileSync } from 'fs';
+import fs, { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync, appendFileSync } from 'fs';
 import path, { join } from 'path';
 import { getGitRoot, getHead, generateRunId, hasStagedChanges, isWorkingTreeClean, isInGitRepo } from '../git.js';
 import type { TrackedRepo } from '../types.js';
@@ -55,6 +55,13 @@ export function detectTrackedRepos(
       }
       if (!isInGitRepo(resolved)) {
         throw new Error(`--track ${raw}: not a git repo`);
+      }
+      const gitRoot = getGitRoot(resolved);
+      // Normalize both sides to resolve OS symlinks (e.g. /var → /private/var on macOS)
+      let realResolved: string;
+      try { realResolved = fs.realpathSync(resolved); } catch { realResolved = resolved; }
+      if (gitRoot !== realResolved) {
+        throw new Error(`--track ${raw}: path must be a git repo root (found root at ${gitRoot})`);
       }
       let head = '';
       try { head = getHead(resolved); } catch { /* no commits */ }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -22,7 +22,7 @@ export async function statusCommand(options: StatusOptions = {}): Promise<void> 
   const runDir = join(harnessDir, runId);
   let state: HarnessState | null;
   try {
-    state = readState(runDir);
+    state = readState(runDir, process.cwd());
   } catch (err) {
     process.stderr.write(
       `Run '${runId}' state is corrupted: ${(err as Error).message}\n`

--- a/src/context/assembler.ts
+++ b/src/context/assembler.ts
@@ -374,10 +374,8 @@ function buildPhase7DiffAndMetadata(state: HarnessState, cwd: string): { diffSec
         }
         return d;
       } else {
-        // No impl anchor — diff base...HEAD (cannot separate external)
-        let d = runGit(`git diff ${repo.baseCommit}...HEAD`, repo.path);
-        d = truncateDiffPerFile(d, PER_FILE_DIFF_LIMIT_KB * 1024);
-        return d;
+        // No impl anchor — exclude from harness diff to avoid mixing unreviewed external changes
+        return `(no harness implementation anchor for this repo — diff excluded; external commits may exist)`;
       }
     } else {
       let d = runGit(`git diff ${repo.baseCommit}...HEAD`, repo.path);

--- a/src/context/assembler.ts
+++ b/src/context/assembler.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
-import type { HarnessState, FlowMode } from '../types.js';
+import type { HarnessState, FlowMode, TrackedRepo } from '../types.js';
 import {
   MAX_FILE_SIZE_KB,
   MAX_PROMPT_SIZE_KB,
@@ -312,7 +312,8 @@ function buildLifecycleContext(phase: 2 | 4 | 7, flow: FlowMode = 'full'): strin
 // ─── Gate 2: Spec review ─────────────────────────────────────────────────────
 
 function buildGatePromptPhase2(state: HarnessState, cwd: string): string | { error: string } {
-  const specResult = readArtifactContent(state.artifacts.spec, cwd);
+  const docsRoot = state.trackedRepos?.[0]?.path || cwd;
+  const specResult = readArtifactContent(state.artifacts.spec, docsRoot);
   if ('error' in specResult) return specResult;
 
   if (state.flow === 'light') {
@@ -333,10 +334,11 @@ function buildGatePromptPhase2(state: HarnessState, cwd: string): string | { err
 // ─── Gate 4: Plan review (spec + plan, per spec) ─────────────────────────────
 
 function buildGatePromptPhase4(state: HarnessState, cwd: string): string | { error: string } {
-  const specResult = readArtifactContent(state.artifacts.spec, cwd);
+  const docsRoot = state.trackedRepos?.[0]?.path || cwd;
+  const specResult = readArtifactContent(state.artifacts.spec, docsRoot);
   if ('error' in specResult) return specResult;
 
-  const planResult = readArtifactContent(state.artifacts.plan, cwd);
+  const planResult = readArtifactContent(state.artifacts.plan, docsRoot);
   if ('error' in planResult) return planResult;
 
   return (
@@ -353,54 +355,125 @@ function buildGatePromptPhase4(state: HarnessState, cwd: string): string | { err
 // prompt and the resume prompt so resume variants include the same external-
 // commit handling and metadata block as the first-time review.
 function buildPhase7DiffAndMetadata(state: HarnessState, cwd: string): { diffSection: string; externalSummary: string; metadata: string } {
-  let diffSection: string;
-  let externalSummary = '';
+  const repos = (state.trackedRepos && state.trackedRepos.length > 0)
+    ? state.trackedRepos
+    : [{ path: cwd, baseCommit: state.baseCommit, implRetryBase: state.implRetryBase, implHead: state.implCommit } as TrackedRepo];
 
-  if (state.externalCommitsDetected) {
-    let primary = '';
-    if (state.implCommit !== null) {
-      primary += runGit(`git diff ${state.baseCommit}...${state.implCommit}`, cwd);
-      if (state.evalCommit !== null) {
-        primary += '\n' + runGit(`git diff ${state.evalCommit}^..${state.evalCommit}`, cwd);
+  const isSingleRepoCwd = repos.length === 1 && repos[0].path === cwd;
+
+  // Per-repo diff builder (ADR-D1: truncateDiffPerFile before markdown wrapping)
+  function buildRepoDiff(repo: TrackedRepo): string {
+    if (state.externalCommitsDetected) {
+      if (repo.implHead !== null) {
+        let d = runGit(`git diff ${repo.baseCommit}...${repo.implHead}`, repo.path);
+        // Per-repo pre-truncation before wrapping (ADR-D1)
+        d = truncateDiffPerFile(d, PER_FILE_DIFF_LIMIT_KB * 1024);
+        // For docs-home repo (trackedRepos[0]), also include eval commit diff
+        if (repo === repos[0] && state.evalCommit !== null) {
+          d += '\n' + runGit(`git diff ${state.evalCommit}^..${state.evalCommit}`, repo.path);
+        }
+        return d;
+      } else {
+        // No impl anchor — diff base...HEAD (cannot separate external)
+        let d = runGit(`git diff ${repo.baseCommit}...HEAD`, repo.path);
+        d = truncateDiffPerFile(d, PER_FILE_DIFF_LIMIT_KB * 1024);
+        return d;
       }
     } else {
+      let d = runGit(`git diff ${repo.baseCommit}...HEAD`, repo.path);
+      d = truncateDiffPerFile(d, PER_FILE_DIFF_LIMIT_KB * 1024);
+      return d;
+    }
+  }
+
+  let combinedDiff: string;
+  if (isSingleRepoCwd) {
+    // N=1 backward path: raw diff, no ### repo: label (ADR-N7, FR-5 invariant)
+    // For N=1 + externalCommitsDetected with null implCommit, preserve the ⚠️ prefix
+    if (state.externalCommitsDetected && repos[0].implHead === null) {
       const target = state.evalCommit ?? 'HEAD';
-      primary = runGit(`git diff ${state.baseCommit}...${target}`, cwd);
+      let primary = runGit(`git diff ${state.baseCommit}...${target}`, cwd);
+      const maxDiffBytes = MAX_DIFF_SIZE_KB * 1024;
+      if (primary.length > maxDiffBytes) {
+        primary = truncateDiffPerFile(primary, PER_FILE_DIFF_LIMIT_KB * 1024);
+      }
       primary =
         `⚠️ IMPORTANT: Phase 5 was skipped and external commits were detected. ` +
         `The primary diff below includes BOTH harness and external changes — they cannot be separated. ` +
         `Focus on the eval report and spec/plan compliance rather than the diff.\n\n` +
         primary;
-    }
-
-    const maxDiffBytes = MAX_DIFF_SIZE_KB * 1024;
-    if (primary.length > maxDiffBytes) {
-      primary = truncateDiffPerFile(primary, PER_FILE_DIFF_LIMIT_KB * 1024);
-    }
-
-    diffSection = `<diff>\n${primary}\n</diff>\n`;
-
-    const anchor = state.evalCommit ?? state.implCommit ?? state.baseCommit;
-    const externalLog = runGit(`git log ${anchor}..HEAD --oneline`, cwd);
-    if (externalLog.trim().length > 0) {
-      externalSummary = `\n## External Commits (not reviewed)\n\n\`\`\`\n${externalLog}\n\`\`\`\n`;
+      combinedDiff = primary;
+    } else {
+      combinedDiff = buildRepoDiff(repos[0]);
     }
   } else {
-    let diff = runGit(`git diff ${state.baseCommit}...HEAD`, cwd);
-    const maxDiffBytes = MAX_DIFF_SIZE_KB * 1024;
-    if (diff.length > maxDiffBytes) {
-      diff = truncateDiffPerFile(diff, PER_FILE_DIFF_LIMIT_KB * 1024);
+    // Multi-repo: concat with ### repo: labels
+    const sections: string[] = [];
+    for (const repo of repos) {
+      const relOrAbs = path.relative(cwd, repo.path) || repo.path;
+      const rawDiff = buildRepoDiff(repo);
+      sections.push(`### repo: ${relOrAbs}\n\`\`\`diff\n${rawDiff}\n\`\`\``);
     }
-    diffSection = diff ? `<diff>\n${diff}\n</diff>\n` : '';
+    combinedDiff = sections.join('\n\n');
   }
 
+  // Global size cap after concat (ADR-D1)
+  const maxDiffBytes = MAX_DIFF_SIZE_KB * 1024;
+  if (combinedDiff.length > maxDiffBytes) {
+    combinedDiff = combinedDiff.slice(0, maxDiffBytes) +
+      `\n--- (diff truncated: total exceeds ${MAX_DIFF_SIZE_KB}KB) ---\n`;
+  }
+
+  const diffSection = combinedDiff ? `<diff>\n${combinedDiff}\n</diff>\n` : '';
+
+  // External commits summary
+  let externalSummary = '';
+  if (state.externalCommitsDetected) {
+    if (isSingleRepoCwd) {
+      // N=1: existing format
+      const anchor = state.evalCommit ?? state.implCommit ?? state.baseCommit;
+      const externalLog = runGit(`git log ${anchor}..HEAD --oneline`, cwd);
+      if (externalLog.trim().length > 0) {
+        externalSummary = `\n## External Commits (not reviewed)\n\n\`\`\`\n${externalLog}\n\`\`\`\n`;
+      }
+    } else {
+      // N>1: per-repo sections
+      const sections: string[] = [];
+      for (const repo of repos) {
+        const anchor = repo.implHead ?? repo.implRetryBase ?? repo.baseCommit;
+        const externalLog = runGit(`git log ${anchor}..HEAD --oneline`, repo.path);
+        if (externalLog.trim().length > 0) {
+          const relOrAbs = path.relative(cwd, repo.path) || repo.path;
+          sections.push(`### ${relOrAbs}\n\`\`\`\n${externalLog}\n\`\`\``);
+        }
+      }
+      if (sections.length > 0) {
+        externalSummary = `\n## External Commits (not reviewed)\n\n${sections.join('\n\n')}\n`;
+      }
+    }
+  }
+
+  // Metadata block: N=1 vs N>1 format (FR-5, gate-2 P1)
   const externalNote = state.externalCommitsDetected
     ? `Note: External commits detected. See '## External Commits (not reviewed)' section below.\nPrimary diff covers harness implementation range only.\n`
     : '';
-  const implRange =
-    state.implCommit !== null
+
+  let implRange: string;
+  if (isSingleRepoCwd) {
+    // N=1: preserve existing single-line format (backward compat)
+    implRange = state.implCommit !== null
       ? `Harness implementation range: ${state.baseCommit}..${state.implCommit} (Phase 1–5 commits).`
       : `Phase 5 skipped; no implementation commit anchor.`;
+  } else {
+    // N>1: per-repo format
+    const lines = repos.map(repo => {
+      const relOrAbs = path.relative(cwd, repo.path) || repo.path;
+      return repo.implHead !== null
+        ? `  - ${relOrAbs}: ${repo.baseCommit}..${repo.implHead}`
+        : `  - ${relOrAbs}: no change (baseCommit=${repo.baseCommit})`;
+    });
+    implRange = `Harness implementation ranges (per tracked repo):\n${lines.join('\n')}`;
+  }
 
   const metadata =
     `<metadata>\n${externalNote}${implRange}\n` +
@@ -413,10 +486,11 @@ function buildPhase7DiffAndMetadata(state: HarnessState, cwd: string): { diffSec
 }
 
 function buildGatePromptPhase7(state: HarnessState, cwd: string): string | { error: string } {
-  const specResult = readArtifactContent(state.artifacts.spec, cwd);
+  const docsRoot = state.trackedRepos?.[0]?.path || cwd;
+  const specResult = readArtifactContent(state.artifacts.spec, docsRoot);
   if ('error' in specResult) return specResult;
 
-  const evalResult = readArtifactContent(state.artifacts.evalReport, cwd);
+  const evalResult = readArtifactContent(state.artifacts.evalReport, docsRoot);
   if ('error' in evalResult) return evalResult;
 
   const { diffSection, externalSummary, metadata } = buildPhase7DiffAndMetadata(state, cwd);
@@ -434,7 +508,7 @@ function buildGatePromptPhase7(state: HarnessState, cwd: string): string | { err
     );
   }
 
-  const planResult = readArtifactContent(state.artifacts.plan, cwd);
+  const planResult = readArtifactContent(state.artifacts.plan, docsRoot);
   if ('error' in planResult) return planResult;
 
   return (
@@ -588,19 +662,20 @@ function buildResumeSections(
   state: HarnessState,
   cwd: string,
 ): string | { error: string } {
-  const specResult = readArtifactContent(state.artifacts.spec, cwd);
+  const docsRoot = state.trackedRepos?.[0]?.path || cwd;
+  const specResult = readArtifactContent(state.artifacts.spec, docsRoot);
   if ('error' in specResult) return specResult;
   let body = `<spec>\n${specResult.content}\n</spec>\n`;
 
   const lightEvalGate = phase === 7 && state.flow === 'light';
 
   if ((phase === 4 || phase === 7) && !lightEvalGate) {
-    const planResult = readArtifactContent(state.artifacts.plan, cwd);
+    const planResult = readArtifactContent(state.artifacts.plan, docsRoot);
     if ('error' in planResult) return planResult;
     body += `\n<plan>\n${planResult.content}\n</plan>\n`;
   }
   if (phase === 7) {
-    const evalResult = readArtifactContent(state.artifacts.evalReport, cwd);
+    const evalResult = readArtifactContent(state.artifacts.evalReport, docsRoot);
     if ('error' in evalResult) return evalResult;
     body += `\n<eval_report>\n${evalResult.content}\n</eval_report>\n`;
 

--- a/src/phases/interactive.ts
+++ b/src/phases/interactive.ts
@@ -82,7 +82,13 @@ export function preparePhase(
 
   // Phase 5: update implRetryBase to current HEAD
   if (phase === 5) {
-    try { state.implRetryBase = getHead(cwd); } catch { /* no git */ }
+    try {
+      const head = getHead(cwd);
+      state.implRetryBase = head;
+      if (state.trackedRepos?.[0]) {
+        state.trackedRepos[0].implRetryBase = head;
+      }
+    } catch { /* no git */ }
   }
 
   // Clear the reopen flag after using it

--- a/src/phases/interactive.ts
+++ b/src/phases/interactive.ts
@@ -1,16 +1,16 @@
 import fs from 'fs';
 import path from 'path';
 import { randomUUID } from 'crypto';
-import { execSync } from 'child_process';
 import chokidar from 'chokidar';
 import type { HarnessState, InteractivePhase, Artifacts } from '../types.js';
 import { getPhaseArtifactFiles, getPresetById } from '../config.js';
-import { writeState } from '../state.js';
+import { writeState, syncLegacyMirror } from '../state.js';
 import { getHead } from '../git.js';
 import { isPidAlive } from '../process.js';
 import { assembleInteractivePrompt } from '../context/assembler.js';
 import { runClaudeInteractive } from '../runners/claude.js';
 import { isValidChecklistSchema } from './checklist.js';
+import { resolveArtifact } from '../artifact.js';
 
 /**
  * Inline Complexity-section check (spec R5). Kept here instead of importing
@@ -67,7 +67,7 @@ export function preparePhase(
     for (const key of artifactKeys) {
       const relPath = state.artifacts[key];
       if (!relPath) continue;
-      const absPath = path.isAbsolute(relPath) ? relPath : path.join(cwd, relPath);
+      const absPath = resolveArtifact(state, relPath, cwd);
       try { fs.unlinkSync(absPath); } catch { /* ignore */ }
     }
   }
@@ -80,15 +80,13 @@ export function preparePhase(
     [String(phase)]: Math.floor(Date.now() / 1000) * 1000,
   };
 
-  // Phase 5: update implRetryBase to current HEAD
+  // Phase 5: update implRetryBase for each tracked repo to current HEAD
   if (phase === 5) {
-    try {
-      const head = getHead(cwd);
-      state.implRetryBase = head;
-      if (state.trackedRepos?.[0]) {
-        state.trackedRepos[0].implRetryBase = head;
-      }
-    } catch { /* no git */ }
+    for (const r of state.trackedRepos) {
+      try { r.implRetryBase = getHead(r.path); } catch { /* no git */ }
+      r.implHead = null;
+    }
+    syncLegacyMirror(state);
   }
 
   // Clear the reopen flag after using it
@@ -135,7 +133,7 @@ export function validatePhaseArtifacts(
 
     for (const key of artifactKeys) {
       const relPath = state.artifacts[key];
-      const absPath = path.isAbsolute(relPath) ? relPath : path.join(cwd, relPath);
+      const absPath = resolveArtifact(state, relPath, cwd);
       try {
         const stat = fs.statSync(absPath);
         // Must be non-empty. Freshness is proven by sentinel attemptId, not mtime:
@@ -149,18 +147,14 @@ export function validatePhaseArtifacts(
 
     // Phase 3: validate checklist.json schema
     if (phase === 3) {
-      const checklistPath = path.isAbsolute(state.artifacts.checklist)
-        ? state.artifacts.checklist
-        : path.join(cwd, state.artifacts.checklist);
+      const checklistPath = resolveArtifact(state, state.artifacts.checklist, cwd);
       if (!isValidChecklistSchema(checklistPath)) return false;
     }
 
     // Phase 1 (both full + light flows): spec must contain a valid
     // `## Complexity` section with one of Small/Medium/Large (spec R5).
     if (phase === 1) {
-      const specPath = path.isAbsolute(state.artifacts.spec)
-        ? state.artifacts.spec
-        : path.join(cwd, state.artifacts.spec);
+      const specPath = resolveArtifact(state, state.artifacts.spec, cwd);
       try {
         const body = fs.readFileSync(specPath, 'utf-8');
         if (!specHasValidComplexity(body)) return false;
@@ -171,14 +165,10 @@ export function validatePhaseArtifacts(
 
     // Light + phase 1: checklist schema + '## Implementation Plan' header
     if (state.flow === 'light' && phase === 1) {
-      const checklistPath = path.isAbsolute(state.artifacts.checklist)
-        ? state.artifacts.checklist
-        : path.join(cwd, state.artifacts.checklist);
+      const checklistPath = resolveArtifact(state, state.artifacts.checklist, cwd);
       if (!isValidChecklistSchema(checklistPath)) return false;
 
-      const specPath = path.isAbsolute(state.artifacts.spec)
-        ? state.artifacts.spec
-        : path.join(cwd, state.artifacts.spec);
+      const specPath = resolveArtifact(state, state.artifacts.spec, cwd);
       try {
         const body = fs.readFileSync(specPath, 'utf-8');
         if (!/^##\s+Implementation\s+Plan\s*$/m.test(body)) return false;
@@ -192,10 +182,22 @@ export function validatePhaseArtifacts(
 
   if (phase === 5) {
     void runDir;
+    // Zero-commit reopen: if a prior attempt already set implHead on some repo, accept.
+    if (state.trackedRepos.some(r => r.implHead !== null)) return true;
     try {
-      const head = execSync('git rev-parse HEAD', { cwd, encoding: 'utf-8' }).trim();
-      if (head !== state.implRetryBase) return true;
-      return state.implCommit !== null;
+      let anyAdvanced = false;
+      for (const r of state.trackedRepos) {
+        const h = getHead(r.path);
+        if (h !== r.implRetryBase) {
+          r.implHead = h;
+          anyAdvanced = true;
+        } else {
+          r.implHead = null;
+        }
+      }
+      if (!anyAdvanced) return false;
+      syncLegacyMirror(state); // sets state.implCommit = trackedRepos[0].implHead
+      return true;
     } catch {
       return false;
     }

--- a/src/phases/runner.ts
+++ b/src/phases/runner.ts
@@ -12,9 +12,9 @@ import {
   getPresetById,
   getReopenTarget,
 } from '../config.js';
-import { writeState } from '../state.js';
+import { writeState, syncLegacyMirror } from '../state.js';
 import { getHead, isPathGitignored } from '../git.js';
-import { commitEvalReport, normalizeArtifactCommit } from '../artifact.js';
+import { commitEvalReport, normalizeArtifactCommit, resolveArtifact } from '../artifact.js';
 import { runInteractivePhase } from './interactive.js';
 import { runGatePhase } from './gate.js';
 import { runVerifyPhase } from './verify.js';
@@ -176,6 +176,8 @@ function normalizeInteractiveArtifacts(
   const artifactKeys = getPhaseArtifactFiles(state.flow, phase);
   if (artifactKeys.length === 0) return;
 
+  const docsRoot = state.trackedRepos?.[0]?.path || cwd;
+
   for (const key of artifactKeys) {
     const relPath = state.artifacts[key];
     if (!relPath) continue;
@@ -183,7 +185,7 @@ function normalizeInteractiveArtifacts(
     if (relPath.startsWith('.harness/')) continue;
 
     const message = `harness[${state.runId}]: Phase ${phase} — ${String(key)}`;
-    normalizeArtifactCommit(relPath, message, cwd);
+    normalizeArtifactCommit(relPath, message, docsRoot);
   }
 }
 
@@ -210,7 +212,8 @@ function writeSyntheticEvalReport(
 
 function savePausedAtHead(state: HarnessState, cwd: string): void {
   try {
-    state.pausedAtHead = getHead(cwd);
+    const docsRoot = state.trackedRepos?.[0]?.path || cwd;
+    state.pausedAtHead = getHead(docsRoot);
   } catch {
     // git not available — leave as null
   }
@@ -446,10 +449,11 @@ export async function handleInteractivePhase(
 
       // Update commit anchors (only AFTER commit succeeds)
       try {
-        const head = getHead(cwd);
+        const docsRoot = state.trackedRepos?.[0]?.path || cwd;
+        const head = getHead(docsRoot);
         if (phase === 1) state.specCommit = head;
         if (phase === 3) state.planCommit = head;
-        if (phase === 5) state.implCommit = head;
+        if (phase === 5) syncLegacyMirror(state); // implHead already set by validatePhaseArtifacts
       } catch {
         // getHead unavailable — leave anchor as-is
       }
@@ -979,10 +983,12 @@ export async function handleVerifyPhase(
     // Emit verify_result before commit attempt (runVerifyPhase did pass)
     logger.logEvent({ event: 'verify_result', passed: true, retryIndex, durationMs });
 
+    const docsRoot = state.trackedRepos?.[0]?.path || cwd;
+
     // Commit the eval report artifact (spec requires committed eval report before Phase 7)
     let evalCommitResult: 'committed' | 'skipped';
     try {
-      evalCommitResult = commitEvalReport(state, cwd);
+      evalCommitResult = commitEvalReport(state, docsRoot);
     } catch (err) {
       // Commit failure → phase goes to error, pendingAction for retry
       printError(`Failed to commit eval report: ${(err as Error).message}`);
@@ -1004,7 +1010,7 @@ export async function handleVerifyPhase(
     // Clear any stale anchors when the commit was skipped (gitignored path).
     if (evalCommitResult === 'committed') {
       try {
-        const head = getHead(cwd);
+        const head = getHead(docsRoot);
         state.evalCommit = head;
         state.verifiedAtHead = head;
       } catch {
@@ -1182,19 +1188,21 @@ export async function forcePassVerify(
   // Emit force_pass as the sole terminal event for this path
   logger.logEvent({ event: 'force_pass', phase: 6, by });
 
+  const docsRoot = state.trackedRepos?.[0]?.path || cwd;
+
   // Write synthetic eval report
-  writeSyntheticEvalReport(state.artifacts.evalReport, state.runId, cwd);
+  writeSyntheticEvalReport(state.artifacts.evalReport, state.runId, docsRoot);
 
   // Normalize the synthetic report — failure must mark phase as error (not silently skip)
   const message = `harness[${state.runId}]: Phase 6 — synthetic eval report (skip)`;
-  const synthCommitted = !isPathGitignored(state.artifacts.evalReport, cwd);
+  const synthCommitted = !isPathGitignored(state.artifacts.evalReport, docsRoot);
   if (!synthCommitted) {
     process.stderr.write(
       `⚠️  eval report path '${state.artifacts.evalReport}' is gitignored — skipping commit (evalCommit will remain null).\n`
     );
   } else {
     try {
-      normalizeArtifactCommit(state.artifacts.evalReport, message, cwd);
+      normalizeArtifactCommit(state.artifacts.evalReport, message, docsRoot);
     } catch (err) {
       printError(`Failed to commit synthetic eval report: ${(err as Error).message}`);
       state.phases['6'] = 'error';
@@ -1209,7 +1217,7 @@ export async function forcePassVerify(
   // Clear any stale anchors when skipped (gitignored path).
   if (synthCommitted) {
     try {
-      const head = getHead(cwd);
+      const head = getHead(docsRoot);
       state.evalCommit = head;
       state.verifiedAtHead = head;
     } catch {

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -97,7 +97,8 @@ function runItem(item: PreflightItem, cwd?: string): { codexPath?: string } {
       try {
         execSync('git rev-parse --show-toplevel', { cwd, stdio: 'pipe' });
       } catch {
-        throw new Error('harness requires a git repository.');
+        const suffix = cwd ? ` in: ${cwd}` : '.';
+        throw new Error(`harness requires a git repository${suffix}`);
       }
       return {};
 
@@ -105,7 +106,8 @@ function runItem(item: PreflightItem, cwd?: string): { codexPath?: string } {
       try {
         execSync('git rev-parse HEAD', { cwd, stdio: 'pipe' });
       } catch {
-        throw new Error('harness requires at least one commit.');
+        const suffix = cwd ? ` in: ${cwd}` : '.';
+        throw new Error(`harness requires at least one commit${suffix}`);
       }
       return {};
 

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -480,7 +480,8 @@ function validateAncestry(state: HarnessState, cwd: string): void {
       }
     }
     if (state.phases['6'] === 'completed' && state.evalCommit) {
-      if (!isAncestor(state.evalCommit, 'HEAD', cwd)) {
+      const evalAncestryRoot = state.trackedRepos?.[0]?.path || cwd;
+      if (!isAncestor(state.evalCommit, 'HEAD', evalAncestryRoot)) {
         process.stderr.write(
           `Eval report commit is no longer in git history.\n` +
           `Use 'phase-harness jump 6' to re-run verification.\n`

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -2,8 +2,8 @@ import { existsSync, readFileSync, statSync, unlinkSync } from 'fs';
 import { execSync } from 'child_process';
 import { isAbsolute, join } from 'path';
 import { getHead, isAncestor, detectExternalCommits, isPathGitignored } from './git.js';
-import { readState, writeState } from './state.js';
-import { commitEvalReport, normalizeArtifactCommit } from './artifact.js';
+import { readState, writeState, syncLegacyMirror } from './state.js';
+import { commitEvalReport, normalizeArtifactCommit, resolveArtifact } from './artifact.js';
 import { checkGateSidecars } from './phases/gate.js';
 import { readVerifyResult, isEvalReportValid } from './phases/verify.js';
 import {
@@ -329,32 +329,33 @@ async function applyStoredVerifyResult(
 }
 
 function validateCompletedArtifacts(state: HarnessState, cwd: string): void {
+  const docsRoot = state.trackedRepos?.[0]?.path || cwd;
   // Phase 1 completed: spec + decisionLog must exist and be non-empty
   if (state.phases['1'] === 'completed') {
-    requireNonEmpty(join(cwd, state.artifacts.spec), 'spec', state.runId);
+    requireNonEmpty(resolveArtifact(state, state.artifacts.spec, cwd), 'spec', state.runId);
     requireNonEmpty(join(cwd, state.artifacts.decisionLog), 'decision log', state.runId);
     // Check spec is not modified since committed (decisionLog is gitignored — skip)
-    requireCommittedClean(state.artifacts.spec, state.specCommit, cwd);
+    requireCommittedClean(state.artifacts.spec, state.specCommit, docsRoot);
   }
   // Phase 3 completed: plan + checklist
   if (state.phases['3'] === 'completed') {
-    requireNonEmpty(join(cwd, state.artifacts.plan), 'plan', state.runId);
+    requireNonEmpty(resolveArtifact(state, state.artifacts.plan, cwd), 'plan', state.runId);
     requireNonEmpty(join(cwd, state.artifacts.checklist), 'checklist', state.runId);
-    // Validate checklist schema
+    // Validate checklist schema (checklist is in .harness/ = outer cwd)
     requireValidChecklist(join(cwd, state.artifacts.checklist));
     // Check plan is not modified since committed (checklist is gitignored — skip)
-    requireCommittedClean(state.artifacts.plan, state.planCommit, cwd);
+    requireCommittedClean(state.artifacts.plan, state.planCommit, docsRoot);
   }
   // Phase 6 completed: eval report
   if (state.phases['6'] === 'completed') {
-    if (!isEvalReportValid(join(cwd, state.artifacts.evalReport))) {
+    if (!isEvalReportValid(resolveArtifact(state, state.artifacts.evalReport, cwd))) {
       process.stderr.write(
         `Artifact missing or invalid for completed phase 6: ${state.artifacts.evalReport}.\n` +
         `Use 'phase-harness jump 6' to re-run from that phase.\n`
       );
       process.exit(1);
     }
-    requireCommittedClean(state.artifacts.evalReport, state.evalCommit, cwd);
+    requireCommittedClean(state.artifacts.evalReport, state.evalCommit, docsRoot);
   }
 }
 
@@ -454,13 +455,28 @@ function validateAncestry(state: HarnessState, cwd: string): void {
       }
     }
     if (state.phases['5'] === 'completed') {
-      const anchor = state.implCommit ?? state.baseCommit;
-      if (!isAncestor(anchor, 'HEAD', cwd)) {
+      // Check all-null invariant (only when trackedRepos have real paths set —
+      // legacy single-repo states have path='' and null implHead is normal for skips)
+      const hasRealPaths = state.trackedRepos.some(r => r.path !== '');
+      const allNull = state.trackedRepos.every(r => r.implHead === null);
+      if (hasRealPaths && allNull) {
         process.stderr.write(
-          `Implementation commit is no longer in git history.\n` +
+          `Phase 5 completed but all trackedRepos[*].implHead are null — state anomaly.\n` +
           `Manual recovery required.\n`
         );
         process.exit(1);
+      }
+      // Per-repo ancestry check (null-safe: skip repos with no anchor)
+      for (const repo of state.trackedRepos) {
+        if (repo.implHead === null) continue;
+        if (!repo.path) continue; // legacy empty-path repo — skip git check
+        if (!isAncestor(repo.implHead, 'HEAD', repo.path)) {
+          process.stderr.write(
+            `Implementation commit is no longer in git history (repo: ${repo.path}).\n` +
+            `Manual recovery required.\n`
+          );
+          process.exit(1);
+        }
       }
     }
     if (state.phases['6'] === 'completed' && state.evalCommit) {
@@ -481,16 +497,22 @@ function validateAncestry(state: HarnessState, cwd: string): void {
 
 function updateExternalCommitsDetected(state: HarnessState, cwd: string, runDir: string): void {
   try {
-    const anchor = state.pausedAtHead ?? state.baseCommit;
-    const knownAnchors = [state.specCommit, state.planCommit, state.implCommit, state.evalCommit];
-    const implRange = state.implCommit
-      ? { from: state.baseCommit, to: state.implCommit }
-      : null;
-    const external = detectExternalCommits(anchor, knownAnchors, implRange, cwd);
-    if (external.length > 0) {
-      process.stderr.write(`⚠️  External commits detected (${external.length} commits).\n`);
-      state.externalCommitsDetected = true;
-      writeState(runDir, state);
+    for (const repo of state.trackedRepos) {
+      const repoCwd = repo.path || cwd;
+      const anchor = repo.implHead ?? repo.implRetryBase ?? repo.baseCommit;
+      const isDocsHome = repo === state.trackedRepos[0];
+      const knownAnchors = isDocsHome
+        ? [state.specCommit, state.planCommit, repo.implHead, state.evalCommit]
+        : [repo.implHead];
+      const implRange = repo.implHead
+        ? { from: repo.baseCommit, to: repo.implHead }
+        : null;
+      const external = detectExternalCommits(anchor, knownAnchors, implRange, repoCwd);
+      if (external.length > 0) {
+        process.stderr.write(`⚠️  External commits detected in ${repoCwd} (${external.length} commits).\n`);
+        state.externalCommitsDetected = true;
+        writeState(runDir, state);
+      }
     }
   } catch {
     // Non-fatal
@@ -520,10 +542,12 @@ export function completeInteractivePhaseFromFreshSentinel(
       const artifactKeys = getPhaseArtifactFiles(state.flow, phase);
       if (artifactKeys.length === 0) return false;
 
+      const docsRoot = state.trackedRepos?.[0]?.path || cwd;
+
       for (const key of artifactKeys) {
         const relPath = state.artifacts[key];
         if (!relPath) return false;
-        const absPath = isAbsolute(relPath) ? relPath : join(cwd, relPath);
+        const absPath = isAbsolute(relPath) ? relPath : resolveArtifact(state, relPath, cwd);
         if (!existsSync(absPath)) return false;
         const stat = statSync(absPath);
         if (stat.size === 0) return false;
@@ -532,9 +556,7 @@ export function completeInteractivePhaseFromFreshSentinel(
       // Phase 1 (both full + light flows): spec must contain a valid
       // `## Complexity` section (spec R5).
       if (phase === 1) {
-        const specAbs = isAbsolute(state.artifacts.spec)
-          ? state.artifacts.spec
-          : join(cwd, state.artifacts.spec);
+        const specAbs = resolveArtifact(state, state.artifacts.spec, cwd);
         try {
           const body = readFileSync(specAbs, 'utf-8');
           if (!specHasValidComplexity(body)) return false;
@@ -550,9 +572,7 @@ export function completeInteractivePhaseFromFreshSentinel(
           : join(cwd, state.artifacts.checklist);
         if (!isValidChecklistSchema(checklistAbs)) return false;
 
-        const specAbs = isAbsolute(state.artifacts.spec)
-          ? state.artifacts.spec
-          : join(cwd, state.artifacts.spec);
+        const specAbs = resolveArtifact(state, state.artifacts.spec, cwd);
         try {
           const body = readFileSync(specAbs, 'utf-8');
           if (!/^##\s+Implementation\s+Plan\s*$/m.test(body)) return false;
@@ -567,11 +587,11 @@ export function completeInteractivePhaseFromFreshSentinel(
         if (!relPath) continue;
         if (relPath.startsWith('.harness/')) continue;
         const message = `harness[${state.runId}]: Phase ${phase} — ${String(key)}`;
-        normalizeArtifactCommit(relPath, message, cwd);
+        normalizeArtifactCommit(relPath, message, docsRoot);
       }
 
-      // Update commit anchor
-      const head = getHead(cwd);
+      // Update commit anchor using docsRoot
+      const head = getHead(docsRoot);
       if (phase === 1) state.specCommit = head;
       if (phase === 3) state.planCommit = head;
       return true;
@@ -579,11 +599,18 @@ export function completeInteractivePhaseFromFreshSentinel(
 
     if (phase === 5) {
       void runDir;
-      const head = getHead(cwd);
-      if (head === state.implRetryBase) {
-        return false;
+      let anyAdvanced = false;
+      for (const r of state.trackedRepos) {
+        const h = getHead(r.path || cwd);
+        if (h !== r.implRetryBase) {
+          r.implHead = h;
+          anyAdvanced = true;
+        } else {
+          r.implHead = null;
+        }
       }
-      state.implCommit = head;
+      if (!anyAdvanced) return false;
+      syncLegacyMirror(state);
       return true;
     }
   } catch {
@@ -604,30 +631,34 @@ async function replayIncompleteSkip(
   cwd: string
 ): Promise<void> {
   const { normalizeArtifactCommit: commit } = await import('./artifact.js');
+  const docsRoot = state.trackedRepos?.[0]?.path || cwd;
   switch (phase) {
     case 1: {
-      const specPath = join(cwd, state.artifacts.spec);
+      const specPath = resolveArtifact(state, state.artifacts.spec, cwd);
       if (existsSync(specPath)) {
-        commit(state.artifacts.spec, `harness[${state.runId}]: Phase 1 — spec (skip)`, cwd);
-        state.specCommit = getHead(cwd);
+        commit(state.artifacts.spec, `harness[${state.runId}]: Phase 1 — spec (skip)`, docsRoot);
+        state.specCommit = getHead(docsRoot);
       }
       break;
     }
     case 3: {
-      const planPath = join(cwd, state.artifacts.plan);
+      const planPath = resolveArtifact(state, state.artifacts.plan, cwd);
       if (existsSync(planPath)) {
-        commit(state.artifacts.plan, `harness[${state.runId}]: Phase 3 — plan (skip)`, cwd);
-        state.planCommit = getHead(cwd);
+        commit(state.artifacts.plan, `harness[${state.runId}]: Phase 3 — plan (skip)`, docsRoot);
+        state.planCommit = getHead(docsRoot);
       }
       break;
     }
     case 5: {
-      // Phase 5 skip: implCommit stays null
-      state.implCommit = null;
+      // Phase 5 skip: implCommit stays null (per-repo implHead also null)
+      for (const r of state.trackedRepos) {
+        r.implHead = null;
+      }
+      syncLegacyMirror(state);
       break;
     }
     case 6: {
-      const evalReportPath = join(cwd, state.artifacts.evalReport);
+      const evalReportPath = resolveArtifact(state, state.artifacts.evalReport, cwd);
       if (!existsSync(evalReportPath)) {
         // Generate synthetic report if missing
         const { writeFileSync, unlinkSync: u } = await import('fs');
@@ -641,10 +672,10 @@ async function replayIncompleteSkip(
           `## Summary\n\nVERIFY SKIPPED\n`;
         writeFileSync(evalReportPath, report, 'utf-8');
       }
-      if (!isPathGitignored(state.artifacts.evalReport, cwd)) {
-        commit(state.artifacts.evalReport, `harness[${state.runId}]: Phase 6 — eval report (skip)`, cwd);
-        state.evalCommit = getHead(cwd);
-        state.verifiedAtHead = getHead(cwd);
+      if (!isPathGitignored(state.artifacts.evalReport, docsRoot)) {
+        commit(state.artifacts.evalReport, `harness[${state.runId}]: Phase 6 — eval report (skip)`, docsRoot);
+        state.evalCommit = getHead(docsRoot);
+        state.verifiedAtHead = getHead(docsRoot);
       } else {
         process.stderr.write(`⚠️  eval report path '${state.artifacts.evalReport}' is gitignored — skipping commit (evalCommit will remain null).\n`);
         state.evalCommit = null;

--- a/src/runners/codex.ts
+++ b/src/runners/codex.ts
@@ -8,6 +8,7 @@ import { updateLockChild, clearLockChild } from '../lock.js';
 import { getProcessStartTime, killProcessGroup } from '../process.js';
 import { writeState } from '../state.js';
 import { buildGateResult, extractCodexMetadata } from '../phases/verdict.js';
+import { isInGitRepo } from '../git.js';
 
 function resolveCodexBin(): string {
   try {
@@ -189,12 +190,16 @@ async function runCodexExecRaw(input: RawExecInput): Promise<RawExecResult> {
   // `codex exec resume`의 CLI contract (spec §2): `[SESSION_ID] [PROMPT]`가 positional.
   // sessionId를 '--model' 같은 플래그 뒤에 두면 parser가 flag value로 오인할 위험이 있다.
   // 반드시 'resume' 직후 sessionId → 플래그들 → prompt placeholder(`-`) 순서.
+  const skipGitFlag = !isInGitRepo(input.cwd) ? ['--skip-git-repo-check'] : [];
+
   const args = input.mode === 'resume'
     ? ['exec', 'resume', input.sessionId!,
+       ...skipGitFlag,
        '--model', input.preset.model,
        '-c', `model_reasoning_effort="${input.preset.effort}"`,
        '-']
     : ['exec',
+       ...skipGitFlag,
        '--model', input.preset.model,
        '-c', `model_reasoning_effort="${input.preset.effort}"`,
        '-'];
@@ -281,6 +286,13 @@ function parseVerdictPresent(stdout: string): boolean {
   return /^##\s+verdict\s*$/im.test(stdout);
 }
 
+export function stderrTail(stderr: string, maxLines = 20): string {
+  // Strip ANSI escape sequences
+  const clean = stderr.replace(/\x1B\[[0-9;]*m/g, '');
+  const lines = clean.split('\n').filter(l => l.trim().length > 0);
+  return lines.slice(-maxLines).join('\n');
+}
+
 function rawToResult(
   raw: RawExecResult,
   preset: ModelPreset,
@@ -302,7 +314,12 @@ function rawToResult(
     raw.category === 'spawn_error' ? `Codex gate error: ${raw.spawnError ?? 'unknown spawn failure'}` :
     raw.category === 'success_no_verdict' ? 'Gate output missing ## Verdict header' :
     raw.category === 'session_missing' ? `Codex resume failed: session not found (stderr: ${raw.stderr.trim().slice(0, 200)})` :
-    `Gate subprocess exited with code ${raw.exitCode ?? 'null'}`;
+    (() => {
+      const tail = stderrTail(raw.stderr);
+      return tail.length > 0
+        ? `Gate subprocess exited with code ${raw.exitCode ?? 'null'}\n--- stderr (tail) ---\n${tail}\n---`
+        : `Gate subprocess exited with code ${raw.exitCode ?? 'null'}`;
+    })();
 
   return {
     type: 'error',

--- a/src/state.ts
+++ b/src/state.ts
@@ -15,9 +15,22 @@ const STATE_TMP_FILE = 'state.json.tmp';
 const GATE_PHASES = ['2', '4', '7'] as const;
 
 /**
+ * Keep top-level commit fields in sync with trackedRepos[0].
+ * Must be called before every writeState to preserve the legacy-mirror invariant (ADR-N3).
+ */
+export function syncLegacyMirror(state: HarnessState): void {
+  if (!state.trackedRepos || state.trackedRepos.length === 0) return;
+  const r0 = state.trackedRepos[0];
+  state.baseCommit = r0.baseCommit;
+  state.implRetryBase = r0.implRetryBase;
+  state.implCommit = r0.implHead;
+}
+
+/**
  * Write state atomically: write to .tmp → fsync → rename
  */
 export function writeState(runDir: string, state: HarnessState): void {
+  syncLegacyMirror(state);
   const statePath = path.join(runDir, STATE_FILE);
   const tmpPath = path.join(runDir, STATE_TMP_FILE);
 
@@ -39,7 +52,7 @@ export function writeState(runDir: string, state: HarnessState): void {
  * - Throws on corrupt JSON.
  * - If state.json missing but state.json.tmp exists, restore from .tmp first.
  */
-export function readState(runDir: string): HarnessState | null {
+export function readState(runDir: string, cwd?: string): HarnessState | null {
   const statePath = path.join(runDir, STATE_FILE);
   const tmpPath = path.join(runDir, STATE_TMP_FILE);
 
@@ -56,7 +69,7 @@ export function readState(runDir: string): HarnessState | null {
 
   const raw = fs.readFileSync(statePath, 'utf-8');
   try {
-    return migrateState(JSON.parse(raw));
+    return migrateState(JSON.parse(raw), cwd);
   } catch {
     throw new Error('state.json is corrupted. Manual recovery required.');
   }
@@ -65,7 +78,7 @@ export function readState(runDir: string): HarnessState | null {
 /**
  * Migrate a raw state object (potentially from an older version) to the current HarnessState shape.
  */
-export function migrateState(raw: any): HarnessState {
+export function migrateState(raw: any, cwd?: string): HarnessState {
   if (raw.flow !== 'full' && raw.flow !== 'light') {
     raw.flow = 'full';
   }
@@ -145,6 +158,14 @@ export function migrateState(raw: any): HarnessState {
   }
   if (!('carryoverFeedback' in raw) || raw.carryoverFeedback === undefined) {
     raw.carryoverFeedback = null;
+  }
+  if (!raw.trackedRepos || !Array.isArray(raw.trackedRepos) || raw.trackedRepos.length === 0) {
+    raw.trackedRepos = [{
+      path: cwd ?? '',
+      baseCommit: raw.baseCommit,
+      implRetryBase: raw.implRetryBase,
+      implHead: raw.implCommit ?? null,
+    }];
   }
   return raw as HarnessState;
 }
@@ -257,6 +278,7 @@ export function createInitialState(
     task,
     baseCommit,
     implRetryBase: baseCommit,
+    trackedRepos: [{ path: '', baseCommit, implRetryBase: baseCommit, implHead: null }],
     codexPath: null,
     externalCommitsDetected: false,
     artifacts,

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,14 @@ export interface CarryoverFeedback {
   paths: string[];
   deliverToPhase: 5;
 }
+
+export interface TrackedRepo {
+  path: string;          // absolute path; '' for legacy-migrated states
+  baseCommit: string;
+  implRetryBase: string;
+  implHead: string | null;
+}
+
 export type RunStatus = 'in_progress' | 'completed' | 'paused';
 export type PauseReason = 'gate-escalation' | 'verify-escalation' | 'gate-error' | 'verify-error' | 'config-cancel';
 export type PendingActionType = 'reopen_phase' | 'rerun_gate' | 'rerun_verify' | 'show_escalation' | 'show_verify_error' | 'skip_phase' | 'reopen_config';
@@ -54,6 +62,7 @@ export interface HarnessState {
   task: string;
   baseCommit: string;
   implRetryBase: string;
+  trackedRepos: TrackedRepo[];
   codexPath: string | null;
   externalCommitsDetected: boolean;
   artifacts: Artifacts;

--- a/tests/commands/inner-footer.test.ts
+++ b/tests/commands/inner-footer.test.ts
@@ -114,6 +114,7 @@ function makeHarnessState(runId: string): HarnessState {
     task: 'existing task',
     baseCommit: 'abc123',
     implRetryBase: 'abc123',
+    trackedRepos: [{ path: '', baseCommit: 'abc123', implRetryBase: 'abc123', implHead: null }],
     codexPath: '/tmp/codex',
     externalCommitsDetected: false,
     artifacts: { spec: 'spec.md', plan: 'plan.md', decisionLog: 'decision-log.md', checklist: 'checklist.md', evalReport: 'eval-report.md' },

--- a/tests/commands/inner.test.ts
+++ b/tests/commands/inner.test.ts
@@ -265,7 +265,9 @@ describe('bootstrapSessionLogger', () => {
     const base: HarnessState = {
       runId: 'r1', flow: 'full', carryoverFeedback: null,
       currentPhase: 1, status: 'in_progress', autoMode: false,
-      task: 'test task', baseCommit: '', implRetryBase: '', codexPath: null,
+      task: 'test task', baseCommit: '', implRetryBase: '',
+      trackedRepos: [{ path: '', baseCommit: '', implRetryBase: '', implHead: null }],
+      codexPath: null,
       externalCommitsDetected: false,
       artifacts: { spec: 's', plan: 'p', decisionLog: 'd', checklist: 'c', evalReport: 'e' },
       phases: { '1': 'pending', '2': 'pending', '3': 'pending', '4': 'pending', '5': 'pending', '6': 'pending', '7': 'pending' },
@@ -347,7 +349,9 @@ describe('buildConfigCancelHandler — lazy bootstrap', () => {
     const base: HarnessState = {
       runId: 'cc1', flow: 'full', carryoverFeedback: null,
       currentPhase: 1, status: 'in_progress', autoMode: false,
-      task: 'test task', baseCommit: 'abc', implRetryBase: 'abc', codexPath: null,
+      task: 'test task', baseCommit: 'abc', implRetryBase: 'abc',
+      trackedRepos: [{ path: '', baseCommit: 'abc', implRetryBase: 'abc', implHead: null }],
+      codexPath: null,
       externalCommitsDetected: false,
       artifacts: { spec: 's', plan: 'p', decisionLog: 'd', checklist: 'c', evalReport: 'e' },
       phases: { '1': 'pending', '2': 'pending', '3': 'pending', '4': 'pending', '5': 'pending', '6': 'pending', '7': 'pending' },
@@ -547,7 +551,9 @@ describe('bootstrapSessionLogger — codexHome integration (Issue #13)', () => {
     const base: HarnessState = {
       runId: 'rx', flow: 'full', carryoverFeedback: null,
       currentPhase: 1, status: 'in_progress', autoMode: false,
-      task: 'test task', baseCommit: '', implRetryBase: '', codexPath: null,
+      task: 'test task', baseCommit: '', implRetryBase: '',
+      trackedRepos: [{ path: '', baseCommit: '', implRetryBase: '', implHead: null }],
+      codexPath: null,
       externalCommitsDetected: false,
       artifacts: { spec: 's', plan: 'p', decisionLog: 'd', checklist: 'c', evalReport: 'e' },
       phases: { '1': 'pending', '2': 'pending', '3': 'pending', '4': 'pending', '5': 'pending', '6': 'pending', '7': 'pending' },

--- a/tests/commands/start.test.ts
+++ b/tests/commands/start.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execSync } from 'child_process';
+import { detectTrackedRepos } from '../../src/commands/start.js';
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true });
+  tmpDirs.length = 0;
+});
+
+function makeTmp(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'start-test-'));
+  tmpDirs.push(d);
+  return d;
+}
+
+function initGitRepo(dir: string): string {
+  fs.mkdirSync(dir, { recursive: true });
+  execSync('git init', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.email "t@t.com"', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.name "T"', { cwd: dir, stdio: 'pipe' });
+  fs.writeFileSync(path.join(dir, 'init.txt'), 'x');
+  execSync('git add .', { cwd: dir, stdio: 'pipe' });
+  execSync('git commit -m "init"', { cwd: dir, stdio: 'pipe' });
+  return execSync('git rev-parse HEAD', { cwd: dir, encoding: 'utf-8' }).trim();
+}
+
+describe('detectTrackedRepos — auto-detect depth=1 (ADR-N2)', () => {
+  it('returns [cwd] single-entry when cwd is a git repo', () => {
+    const outer = makeTmp();
+    initGitRepo(outer);
+    const result = detectTrackedRepos(outer);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe(outer);
+  });
+
+  it('auto-detects depth=1 git repos when cwd is not a git repo', () => {
+    const outer = makeTmp();
+    const repoA = path.join(outer, 'repo-a');
+    const repoB = path.join(outer, 'repo-b');
+    initGitRepo(repoA);
+    initGitRepo(repoB);
+    const result = detectTrackedRepos(outer);
+    expect(result).toHaveLength(2);
+    const paths = result.map(r => r.path).sort();
+    expect(paths).toEqual([repoA, repoB].sort());
+  });
+
+  it('skips hidden dirs, node_modules, dist, build, .harness in auto-detect', () => {
+    const outer = makeTmp();
+    for (const skip of ['.hidden', 'node_modules', 'dist', 'build', '.harness']) {
+      initGitRepo(path.join(outer, skip));
+    }
+    initGitRepo(path.join(outer, 'real-repo'));
+    const result = detectTrackedRepos(outer);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe(path.join(outer, 'real-repo'));
+  });
+
+  it('throws when no repos found and no --track', () => {
+    const outer = makeTmp();
+    expect(() => detectTrackedRepos(outer)).toThrow(
+      'No tracked git repos found under cwd.'
+    );
+  });
+});
+
+describe('detectTrackedRepos — --track / --exclude (FR-10)', () => {
+  it('--track overrides auto-detect entirely', () => {
+    const outer = makeTmp();
+    const repoA = path.join(outer, 'repo-a');
+    const repoB = path.join(outer, 'repo-b');
+    initGitRepo(repoA);
+    initGitRepo(repoB);
+    const result = detectTrackedRepos(outer, [repoA]);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe(repoA);
+  });
+
+  it('--exclude removes from auto-detect result', () => {
+    const outer = makeTmp();
+    const repoA = path.join(outer, 'repo-a');
+    const repoB = path.join(outer, 'repo-b');
+    initGitRepo(repoA);
+    initGitRepo(repoB);
+    const result = detectTrackedRepos(outer, undefined, [repoB]);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe(repoA);
+  });
+
+  it('--track with out-of-tree path throws (cwd-descendant rule)', () => {
+    const outer = makeTmp();
+    const outside = makeTmp();
+    initGitRepo(outside);
+    expect(() => detectTrackedRepos(outer, [outside])).toThrow(
+      'must be inside cwd'
+    );
+  });
+
+  it('--track with non-existent path throws', () => {
+    const outer = makeTmp();
+    expect(() => detectTrackedRepos(outer, [path.join(outer, 'nonexistent')])).toThrow(
+      'path not found'
+    );
+  });
+
+  it('--track with non-git path throws', () => {
+    const outer = makeTmp();
+    const notGit = path.join(outer, 'notgit');
+    fs.mkdirSync(notGit);
+    expect(() => detectTrackedRepos(outer, [notGit])).toThrow(
+      'not a git repo'
+    );
+  });
+
+  it('result is alphabetically sorted (deterministic)', () => {
+    const outer = makeTmp();
+    for (const name of ['z-repo', 'a-repo', 'm-repo']) {
+      initGitRepo(path.join(outer, name));
+    }
+    const result = detectTrackedRepos(outer);
+    const names = result.map(r => path.basename(r.path));
+    expect(names).toEqual(['a-repo', 'm-repo', 'z-repo']);
+  });
+});

--- a/tests/context/assembler.test.ts
+++ b/tests/context/assembler.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { execSync } from 'child_process';
 import {
   assembleInteractivePrompt,
   assembleGatePrompt,
@@ -808,6 +809,126 @@ describe('complexity signal — E2E', () => {
     } finally {
       stderrSpy.mockRestore();
     }
+  });
+});
+
+describe('buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1)', () => {
+  const tmpDirs: string[] = [];
+  afterEach(() => {
+    for (const d of tmpDirs) { try { fs.rmSync(d, { recursive: true, force: true }); } catch {} }
+    tmpDirs.length = 0;
+  });
+
+  function makeTmpDir2(prefix = 'asm-test-'): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    tmpDirs.push(d);
+    return d;
+  }
+
+  function initRepo(dir: string): string {
+    execSync('git init', { cwd: dir, stdio: 'pipe' });
+    execSync('git config user.email "t@t.com"', { cwd: dir, stdio: 'pipe' });
+    execSync('git config user.name "T"', { cwd: dir, stdio: 'pipe' });
+    fs.writeFileSync(path.join(dir, 'init.txt'), 'x');
+    execSync('git add .', { cwd: dir, stdio: 'pipe' });
+    execSync('git commit -m "init"', { cwd: dir, stdio: 'pipe' });
+    return execSync('git rev-parse HEAD', { cwd: dir, encoding: 'utf-8' }).trim();
+  }
+
+  it('N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label', () => {
+    const cwd = makeTmpDir2();
+    const base = initRepo(cwd);
+    // set up docs structure
+    fs.mkdirSync(path.join(cwd, 'docs/specs'), { recursive: true });
+    fs.mkdirSync(path.join(cwd, 'docs/plans'), { recursive: true });
+    fs.mkdirSync(path.join(cwd, 'docs/process/evals'), { recursive: true });
+    fs.writeFileSync(path.join(cwd, 'docs/specs/my-run-design.md'), '# spec\n## Complexity\nSmall');
+    fs.writeFileSync(path.join(cwd, 'docs/plans/my-run.md'), '# plan');
+    fs.writeFileSync(path.join(cwd, 'docs/process/evals/my-run-eval.md'), '# eval');
+    execSync('git add .', { cwd, stdio: 'pipe' });
+    execSync('git commit -m "docs"', { cwd, stdio: 'pipe' });
+    const implHead = execSync('git rev-parse HEAD', { cwd, encoding: 'utf-8' }).trim();
+
+    const state = makeFullEvalState({
+      baseCommit: base,
+      implCommit: implHead,
+      evalCommit: implHead,
+      trackedRepos: [{ path: cwd, baseCommit: base, implRetryBase: base, implHead }],
+    });
+
+    const prompt = assembleGatePrompt(7, state, '', cwd);
+    if (typeof prompt !== 'string') { return; }
+    expect(prompt).not.toContain('### repo:');
+  });
+
+  it('N=2 → diff sections with ### repo: label for each repo', () => {
+    const outer = makeTmpDir2();
+    const repoA = path.join(outer, 'repo-a');
+    const repoB = path.join(outer, 'repo-b');
+    fs.mkdirSync(repoA); fs.mkdirSync(repoB);
+    const baseA = initRepo(repoA);
+    const baseB = initRepo(repoB);
+
+    // Set up docs in repoA (trackedRepos[0])
+    fs.mkdirSync(path.join(repoA, 'docs/specs'), { recursive: true });
+    fs.mkdirSync(path.join(repoA, 'docs/plans'), { recursive: true });
+    fs.mkdirSync(path.join(repoA, 'docs/process/evals'), { recursive: true });
+    fs.writeFileSync(path.join(repoA, 'docs/specs/my-run-design.md'), '# spec\n## Complexity\nSmall');
+    fs.writeFileSync(path.join(repoA, 'docs/plans/my-run.md'), '# plan');
+    fs.writeFileSync(path.join(repoA, 'docs/process/evals/my-run-eval.md'), '# eval');
+    execSync('git add .', { cwd: repoA, stdio: 'pipe' });
+    execSync('git commit -m "docs"', { cwd: repoA, stdio: 'pipe' });
+    const implA = execSync('git rev-parse HEAD', { cwd: repoA, encoding: 'utf-8' }).trim();
+
+    const state = makeFullEvalState({
+      baseCommit: baseA,
+      implCommit: implA,
+      evalCommit: implA,
+      trackedRepos: [
+        { path: repoA, baseCommit: baseA, implRetryBase: baseA, implHead: implA },
+        { path: repoB, baseCommit: baseB, implRetryBase: baseB, implHead: null },
+      ],
+    });
+
+    const prompt = assembleGatePrompt(7, state, '', outer);
+    if (typeof prompt !== 'string') { return; }
+    expect(prompt).toContain('### repo: repo-a');
+    expect(prompt).toContain('### repo: repo-b');
+  });
+
+  it('N>1 metadata uses "Harness implementation ranges (per tracked repo):" block', () => {
+    const outer = makeTmpDir2();
+    const repoA = path.join(outer, 'repo-a');
+    const repoB = path.join(outer, 'repo-b');
+    fs.mkdirSync(repoA); fs.mkdirSync(repoB);
+    const baseA = initRepo(repoA);
+    const baseB = initRepo(repoB);
+
+    fs.mkdirSync(path.join(repoA, 'docs/specs'), { recursive: true });
+    fs.mkdirSync(path.join(repoA, 'docs/plans'), { recursive: true });
+    fs.mkdirSync(path.join(repoA, 'docs/process/evals'), { recursive: true });
+    fs.writeFileSync(path.join(repoA, 'docs/specs/my-run-design.md'), '# spec\n## Complexity\nSmall');
+    fs.writeFileSync(path.join(repoA, 'docs/plans/my-run.md'), '# plan');
+    fs.writeFileSync(path.join(repoA, 'docs/process/evals/my-run-eval.md'), '# eval');
+    execSync('git add .', { cwd: repoA, stdio: 'pipe' });
+    execSync('git commit -m "docs"', { cwd: repoA, stdio: 'pipe' });
+    const implA = execSync('git rev-parse HEAD', { cwd: repoA, encoding: 'utf-8' }).trim();
+
+    const state = makeFullEvalState({
+      baseCommit: baseA,
+      implCommit: implA,
+      evalCommit: implA,
+      trackedRepos: [
+        { path: repoA, baseCommit: baseA, implRetryBase: baseA, implHead: implA },
+        { path: repoB, baseCommit: baseB, implRetryBase: baseB, implHead: null },
+      ],
+    });
+
+    const prompt = assembleGatePrompt(7, state, '', outer);
+    if (typeof prompt !== 'string') { return; }
+    expect(prompt).toContain('Harness implementation ranges (per tracked repo):');
+    expect(prompt).toContain('repo-a:');
+    expect(prompt).toContain('no change');
   });
 });
 

--- a/tests/integration/logging.test.ts
+++ b/tests/integration/logging.test.ts
@@ -14,7 +14,9 @@ function buildState(overrides: Partial<HarnessState> = {}): HarnessState {
   const base: HarnessState = {
     runId: 'r', flow: 'full', carryoverFeedback: null,
     currentPhase: 1, status: 'in_progress', autoMode: false,
-    task: 'test', baseCommit: '', implRetryBase: '', codexPath: null,
+    task: 'test', baseCommit: '', implRetryBase: '',
+    trackedRepos: [{ path: '', baseCommit: '', implRetryBase: '', implHead: null }],
+    codexPath: null,
     externalCommitsDetected: false,
     artifacts: { spec: 's', plan: 'p', decisionLog: 'd', checklist: 'c', evalReport: 'e' },
     phases: { '1': 'pending', '2': 'pending', '3': 'pending', '4': 'pending', '5': 'pending', '6': 'pending', '7': 'pending' },

--- a/tests/multi-worktree.test.ts
+++ b/tests/multi-worktree.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execSync } from 'child_process';
+import { migrateState, createInitialState, syncLegacyMirror } from '../src/state.js';
+import { detectTrackedRepos } from '../src/commands/start.js';
+import { validatePhaseArtifacts } from '../src/phases/interactive.js';
+import { resolveArtifact } from '../src/artifact.js';
+import type { HarnessState } from '../src/types.js';
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true });
+  tmpDirs.length = 0;
+});
+
+function makeTmp(prefix = 'mwt-'): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(d);
+  return d;
+}
+
+function initRepo(dir: string): string {
+  fs.mkdirSync(dir, { recursive: true });
+  execSync('git init', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.email "t@t.com"', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.name "T"', { cwd: dir, stdio: 'pipe' });
+  fs.writeFileSync(path.join(dir, 'init.txt'), 'x');
+  execSync('git add .', { cwd: dir, stdio: 'pipe' });
+  execSync('git commit -m "init"', { cwd: dir, stdio: 'pipe' });
+  return execSync('git rev-parse HEAD', { cwd: dir, encoding: 'utf-8' }).trim();
+}
+
+// (a) depth=1 scan: cwd not a git repo, depth=1 has 2 git repos
+describe('(a) depth=1 auto-detect — non-git outer cwd', () => {
+  it('detects exactly depth=1 git repos, skips non-git dirs', () => {
+    const outer = makeTmp();
+    const repoA = path.join(outer, 'repo-a');
+    const repoB = path.join(outer, 'repo-b');
+    const notGit = path.join(outer, 'not-git');
+    fs.mkdirSync(notGit);
+    initRepo(repoA);
+    initRepo(repoB);
+    const repos = detectTrackedRepos(outer);
+    const paths = repos.map(r => r.path).sort();
+    expect(paths).toEqual([repoA, repoB].sort());
+  });
+});
+
+// (b) --track / --exclude
+describe('(b) --track / --exclude flag combinations', () => {
+  it('--track replaces auto-detect', () => {
+    const outer = makeTmp();
+    const repoA = path.join(outer, 'a');
+    const repoB = path.join(outer, 'b');
+    initRepo(repoA); initRepo(repoB);
+    const result = detectTrackedRepos(outer, [repoA]);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe(repoA);
+  });
+
+  it('--exclude removes from auto-detect', () => {
+    const outer = makeTmp();
+    const repoA = path.join(outer, 'a');
+    const repoB = path.join(outer, 'b');
+    initRepo(repoA); initRepo(repoB);
+    const result = detectTrackedRepos(outer, undefined, [repoB]);
+    expect(result.map(r => r.path)).not.toContain(repoB);
+    expect(result.map(r => r.path)).toContain(repoA);
+  });
+});
+
+// (c) N=2 tracked repos assembler diff concat
+describe('(c) assembler diff concat for N=2 repos', () => {
+  it('includes ### repo: label for each repo in N=2 case', async () => {
+    const { assembleGatePrompt } = await import('../src/context/assembler.js');
+    const outer = makeTmp();
+    const repoA = path.join(outer, 'repo-a');
+    const repoB = path.join(outer, 'repo-b');
+    const baseA = initRepo(repoA);
+    const baseB = initRepo(repoB);
+
+    // Create docs in repoA (trackedRepos[0])
+    fs.mkdirSync(path.join(repoA, 'docs/specs'), { recursive: true });
+    fs.mkdirSync(path.join(repoA, 'docs/plans'), { recursive: true });
+    fs.mkdirSync(path.join(repoA, 'docs/process/evals'), { recursive: true });
+    fs.writeFileSync(path.join(repoA, 'docs/specs/run-design.md'), '# spec\n## Complexity\nMedium');
+    fs.writeFileSync(path.join(repoA, 'docs/plans/run.md'), '# plan');
+    fs.writeFileSync(path.join(repoA, 'docs/process/evals/run-eval.md'), '# eval');
+
+    const state = createInitialState('run', 'task', baseA, false);
+    state.trackedRepos = [
+      { path: repoA, baseCommit: baseA, implRetryBase: baseA, implHead: null },
+      { path: repoB, baseCommit: baseB, implRetryBase: baseB, implHead: null },
+    ];
+    state.artifacts = {
+      spec: 'docs/specs/run-design.md',
+      plan: 'docs/plans/run.md',
+      decisionLog: '.harness/run/decisions.md',
+      checklist: '.harness/run/checklist.json',
+      evalReport: 'docs/process/evals/run-eval.md',
+    };
+    state.phases['5'] = 'completed';
+    state.phases['6'] = 'completed';
+    state.implCommit = baseA;
+    state.evalCommit = baseA;
+
+    const prompt = assembleGatePrompt(7, state, '', outer);
+    expect(typeof prompt).toBe('string');
+    if (typeof prompt === 'string') {
+      expect(prompt).toContain('### repo: repo-a');
+      expect(prompt).toContain('### repo: repo-b');
+    }
+  });
+
+  it('N=1 trackedRepos[0].path===cwd → no ### repo: label (backward compat)', async () => {
+    const { assembleGatePrompt } = await import('../src/context/assembler.js');
+    const cwd = makeTmp();
+    const base = initRepo(cwd);
+    fs.mkdirSync(path.join(cwd, 'docs/specs'), { recursive: true });
+    fs.mkdirSync(path.join(cwd, 'docs/plans'), { recursive: true });
+    fs.mkdirSync(path.join(cwd, 'docs/process/evals'), { recursive: true });
+    fs.writeFileSync(path.join(cwd, 'docs/specs/run-design.md'), '# spec\n## Complexity\nMedium');
+    fs.writeFileSync(path.join(cwd, 'docs/plans/run.md'), '# plan');
+    fs.writeFileSync(path.join(cwd, 'docs/process/evals/run-eval.md'), '# eval');
+
+    const state = createInitialState('run', 'task', base, false);
+    state.trackedRepos = [{ path: cwd, baseCommit: base, implRetryBase: base, implHead: null }];
+    state.phases['5'] = 'completed';
+    state.phases['6'] = 'completed';
+    state.implCommit = base;
+    state.evalCommit = base;
+
+    const prompt = assembleGatePrompt(7, state, '', cwd);
+    if (typeof prompt === 'string') {
+      expect(prompt).not.toContain('### repo:');
+    }
+  });
+});
+
+// (d) Phase 5 judgment: "any repo advanced" = success
+describe('(d) Phase 5 success: one-of-N advanced', () => {
+  it('returns true when only repo-a advanced in a 2-repo setup', () => {
+    const outer = makeTmp();
+    const repoA = path.join(outer, 'a');
+    const repoB = path.join(outer, 'b');
+    const headA = initRepo(repoA);
+    const headB = initRepo(repoB);
+
+    // Advance repoA
+    fs.writeFileSync(path.join(repoA, 'new.txt'), 'impl');
+    execSync('git add .', { cwd: repoA, stdio: 'pipe' });
+    execSync('git commit -m "impl"', { cwd: repoA, stdio: 'pipe' });
+    const newHeadA = execSync('git rev-parse HEAD', { cwd: repoA, encoding: 'utf-8' }).trim();
+
+    const state = createInitialState('r', 't', headA, false);
+    state.trackedRepos = [
+      { path: repoA, baseCommit: headA, implRetryBase: headA, implHead: null },
+      { path: repoB, baseCommit: headB, implRetryBase: headB, implHead: null },
+    ];
+    const runDir = makeTmp('rundir-');
+    const result = validatePhaseArtifacts(5, state, outer, runDir);
+
+    expect(result).toBe(true);
+    expect(state.trackedRepos[0].implHead).toBe(newHeadA);
+    expect(state.trackedRepos[1].implHead).toBeNull();
+    expect(state.implCommit).toBe(newHeadA);
+  });
+});
+
+// (e) state migration: legacy state.json → trackedRepos synthesis
+describe('(e) state migration: legacy → trackedRepos', () => {
+  it('synthesizes trackedRepos[0] from top-level fields with provided cwd', () => {
+    const legacy = {
+      runId: 'run-1',
+      baseCommit: 'deadbeef',
+      implRetryBase: 'deadbeef',
+      implCommit: null,
+      flow: 'full',
+    };
+    const migrated = migrateState(legacy, '/outer/my-repo');
+    expect(migrated.trackedRepos).toHaveLength(1);
+    expect(migrated.trackedRepos[0].path).toBe('/outer/my-repo');
+    expect(migrated.trackedRepos[0].baseCommit).toBe('deadbeef');
+    expect(migrated.trackedRepos[0].implHead).toBeNull();
+  });
+
+  it('syncLegacyMirror keeps top-level fields in sync with trackedRepos[0]', () => {
+    const state = createInitialState('r', 't', 'old', false);
+    state.trackedRepos = [
+      { path: '/repo', baseCommit: 'new', implRetryBase: 'new', implHead: 'impl' },
+    ];
+    syncLegacyMirror(state);
+    expect(state.baseCommit).toBe('new');
+    expect(state.implRetryBase).toBe('new');
+    expect(state.implCommit).toBe('impl');
+  });
+});
+
+// resolveArtifact: uses trackedRepos[0].path
+describe('resolveArtifact (FR-7)', () => {
+  it('resolves relative path against trackedRepos[0].path', () => {
+    const state = createInitialState('r', 't', 'abc', false);
+    state.trackedRepos = [{ path: '/repo-a', baseCommit: 'abc', implRetryBase: 'abc', implHead: null }];
+    const result = resolveArtifact(state, 'docs/specs/foo.md', '/outer');
+    expect(result).toBe('/repo-a/docs/specs/foo.md');
+  });
+
+  it('falls back to outerCwd when trackedRepos[0].path is empty string (legacy)', () => {
+    const state = createInitialState('r', 't', 'abc', false);
+    state.trackedRepos = [{ path: '', baseCommit: 'abc', implRetryBase: 'abc', implHead: null }];
+    const result = resolveArtifact(state, 'docs/specs/foo.md', '/outer');
+    expect(result).toBe('/outer/docs/specs/foo.md');
+  });
+});

--- a/tests/multi-worktree.test.ts
+++ b/tests/multi-worktree.test.ts
@@ -213,4 +213,11 @@ describe('resolveArtifact (FR-7)', () => {
     const result = resolveArtifact(state, 'docs/specs/foo.md', '/outer');
     expect(result).toBe('/outer/docs/specs/foo.md');
   });
+
+  it('.harness/... paths are always anchored to outerCwd, not trackedRepos[0]', () => {
+    const state = createInitialState('r', 't', 'abc', false);
+    state.trackedRepos = [{ path: '/repo-a', baseCommit: 'abc', implRetryBase: 'abc', implHead: null }];
+    const result = resolveArtifact(state, '.harness/run-1/checklist.json', '/outer');
+    expect(result).toBe('/outer/.harness/run-1/checklist.json');
+  });
 });

--- a/tests/phases/gate-resume.test.ts
+++ b/tests/phases/gate-resume.test.ts
@@ -24,7 +24,9 @@ function makeState(): HarnessState {
   return {
     runId: 'r1', flow: 'full', carryoverFeedback: null,
     currentPhase: 2, status: 'in_progress', autoMode: false,
-    task: 't', baseCommit: '', implRetryBase: '', codexPath: null,
+    task: 't', baseCommit: '', implRetryBase: '',
+    trackedRepos: [{ path: '', baseCommit: '', implRetryBase: '', implHead: null }],
+    codexPath: null,
     externalCommitsDetected: false,
     artifacts: { spec: 's', plan: 'p', decisionLog: 'd', checklist: 'c', evalReport: 'e' },
     phases: { '1': 'pending', '2': 'pending', '3': 'pending', '4': 'pending', '5': 'pending', '6': 'pending', '7': 'pending' },

--- a/tests/phases/interactive.test.ts
+++ b/tests/phases/interactive.test.ts
@@ -70,12 +70,23 @@ function makeState(overrides: Partial<HarnessState> = {}): HarnessState {
     'deadbeef',
     false
   );
-  return {
+  const merged = {
     ...base,
     tmuxWorkspacePane: '%1',
     tmuxControlPane: '%0',
     ...overrides,
   };
+  // Keep trackedRepos[0] in sync with top-level fields so syncLegacyMirror
+  // (called by writeState) does not overwrite them back to base values.
+  if (merged.trackedRepos?.[0]) {
+    merged.trackedRepos = [{
+      ...merged.trackedRepos[0],
+      baseCommit: merged.baseCommit,
+      implRetryBase: merged.implRetryBase,
+      implHead: merged.implCommit,
+    }];
+  }
+  return merged;
 }
 
 /** Create a minimal git repo and return its path (registered for cleanup). */

--- a/tests/phases/interactive.test.ts
+++ b/tests/phases/interactive.test.ts
@@ -192,6 +192,8 @@ describe('preparePhase — Phase 1/3 artifact deletion', () => {
     const harnessDir = makeTmpDir();
 
     const state = makeState();
+    // Set trackedRepos[0].path so getHead(r.path) works in Phase 5 preparePhase
+    state.trackedRepos = [{ path: repoDir, baseCommit: state.baseCommit, implRetryBase: state.implRetryBase, implHead: null }];
 
     // Phase 5 should not attempt to delete spec/plan/etc.
     // Create a file that would be deleted if cleanup ran incorrectly
@@ -323,6 +325,8 @@ describe('preparePhase — Phase 5 implRetryBase', () => {
 
     const head = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
     const state = makeState({ implRetryBase: 'old-base-sha' });
+    // Set trackedRepos[0].path so getHead(r.path) works
+    state.trackedRepos = [{ path: repoDir, baseCommit: 'old-base-sha', implRetryBase: 'old-base-sha', implHead: null }];
 
     const newState = preparePhase(5, state, harnessDir, runDir, repoDir);
 
@@ -615,6 +619,7 @@ describe('validatePhaseArtifacts — Phase 5', () => {
     execSync('git add impl.txt && git commit -m "impl"', { cwd: repoDir });
 
     const state = makeState({ implRetryBase: head });
+    state.trackedRepos = [{ path: repoDir, baseCommit: head, implRetryBase: head, implHead: null }];
     const result = validatePhaseArtifacts(5, state, repoDir, repoDir);
     expect(result).toBe(true);
   });
@@ -623,14 +628,17 @@ describe('validatePhaseArtifacts — Phase 5', () => {
     const repoDir = createTestRepo();
     const head = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
     const state = makeState({ implRetryBase: head, implCommit: null });
+    state.trackedRepos = [{ path: repoDir, baseCommit: head, implRetryBase: head, implHead: null }];
     const result = validatePhaseArtifacts(5, state, repoDir, repoDir);
     expect(result).toBe(false);
   });
 
-  it('accepts zero-commit reopen when implCommit is already set', () => {
+  it('accepts zero-commit reopen when implHead is already set on trackedRepos[0]', () => {
     const repoDir = createTestRepo();
     const head = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
-    const state = makeState({ implRetryBase: head, implCommit: 'prior-impl-sha' });
+    const state = makeState({ implRetryBase: head, implCommit: null });
+    // Simulate a prior attempt that set implHead
+    state.trackedRepos = [{ path: repoDir, baseCommit: head, implRetryBase: head, implHead: 'prior-impl-sha' }];
     const result = validatePhaseArtifacts(5, state, repoDir, repoDir);
     expect(result).toBe(true);
   });
@@ -643,6 +651,7 @@ describe('validatePhaseArtifacts — Phase 5', () => {
     fs.writeFileSync(path.join(repoDir, 'dirty.txt'), 'untracked scratch');
 
     const state = makeState({ implRetryBase: head });
+    state.trackedRepos = [{ path: repoDir, baseCommit: head, implRetryBase: head, implHead: null }];
     const result = validatePhaseArtifacts(5, state, repoDir, repoDir);
     expect(result).toBe(true);
   });
@@ -840,5 +849,68 @@ describe('runInteractivePhase — codex-interactive branch invokes codex isolati
     const errorSidecar = path.join(runDir, 'codex-1-error.md');
     expect(fs.existsSync(errorSidecar)).toBe(true);
     expect(fs.readFileSync(errorSidecar, 'utf-8')).toMatch(/fake.*auth\.json missing/);
+  });
+});
+
+describe('validatePhaseArtifacts — Phase 5 multi-repo (FR-6, ADR-D4)', () => {
+  it('returns true when any repo advanced; sets implHead on advanced repos only', () => {
+    const outer = makeTmpDir();
+    const repoA = makeTmpDir('repoA-');
+    const repoB = makeTmpDir('repoB-');
+
+    // Init both repos with an initial commit
+    for (const d of [repoA, repoB]) {
+      execSync('git init', { cwd: d, stdio: 'pipe' });
+      execSync('git config user.email "t@t.com"', { cwd: d, stdio: 'pipe' });
+      execSync('git config user.name "T"', { cwd: d, stdio: 'pipe' });
+      fs.writeFileSync(path.join(d, 'a.txt'), 'x');
+      execSync('git add .', { cwd: d, stdio: 'pipe' });
+      execSync('git commit -m "init"', { cwd: d, stdio: 'pipe' });
+    }
+
+    const headA = execSync('git rev-parse HEAD', { cwd: repoA, encoding: 'utf-8' }).trim();
+    const headB = execSync('git rev-parse HEAD', { cwd: repoB, encoding: 'utf-8' }).trim();
+
+    // Advance only repoA
+    fs.writeFileSync(path.join(repoA, 'new.txt'), 'y');
+    execSync('git add .', { cwd: repoA, stdio: 'pipe' });
+    execSync('git commit -m "impl"', { cwd: repoA, stdio: 'pipe' });
+    const newHeadA = execSync('git rev-parse HEAD', { cwd: repoA, encoding: 'utf-8' }).trim();
+
+    const state = makeState({ baseCommit: headA, implRetryBase: headA });
+    state.trackedRepos = [
+      { path: repoA, baseCommit: headA, implRetryBase: headA, implHead: null },
+      { path: repoB, baseCommit: headB, implRetryBase: headB, implHead: null },
+    ];
+
+    const runDir = makeTmpDir('rundir-');
+    const result = validatePhaseArtifacts(5, state, outer, runDir);
+
+    expect(result).toBe(true);
+    expect(state.trackedRepos[0].implHead).toBe(newHeadA);
+    expect(state.trackedRepos[1].implHead).toBeNull(); // not advanced
+    expect(state.implCommit).toBe(newHeadA); // legacy mirror from trackedRepos[0]
+  });
+
+  it('returns false when no repo advanced', () => {
+    const outer = makeTmpDir();
+    const repoA = makeTmpDir('repoA2-');
+    execSync('git init', { cwd: repoA, stdio: 'pipe' });
+    execSync('git config user.email "t@t.com"', { cwd: repoA, stdio: 'pipe' });
+    execSync('git config user.name "T"', { cwd: repoA, stdio: 'pipe' });
+    fs.writeFileSync(path.join(repoA, 'a.txt'), 'x');
+    execSync('git add .', { cwd: repoA, stdio: 'pipe' });
+    execSync('git commit -m "init"', { cwd: repoA, stdio: 'pipe' });
+    const head = execSync('git rev-parse HEAD', { cwd: repoA, encoding: 'utf-8' }).trim();
+
+    const state = makeState({ baseCommit: head, implRetryBase: head });
+    state.trackedRepos = [
+      { path: repoA, baseCommit: head, implRetryBase: head, implHead: null },
+    ];
+    state.implCommit = null;
+
+    const runDir = makeTmpDir('rundir2-');
+    const result = validatePhaseArtifacts(5, state, outer, runDir);
+    expect(result).toBe(false);
   });
 });

--- a/tests/phases/runner.test.ts
+++ b/tests/phases/runner.test.ts
@@ -710,6 +710,12 @@ describe('Phase 5 completion sets implCommit', () => {
   it('updates implCommit after Phase 5 completes', async () => {
     const runDir = makeTmpDir();
     const state = makeState({ currentPhase: 5 });
+    // Simulate what validatePhaseArtifacts (mocked) would have set on implHead.
+    // In the multi-repo design, syncLegacyMirror reads trackedRepos[0].implHead
+    // to populate implCommit — getHead is only used for Phase 1/3 anchors.
+    if (state.trackedRepos?.[0]) {
+      state.trackedRepos[0].implHead = 'impl-commit-sha';
+    }
 
     vi.mocked(getHead).mockReturnValue('impl-commit-sha');
 
@@ -720,9 +726,8 @@ describe('Phase 5 completion sets implCommit', () => {
 
     await runPhaseLoop(state, HDIR, runDir, CWD, createNoOpInputManager(), new NoopLogger(), { value: false });
 
-    const writes = vi.mocked(writeState).mock.calls.map(([, s]) => s);
-    const withImpl = writes.find(s => s.implCommit === 'impl-commit-sha');
-    expect(withImpl).toBeDefined();
+    // implCommit is propagated from trackedRepos[0].implHead via syncLegacyMirror
+    expect(state.implCommit).toBe('impl-commit-sha');
   });
 });
 

--- a/tests/phases/terminal-ui.test.ts
+++ b/tests/phases/terminal-ui.test.ts
@@ -32,6 +32,7 @@ function makeState(overrides: Partial<HarnessState> = {}): HarnessState {
     task: 't',
     baseCommit: 'base',
     implRetryBase: 'base',
+    trackedRepos: [{ path: '', baseCommit: 'base', implRetryBase: 'base', implHead: null }],
     codexPath: null,
     externalCommitsDetected: false,
     artifacts: {

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -78,7 +78,7 @@ describe('runPreflight - git check', () => {
   it('throws when cwd is not a git repo', () => {
     // os.tmpdir() is not a git repo.
     const cwd = os.tmpdir();
-    expect(() => runPreflight(['git'], cwd)).toThrow('harness requires a git repository.');
+    expect(() => runPreflight(['git'], cwd)).toThrow('harness requires a git repository');
   });
 });
 
@@ -162,7 +162,7 @@ describe('runPreflight - multiple items', () => {
   it('throws on first failure and does not continue', () => {
     // 'git' will fail with os.tmpdir() as cwd
     expect(() => runPreflight(['platform', 'git', 'node'], os.tmpdir())).toThrow(
-      'harness requires a git repository.'
+      'harness requires a git repository'
     );
   });
 });

--- a/tests/resume.test.ts
+++ b/tests/resume.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { execSync } from 'child_process';
-import { mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs';
 import { join } from 'path';
+import { tmpdir } from 'os';
 import { createTestRepo } from './helpers/test-repo.js';
-import { resumeRun } from '../src/resume.js';
+import { resumeRun, completeInteractivePhaseFromFreshSentinel } from '../src/resume.js';
 import { createInitialState, writeState } from '../src/state.js';
 
 vi.mock('../src/phases/runner.js', () => ({
@@ -223,6 +224,26 @@ describe('resumeRun', () => {
     expect(stderrSpy.mock.calls.map((c: any) => c[0]).join('')).toContain('Spec commit');
   });
 
+  it('errors when phase 5 completed but all trackedRepos implHead are null (state anomaly)', async () => {
+    const phases = {
+      '1': 'pending', '2': 'pending', '3': 'pending',
+      '4': 'pending', '5': 'completed', '6': 'pending', '7': 'pending',
+    };
+    const baseCommit = execSync('git rev-parse HEAD', { cwd: repo.path, encoding: 'utf-8' }).trim();
+    const { state, harnessDir, runDir } = setupRun(repo, {
+      currentPhase: 6,
+      phases,
+      implCommit: baseCommit,
+      trackedRepos: [
+        { path: repo.path, baseCommit, implRetryBase: baseCommit, implHead: null },
+      ],
+    });
+
+    await expect(resumeRun(state, harnessDir, runDir, repo.path)).rejects.toThrow('__exit__');
+    const output = stderrSpy.mock.calls.map((c: any) => c[0]).join('');
+    expect(output).toContain('state anomaly');
+  });
+
   it('skip_phase Phase 6 with gitignored eval report: skips commit and leaves evalCommit null', async () => {
     // setupRun first (creates .harness/ gitignore and initial commits)
     const { state, harnessDir, runDir } = setupRun(repo, {
@@ -259,5 +280,117 @@ describe('resumeRun', () => {
     expect(updated.phases['6']).toBe('completed');
     // Warning must be emitted
     expect(stderrSpy.mock.calls.map((c: any) => c[0]).join('')).toContain('gitignored');
+  });
+});
+
+// Standalone helpers for multi-repo tests (real git, no mocks needed)
+const multiRepoTmpDirs: string[] = [];
+
+function makeMultiTmpDir(prefix = 'harness-mr-'): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  multiRepoTmpDirs.push(dir);
+  return dir;
+}
+
+function initRepo(repoPath: string, filename = 'init.txt'): string {
+  mkdirSync(repoPath, { recursive: true });
+  execSync('git init', { cwd: repoPath, stdio: 'pipe' });
+  execSync('git config user.email "t@t.com"', { cwd: repoPath, stdio: 'pipe' });
+  execSync('git config user.name "T"', { cwd: repoPath, stdio: 'pipe' });
+  writeFileSync(join(repoPath, filename), 'x');
+  execSync('git add .', { cwd: repoPath, stdio: 'pipe' });
+  execSync('git commit -m "init"', { cwd: repoPath, stdio: 'pipe' });
+  return execSync('git rev-parse HEAD', { cwd: repoPath, encoding: 'utf-8' }).trim();
+}
+
+afterEach(() => {
+  for (const dir of multiRepoTmpDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  multiRepoTmpDirs.length = 0;
+});
+
+describe('completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8)', () => {
+  it('returns true and sets implHead when any repo advanced', () => {
+    const outer = makeMultiTmpDir();
+    const repoA = join(outer, 'a');
+    const base = initRepo(repoA);
+
+    // Advance repoA
+    writeFileSync(join(repoA, 'impl.txt'), 'y');
+    execSync('git add .', { cwd: repoA, stdio: 'pipe' });
+    execSync('git commit -m "impl"', { cwd: repoA, stdio: 'pipe' });
+    const newHead = execSync('git rev-parse HEAD', { cwd: repoA, encoding: 'utf-8' }).trim();
+
+    const state = createInitialState('test-run', 'task', base, false);
+    state.trackedRepos = [
+      { path: repoA, baseCommit: base, implRetryBase: base, implHead: null },
+    ];
+    state.implRetryBase = base;
+
+    const runDir = makeMultiTmpDir('rundir-');
+    const result = completeInteractivePhaseFromFreshSentinel(5, state, outer, runDir);
+
+    expect(result).toBe(true);
+    expect(state.trackedRepos[0].implHead).toBe(newHead);
+    // syncLegacyMirror: state.implCommit mirrors trackedRepos[0].implHead
+    expect(state.implCommit).toBe(newHead);
+  });
+
+  it('returns false when no repo advanced (HEAD === implRetryBase)', () => {
+    const outer = makeMultiTmpDir();
+    const repoA = join(outer, 'a');
+    const head = initRepo(repoA);
+
+    const state = createInitialState('test-run', 'task', head, false);
+    state.trackedRepos = [
+      { path: repoA, baseCommit: head, implRetryBase: head, implHead: null },
+    ];
+    state.implRetryBase = head;
+
+    const runDir = makeMultiTmpDir('rundir-');
+    const result = completeInteractivePhaseFromFreshSentinel(5, state, outer, runDir);
+
+    expect(result).toBe(false);
+  });
+
+  it('skips ancestry check for repos with implHead=null (null-safe FR-8)', async () => {
+    const outer = makeMultiTmpDir();
+    const repoA = join(outer, 'a');
+    const implSha = initRepo(repoA);
+
+    // repoB doesn't need to be a real git repo — implHead=null means no ancestry check
+    const repoB = join(outer, 'b');
+    mkdirSync(repoB);
+
+    const state = createInitialState('test-run', 'task', implSha, false);
+    state.phases['5'] = 'completed';
+    state.trackedRepos = [
+      { path: repoA, baseCommit: implSha, implRetryBase: implSha, implHead: implSha },
+      { path: repoB, baseCommit: 'dummy', implRetryBase: 'dummy', implHead: null },
+    ];
+    state.implCommit = implSha;
+
+    // Set up a runDir with a fresh state.json so resumeRun can proceed
+    const harnessDir = join(outer, '.harness');
+    const runDir = join(harnessDir, 'test-run');
+    mkdirSync(runDir, { recursive: true });
+    writeState(runDir, state);
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: any) => {
+      throw new Error(`__exit__${_code}`);
+    });
+    const stderrSpy2 = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    try {
+      // Calling resumeRun will exercise validateAncestry — the null-safe path
+      // should NOT call isAncestor on repoB and should NOT exit
+      // (only repoA with a real implHead is checked)
+      // It will eventually reach runPhaseLoop which is already mocked
+      await resumeRun(state, harnessDir, runDir, outer);
+    } finally {
+      exitSpy.mockRestore();
+      stderrSpy2.mockRestore();
+    }
+    // No __exit__ thrown = test passes
   });
 });

--- a/tests/runners/codex.test.ts
+++ b/tests/runners/codex.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
-import { runCodexGate, runCodexInteractive } from '../../src/runners/codex.js';
+import { runCodexGate, runCodexInteractive, stderrTail } from '../../src/runners/codex.js';
 import { type ModelPreset } from '../../src/config.js';
 import type { HarnessState } from '../../src/types.js';
 
@@ -8,6 +8,12 @@ vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>();
   return { ...actual, spawn: vi.fn(), execSync: vi.fn(() => '/usr/local/bin/codex') };
 });
+
+vi.mock('../../src/git.js', () => ({
+  getHead: vi.fn(() => 'abc123'),
+  isPathGitignored: vi.fn(() => false),
+  isInGitRepo: vi.fn(() => true),
+}));
 vi.mock('../../src/lock.js', () => ({
   updateLockChild: vi.fn(),
   clearLockChild: vi.fn(),
@@ -131,5 +137,136 @@ describe('runCodexInteractive — CODEX_HOME env plumbing', () => {
     expect(spawnOpts.env.CODEX_HOME).toBe('/iso/interactive');
 
     fs.rmSync(tmp, { recursive: true, force: true });
+  });
+});
+
+describe('stderrTail — helper unit tests', () => {
+  it('returns last N non-empty lines', () => {
+    const lines = Array.from({ length: 30 }, (_, i) => `line ${i + 1}`).join('\n');
+    const result = stderrTail(lines, 5);
+    expect(result).toBe('line 26\nline 27\nline 28\nline 29\nline 30');
+  });
+
+  it('strips ANSI escape sequences', () => {
+    const input = '\x1B[31mERROR\x1B[0m: something went wrong';
+    const result = stderrTail(input);
+    expect(result).toBe('ERROR: something went wrong');
+  });
+
+  it('filters out blank lines', () => {
+    const input = 'line1\n\n   \nline2\n';
+    const result = stderrTail(input);
+    expect(result).toBe('line1\nline2');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(stderrTail('')).toBe('');
+    expect(stderrTail('\n\n   \n')).toBe('');
+  });
+
+  it('defaults to max 20 lines', () => {
+    const lines = Array.from({ length: 25 }, (_, i) => `line ${i + 1}`).join('\n');
+    const result = stderrTail(lines);
+    const resultLines = result.split('\n');
+    expect(resultLines).toHaveLength(20);
+    expect(resultLines[0]).toBe('line 6');
+    expect(resultLines[19]).toBe('line 25');
+  });
+});
+
+describe('runCodexGate — --skip-git-repo-check flag (FR-4)', () => {
+  it('does NOT add --skip-git-repo-check when cwd is a git repo', async () => {
+    const cp = await import('child_process');
+    const gitMod = await import('../../src/git.js');
+    (gitMod.isInGitRepo as any).mockReturnValueOnce(true);
+    (cp.spawn as any).mockImplementationOnce(() => makeMockChild({ stdout: SUCCESS_STDOUT }));
+
+    await runCodexGate(2, preset, 'p', '/tmp/h', '/tmp/c');
+
+    const spawnArgs: string[] = (cp.spawn as any).mock.calls[0][1];
+    expect(spawnArgs).not.toContain('--skip-git-repo-check');
+  });
+
+  it('adds --skip-git-repo-check when cwd is NOT a git repo', async () => {
+    const cp = await import('child_process');
+    const gitMod = await import('../../src/git.js');
+    (gitMod.isInGitRepo as any).mockReturnValueOnce(false);
+    (cp.spawn as any).mockImplementationOnce(() => makeMockChild({ stdout: SUCCESS_STDOUT }));
+
+    await runCodexGate(2, preset, 'p', '/tmp/h', '/tmp/c');
+
+    const spawnArgs: string[] = (cp.spawn as any).mock.calls[0][1];
+    expect(spawnArgs).toContain('--skip-git-repo-check');
+  });
+
+  it('adds --skip-git-repo-check before --model flag', async () => {
+    const cp = await import('child_process');
+    const gitMod = await import('../../src/git.js');
+    (gitMod.isInGitRepo as any).mockReturnValueOnce(false);
+    (cp.spawn as any).mockImplementationOnce(() => makeMockChild({ stdout: SUCCESS_STDOUT }));
+
+    await runCodexGate(2, preset, 'p', '/tmp/h', '/tmp/c');
+
+    const spawnArgs: string[] = (cp.spawn as any).mock.calls[0][1];
+    const skipIdx = spawnArgs.indexOf('--skip-git-repo-check');
+    const modelIdx = spawnArgs.indexOf('--model');
+    expect(skipIdx).toBeGreaterThan(-1);
+    expect(skipIdx).toBeLessThan(modelIdx);
+  });
+
+  it('adds --skip-git-repo-check in resume mode when cwd is NOT a git repo', async () => {
+    const cp = await import('child_process');
+    const gitMod = await import('../../src/git.js');
+    (gitMod.isInGitRepo as any).mockReturnValueOnce(false);
+    (cp.spawn as any).mockImplementationOnce(() =>
+      makeMockChild({ stdout: SUCCESS_STDOUT.replace('sid-xyz', 'resume-sid') })
+    );
+
+    await runCodexGate(2, preset, 'p', '/tmp/h', '/tmp/c', 'resume-sid');
+
+    const spawnArgs: string[] = (cp.spawn as any).mock.calls[0][1];
+    expect(spawnArgs).toContain('--skip-git-repo-check');
+    // In resume mode: exec resume <sessionId> [--skip-git-repo-check] --model ...
+    expect(spawnArgs[0]).toBe('exec');
+    expect(spawnArgs[1]).toBe('resume');
+    expect(spawnArgs[2]).toBe('resume-sid');
+  });
+});
+
+describe('runCodexGate — nonzero_exit_other includes stderr tail (FR-4)', () => {
+  it('includes stderr tail in error message when subprocess exits non-zero', async () => {
+    const cp = await import('child_process');
+    const gitMod = await import('../../src/git.js');
+    (gitMod.isInGitRepo as any).mockReturnValueOnce(true);
+    const stderrContent = 'fatal: something went wrong\ndetail: bad config\naborting';
+    (cp.spawn as any).mockImplementationOnce(() =>
+      makeMockChild({ stdout: '', stderr: stderrContent, exitCode: 1 })
+    );
+
+    const result = await runCodexGate(2, preset, 'p', '/tmp/h', '/tmp/c');
+
+    expect(result.type).toBe('error');
+    if (result.type === 'error') {
+      expect(result.error).toContain('Gate subprocess exited with code 1');
+      expect(result.error).toContain('--- stderr (tail) ---');
+      expect(result.error).toContain('fatal: something went wrong');
+    }
+  });
+
+  it('omits stderr section when stderr is empty on non-zero exit', async () => {
+    const cp = await import('child_process');
+    const gitMod = await import('../../src/git.js');
+    (gitMod.isInGitRepo as any).mockReturnValueOnce(true);
+    (cp.spawn as any).mockImplementationOnce(() =>
+      makeMockChild({ stdout: '', stderr: '', exitCode: 2 })
+    );
+
+    const result = await runCodexGate(2, preset, 'p', '/tmp/h', '/tmp/c');
+
+    expect(result.type).toBe('error');
+    if (result.type === 'error') {
+      expect(result.error).toBe('Gate subprocess exited with code 2');
+      expect(result.error).not.toContain('--- stderr (tail) ---');
+    }
   });
 });

--- a/tests/state-invalidation.test.ts
+++ b/tests/state-invalidation.test.ts
@@ -16,7 +16,9 @@ function makeState(): HarnessState {
   return {
     runId: 'r1', flow: 'full', carryoverFeedback: null,
     currentPhase: 2, status: 'in_progress', autoMode: false,
-    task: 't', baseCommit: '', implRetryBase: '', codexPath: null,
+    task: 't', baseCommit: '', implRetryBase: '',
+    trackedRepos: [{ path: '', baseCommit: '', implRetryBase: '', implHead: null }],
+    codexPath: null,
     externalCommitsDetected: false,
     artifacts: { spec: 's', plan: 'p', decisionLog: 'd', checklist: 'c', evalReport: 'e' },
     phases: { '1': 'pending', '2': 'pending', '3': 'pending', '4': 'pending', '5': 'pending', '6': 'pending', '7': 'pending' },

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { writeState, readState, createInitialState, migrateState } from '../src/state.js';
+import { writeState, readState, createInitialState, migrateState, syncLegacyMirror } from '../src/state.js';
 import type { HarnessState } from '../src/types.js';
 import { PHASE_DEFAULTS, getPhaseArtifactFiles, getReopenTarget, getRequiredPhaseKeys } from '../src/config.js';
 
@@ -434,5 +434,55 @@ describe('getReopenTarget (ADR-4)', () => {
   });
   it('light + gate 7 → phase 1 (design combined doc is re-authored)', () => {
     expect(getReopenTarget('light', 7)).toBe(1);
+  });
+});
+
+describe('trackedRepos — migration (FR-2, ADR-N3)', () => {
+  it('migrateState synthesizes trackedRepos[0] from top-level fields when absent', () => {
+    const legacy = JSON.parse(JSON.stringify(makeState()));
+    delete (legacy as any).trackedRepos;
+    legacy.baseCommit = 'abc123';
+    legacy.implRetryBase = 'abc123';
+    legacy.implCommit = null;
+    const migrated = migrateState(legacy, '/outer/cwd');
+    expect(migrated.trackedRepos).toHaveLength(1);
+    expect(migrated.trackedRepos[0]).toEqual({
+      path: '/outer/cwd',
+      baseCommit: 'abc123',
+      implRetryBase: 'abc123',
+      implHead: null,
+    });
+  });
+
+  it('migrateState uses empty string for path when no cwd provided', () => {
+    const legacy = JSON.parse(JSON.stringify(makeState()));
+    delete (legacy as any).trackedRepos;
+    const migrated = migrateState(legacy);
+    expect(migrated.trackedRepos[0].path).toBe('');
+  });
+
+  it('migrateState preserves existing trackedRepos', () => {
+    const state = makeState();
+    (state as any).trackedRepos = [{ path: '/repo', baseCommit: 'abc', implRetryBase: 'abc', implHead: null }];
+    const migrated = migrateState(state as any);
+    expect(migrated.trackedRepos[0].path).toBe('/repo');
+  });
+});
+
+describe('syncLegacyMirror (ADR-N3 mirror invariant)', () => {
+  it('syncLegacyMirror keeps baseCommit in sync with trackedRepos[0]', () => {
+    const state = makeState();
+    state.trackedRepos = [{ path: '/r', baseCommit: 'newbase', implRetryBase: 'newbase', implHead: null }];
+    syncLegacyMirror(state);
+    expect(state.baseCommit).toBe('newbase');
+    expect(state.implRetryBase).toBe('newbase');
+    expect(state.implCommit).toBeNull();
+  });
+
+  it('syncLegacyMirror sets implCommit from trackedRepos[0].implHead', () => {
+    const state = makeState();
+    state.trackedRepos = [{ path: '/r', baseCommit: 'b', implRetryBase: 'b', implHead: 'impl-sha' }];
+    syncLegacyMirror(state);
+    expect(state.implCommit).toBe('impl-sha');
   });
 });


### PR DESCRIPTION
## Summary
- Add multi-worktree harness flow: outer cwd + N tracked repos with `--track`/`--exclude` flags, per-repo preflight, and TrackedRepo state schema
- Phase 5 judgment across multiple repos: artifact-path resolution via `resolveArtifact`, fresh-sentinel ancestry check, external-commit detection on resume
- Codex gate multi-repo context: diff concat across tracked repos with N=1 backward-compat path, D-1 resolution; auto-add `--skip-git-repo-check` for non-git cwd + stderr tail in error messages

## Test plan
- [x] `pnpm tsc --noEmit`
- [x] `pnpm vitest run` (incl. new `tests/multi-worktree.test.ts`, `tests/commands/start.test.ts`, `tests/context/assembler.test.ts`, `tests/resume.test.ts` additions)
- [x] `pnpm build`
- [x] Docs: `docs/HOW-IT-WORKS.{md,ko.md}` multi-worktree flow section
- [ ] Manual dogfood: `phase-harness start --light` with multiple `--track` targets