### PR TITLE
chore(release): bump version to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phase-harness",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "AI agent harness orchestrator — multi-phase brainstorm/spec/plan/implement/verify lifecycle with gate reviews",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Minor version bump 0.2.5 → 0.3.0, reflecting the multi-worktree flow merged in #59

## Test plan
- [ ] `pnpm install` installs cleanly at new version
- [ ] `pnpm build` produces dist without errors