### PR TITLE
fix(verify): isolate per-check cwd/env in harness-verify.sh

### DIFF
--- a/scripts/harness-verify.sh
+++ b/scripts/harness-verify.sh
@@ -69,7 +69,9 @@ for i in $(seq 0 $((CHECK_COUNT - 1))); do
   STDERR_FILE=$(mktemp)
 
   set +e
-  eval "$COMMAND" > "$STDOUT_FILE" 2> "$STDERR_FILE"
+  # Subshell isolates per-check cwd/env mutations (e.g. `cd subdir && pnpm test`)
+  # so a preceding check cannot break `>> "$OUTPUT_FILE"` via a stale cwd.
+  ( eval "$COMMAND" ) > "$STDOUT_FILE" 2> "$STDERR_FILE"
   EXIT_CODE=$?
   set -e
 

--- a/tests/scripts/harness-verify.test.ts
+++ b/tests/scripts/harness-verify.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'child_process';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+
+const SCRIPT_PATH = resolve(process.cwd(), 'scripts/harness-verify.sh');
+
+function makeWorkspace() {
+  const dir = mkdtempSync(join(tmpdir(), 'harness-verify-test-'));
+  const cleanup = () => rmSync(dir, { recursive: true, force: true });
+  return { dir, cleanup };
+}
+
+describe('harness-verify.sh', () => {
+  it('isolates per-check cwd so a `cd subdir` check does not break subsequent appends to a relative OUTPUT_FILE', () => {
+    const { dir, cleanup } = makeWorkspace();
+    try {
+      // Create a subdirectory the first check will `cd` into.
+      // If the script did not isolate cwd, the relative OUTPUT_FILE path
+      // would resolve under `subpkg/` on the second check and fail.
+      mkdirSync(join(dir, 'subpkg'));
+
+      const checklistPath = join(dir, 'checklist.json');
+      writeFileSync(
+        checklistPath,
+        JSON.stringify({
+          checks: [
+            { name: 'first-cd-subpkg', command: 'cd subpkg && true' },
+            { name: 'second-append', command: 'true' },
+          ],
+        }),
+      );
+
+      // Relative output path — script is spawned with cwd = dir.
+      const relativeOutput = 'docs/process/evals/test-eval.md';
+
+      const result = spawnSync('bash', [SCRIPT_PATH, checklistPath, relativeOutput], {
+        cwd: dir,
+        encoding: 'utf-8',
+      });
+
+      expect(result.status).toBe(0);
+
+      const outputAbs = join(dir, relativeOutput);
+      expect(existsSync(outputAbs)).toBe(true);
+
+      const report = readFileSync(outputAbs, 'utf-8');
+      expect(report).toContain('first-cd-subpkg');
+      expect(report).toContain('second-append');
+      expect(report).toContain('| pass |');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('isolates env mutations between checks', () => {
+    const { dir, cleanup } = makeWorkspace();
+    try {
+      const checklistPath = join(dir, 'checklist.json');
+      writeFileSync(
+        checklistPath,
+        JSON.stringify({
+          checks: [
+            { name: 'set-env', command: 'export LEAK_VAR=leaked' },
+            // If the first check leaked LEAK_VAR into the script shell,
+            // this check would succeed. With subshell isolation, LEAK_VAR
+            // must be unset in the second check's shell → test -z passes.
+            { name: 'expect-unset', command: 'test -z "${LEAK_VAR:-}"' },
+          ],
+        }),
+      );
+
+      const relativeOutput = 'eval.md';
+      const result = spawnSync('bash', [SCRIPT_PATH, checklistPath, relativeOutput], {
+        cwd: dir,
+        encoding: 'utf-8',
+      });
+
+      expect(result.status).toBe(0);
+      const report = readFileSync(join(dir, relativeOutput), 'utf-8');
+      expect(report).toMatch(/\| expect-unset \| pass \|/);
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- **Bug**: Each check in `checklist.json` was `eval`-ed in the script's parent shell, so a command like `cd subdir && pnpm test` permanently shifted the script's cwd. The next `>> "\$OUTPUT_FILE"` (line 90) then failed with `No such file or directory` because `\$OUTPUT_FILE` is a relative path (`docs/process/evals/<runId>-eval.md` per `state.artifacts.evalReport`). `set -euo pipefail` aborts the whole script, Phase 6 lands in error.
- **Fix**: Wrap `eval "\$COMMAND"` in a subshell — `( eval "\$COMMAND" )`. Isolates cwd and env mutations per check. Single-line change.
- **Test**: New `tests/scripts/harness-verify.test.ts` covers both leak modes (cwd via `cd subpkg`, env via `export VAR=…`). Verified it fails on `origin/main` and passes on this branch.

## Impact surface
- **Who is affected**: Anyone whose checklist needs to run tools outside repo root (monorepo subpackages, nested git repos, `scripts/` dirs). Single-package repos are unaffected.
- **Observable contract**: No change to checklist schema, report format, or exit codes.
- **Theoretical regression**: Checklists that *rely* on env or cwd leaking between checks would break. Such reliance is implicit shared state and already a bug; no real-world user should depend on it.

## Reproducer
A real run hitting this today: monorepo with a subpackage, checklist first check `"cd qa-mcp && pnpm typecheck"`. harness-verify.sh fails on the second check's append to `OUTPUT_FILE` with `No such file or directory`, Phase 6 marked error, `verify-error.md` captures the message.

## Test plan
- [x] `pnpm vitest run tests/scripts/harness-verify.test.ts` — 2/2 pass on this branch.
- [x] Same tests fail on `origin/main` (patch absent) → confirms the test catches the real bug.
- [x] `pnpm tsc --noEmit` — clean.
- [x] `pnpm vitest run` — only pre-existing date-boundary failures in `tests/git.test.ts` (reproduces on `origin/main`, unrelated to this PR).
- [x] `pnpm build` — clean; `dist/scripts/harness-verify.sh` picks up the subshell wrap.

## Notes
- `README/HOW-IT-WORKS` 검토 결과 문서 변경 불필요 — robustness-only fix, observable behavior unchanged.
- No co-authored-by trailer per repo convention.