### PR TITLE
fix(phase5): preserve implHead so symmetric reopen can validate

### DIFF
--- a/src/context/skills/harness-phase-5-implement.md
+++ b/src/context/skills/harness-phase-5-implement.md
@@ -55,6 +55,7 @@ superpowers가 커버하지 않는 두 원칙을 지킨다:
 - sentinel 이후 추가 작업 금지.
 - Content Filter로 subagent dispatch 실패 시 fallback → 직접 구현 + 로그 남김 (plan의 각 task 하단에 `fallback: direct` 메모).
 - Reopen 시 artifact를 변경하지 않아도 phase는 valid — sentinel attemptId 매칭이 freshness의 근거다. Claude가 gate 피드백이 rev-invariant(현 산출물로 반박 가능)하다고 판단하면 **건드리지 않는 것이 옳다**. (대응: ADR-13 symmetric reopen + T1 mtime drop.)
+- **예외**: 현 round feedback이 **"still unresolved"**, **"still persists"**, **"fix was insufficient"** 등으로 이전 round 의 수정이 부족하다고 명시하면 rev-invariant 판단을 해서는 안 된다. 직전 reopen 이 해당 이슈에 대해 커밋을 생성했더라도, 현재 feedback 이 그것을 불충분으로 지목한 이상 **추가 수정 또는 `plan-bug:`/`spec-bug:` escalation** 중 하나를 반드시 수행한다. "이미 이전 세션에서 처리했다"는 판단으로 zero-commit 종료하지 말 것.
 
 **HARNESS FLOW CONSTRAINT**: 이 세션은 orchestrated harness 라이프사이클 내부에서 실행된다. 다음 phase에서 Codex 기반 독립 reviewer가 산출물을 검토한다(gate). 따라서:
 - `advisor()` 툴을 호출하지 말 것. 외부 리뷰가 이미 예약되어 있다.

--- a/src/phases/interactive.ts
+++ b/src/phases/interactive.ts
@@ -80,11 +80,13 @@ export function preparePhase(
     [String(phase)]: Math.floor(Date.now() / 1000) * 1000,
   };
 
-  // Phase 5: update implRetryBase for each tracked repo to current HEAD
+  // Phase 5: update implRetryBase for each tracked repo to current HEAD.
+  // implHead is intentionally preserved so the symmetric-reopen path (ADR-13,
+  // phase-5 prompt invariant: "reopen 시 artifact를 변경하지 않아도 phase는 valid")
+  // can actually fire in validatePhaseArtifacts. Wiping it here killed that path.
   if (phase === 5) {
     for (const r of state.trackedRepos) {
       try { r.implRetryBase = getHead(r.path); } catch { /* no git */ }
-      r.implHead = null;
     }
     syncLegacyMirror(state);
   }
@@ -182,22 +184,27 @@ export function validatePhaseArtifacts(
 
   if (phase === 5) {
     void runDir;
-    // Zero-commit reopen: if a prior attempt already set implHead on some repo, accept.
-    if (state.trackedRepos.some(r => r.implHead !== null)) return true;
     try {
+      // Refresh implHead to current HEAD for any repo that advanced this phase.
+      // Repos that did not advance keep their prior implHead value (preserved by
+      // preparePhase), so a successful fresh phase 5 followed by a rev-invariant
+      // reopen continues to validate.
       let anyAdvanced = false;
       for (const r of state.trackedRepos) {
         const h = getHead(r.path);
         if (h !== r.implRetryBase) {
           r.implHead = h;
           anyAdvanced = true;
-        } else {
-          r.implHead = null;
         }
       }
-      if (!anyAdvanced) return false;
       syncLegacyMirror(state); // sets state.implCommit = trackedRepos[0].implHead
-      return true;
+
+      // Accept when:
+      //   (a) at least one repo advanced past implRetryBase this phase, OR
+      //   (b) a prior attempt already set implHead on some repo
+      //       (symmetric reopen — reviewer feedback was rev-invariant so no
+      //        new commits were required).
+      return anyAdvanced || state.trackedRepos.some(r => r.implHead !== null);
     } catch {
       return false;
     }

--- a/tests/phases/interactive.test.ts
+++ b/tests/phases/interactive.test.ts
@@ -355,6 +355,33 @@ describe('preparePhase — Phase 5 implRetryBase', () => {
 
     expect(newState.implRetryBase).toBe('base-from-start');
   });
+
+  it('preserves trackedRepos[].implHead across phase 5 entries (symmetric reopen)', () => {
+    // Prior Phase 5 succeeded and recorded implHead. Phase 6 then advanced HEAD.
+    // On gate-7 REJECT reopen, preparePhase must NOT wipe implHead — otherwise
+    // a rev-invariant reopen (zero new commits) can never validate, contradicting
+    // the Phase 5 prompt invariant.
+    const repoDir = createTestRepo();
+    const runDir = makeTmpDir();
+    const harnessDir = makeTmpDir();
+    const headBeforeReopen = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+
+    const state = makeState();
+    state.trackedRepos = [{
+      path: repoDir,
+      baseCommit: headBeforeReopen,
+      implRetryBase: 'old-base-before-verify',
+      implHead: 'sha-from-prior-impl-phase',
+    }];
+
+    preparePhase(5, state, harnessDir, runDir, repoDir);
+
+    // implRetryBase rebased to current HEAD (existing behavior) …
+    expect(state.trackedRepos[0].implRetryBase).toBe(headBeforeReopen);
+    // … but implHead must survive, so validatePhaseArtifacts' zero-commit
+    // reopen branch can still accept a rev-invariant reopen.
+    expect(state.trackedRepos[0].implHead).toBe('sha-from-prior-impl-phase');
+  });
 });
 
 // ─── checkSentinelFreshness ──────────────────────────────────────────────────
@@ -654,6 +681,57 @@ describe('validatePhaseArtifacts — Phase 5', () => {
     state.trackedRepos = [{ path: repoDir, baseCommit: head, implRetryBase: head, implHead: null }];
     const result = validatePhaseArtifacts(5, state, repoDir, repoDir);
     expect(result).toBe(true);
+  });
+
+  it('symmetric reopen: HEAD unchanged from implRetryBase, but prior implHead preserved → accept', () => {
+    // This is the whole point of the fix: a gate-7 REJECT reopen in which Claude
+    // judges the feedback rev-invariant and writes only the sentinel must validate.
+    // preparePhase would have rebased implRetryBase to the current HEAD and
+    // preserved implHead from the prior successful phase-5.
+    const repoDir = createTestRepo();
+    const head = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+    const state = makeState({ implRetryBase: head, implCommit: 'sha-from-prior-impl' });
+    state.trackedRepos = [{
+      path: repoDir,
+      baseCommit: head,
+      implRetryBase: head,          // rebased to current HEAD by preparePhase
+      implHead: 'sha-from-prior-impl', // preserved by preparePhase
+    }];
+    const result = validatePhaseArtifacts(5, state, repoDir, repoDir);
+    expect(result).toBe(true);
+  });
+
+  it('fresh phase 5 (implHead null) with zero commits still returns false', () => {
+    // Guardrail check: first-ever Phase 5 must actually produce commits. The
+    // symmetric-reopen escape hatch applies only when a prior attempt set implHead.
+    const repoDir = createTestRepo();
+    const head = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+    const state = makeState({ implRetryBase: head, implCommit: null });
+    state.trackedRepos = [{ path: repoDir, baseCommit: head, implRetryBase: head, implHead: null }];
+    const result = validatePhaseArtifacts(5, state, repoDir, repoDir);
+    expect(result).toBe(false);
+  });
+
+  it('reopen with new commits refreshes implHead to current HEAD (no stale value)', () => {
+    // Claude addressed feedback with new commits on reopen. implHead must now
+    // reflect current HEAD, not the pre-reopen value.
+    const repoDir = createTestRepo();
+    const headBeforeReopen = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+    fs.writeFileSync(path.join(repoDir, 'fix.txt'), 'reopen fix');
+    execSync('git add fix.txt && git commit -m "reopen fix"', { cwd: repoDir });
+    const newHead = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+
+    const state = makeState({ implRetryBase: headBeforeReopen, implCommit: 'sha-from-prior-impl' });
+    state.trackedRepos = [{
+      path: repoDir,
+      baseCommit: headBeforeReopen,
+      implRetryBase: headBeforeReopen,
+      implHead: 'sha-from-prior-impl',
+    }];
+
+    const result = validatePhaseArtifacts(5, state, repoDir, repoDir);
+    expect(result).toBe(true);
+    expect(state.trackedRepos[0].implHead).toBe(newHead);
   });
 });
 


### PR DESCRIPTION
## Summary
- **Bug**: `preparePhase(5)` wipes `trackedRepos[].implHead` on every phase entry. Combined with the \"prior attempt set implHead\" being the *only* zero-commit acceptance path in `validatePhaseArtifacts`, the Phase 5 prompt invariant (\"Reopen 시 artifact를 변경하지 않아도 phase는 valid … Claude가 gate 피드백이 rev-invariant하다고 판단하면 **건드리지 않는 것이 옳다**\") is literally impossible to satisfy — that branch is dead code.
- **Observed failure**: Gate-7 REJECT reopens where Claude resume-sessions (correctly) judged the feedback rev-invariant and exited with zero new commits crashed into `terminal-failed` with no recovery short of `phase-harness skip`. Reproducer below.
- **Fix**: stop wiping `implHead` in `preparePhase(5)` and `validatePhaseArtifacts(5)`'s no-advance branch. Accept when any repo advanced OR any repo has a non-null `implHead` from a prior attempt.
- **Prompt guardrail**: add an explicit exception to the Phase 5 skill invariant so \"still unresolved / still persists / fix was insufficient\" feedback wording blocks rev-invariant judgement — otherwise Claude sees its own prior-round fix commits and wrongly concludes \"already done.\"

## Reproducer (observed in a real mission)
1. Phase 5 runs, commits impl. `implHead = <sha-A>`.
2. Phase 6 verify passes, commits eval report. HEAD = `<sha-B>`.
3. Phase 7 REJECT → Phase 5 reopen. `preparePhase` sets `implRetryBase = <sha-B>` and **wipes** `implHead`.
4. Claude resume-session reads gate-7-feedback, concludes feedback is already addressed by prior commits (rev-invariant), writes sentinel, exits — zero new commits.
5. `validatePhaseArtifacts(5)`: zero-commit reopen branch cannot fire (implHead just wiped). HEAD == implRetryBase → `anyAdvanced=false` → return false.
6. `phases[5]='failed'` → `terminal-failed`. R/J cycles reproduce the same trap.

In the observed mission the only escape was `phase-harness skip`, which defeats the validator entirely.

## Diff surface
- `src/phases/interactive.ts`
  - `preparePhase`: drop `r.implHead = null` in the phase-5 block.
  - `validatePhaseArtifacts(5)`: refresh `implHead` on advance; do not null it on no-advance; accept when `anyAdvanced || trackedRepos.some(r => r.implHead !== null)`.
- `src/context/skills/harness-phase-5-implement.md`
  - Invariants: new line under the rev-invariant bullet — \"still unresolved / still persists / fix was insufficient\" feedback blocks the rev-invariant shortcut; Claude must either fix further or escalate via `## Deferred` (`spec-bug:` / `plan-bug:`).
- `tests/phases/interactive.test.ts`
  - `preparePhase` preserves implHead across Phase 5 re-entries (regression).
  - `validatePhaseArtifacts(5)` symmetric-reopen case: HEAD unchanged + prior implHead preserved → accept.
  - Fresh Phase 5 guardrail: implHead null + zero commits → reject (unchanged).
  - Reopen with new commits refreshes implHead to current HEAD (no stale value).

## Test plan
- [x] \`pnpm vitest run tests/phases/interactive.test.ts\` — 51/51 pass (includes 4 new cases).
- [x] \`pnpm vitest run\` — 929 pass, 1 skip, 2 pre-existing date-boundary flakes in \`tests/git.test.ts\` (reproduce on \`origin/main\`, unrelated to this PR).
- [x] \`pnpm tsc --noEmit\` — clean.
- [x] \`pnpm build\` — dist refreshed.

## Notes
- README/HOW-IT-WORKS 검토 결과 문서 변경 불필요 — Phase 5 validator mechanics are an internal contract; observable CLI behavior (phase status transitions, exit codes, sidecar outputs) is unchanged on the non-reopen and HEAD-advancing-reopen paths.
- No Co-authored-by trailer per repo convention.