### PR TITLE
fix(multi-repo): resolve cross-repo Phase-1/6 regressions on 0.3.0

### DIFF
--- a/docs/process/evals/2026-04-21-untitled-662d-eval.md
+++ b/docs/process/evals/2026-04-21-untitled-662d-eval.md
@@ -1,0 +1,240 @@
+# Auto Verification Report
+- Date: 2026-04-21
+- Related Spec: N/A
+- Related Plan: N/A
+
+## Results
+| Check | Status | Detail |
+|-------|--------|--------|
+| lint | pass |  |
+| test | pass |  |
+| build | pass |  |
+
+## Summary
+- Total: 3 checks
+- Pass: 3
+- Fail: 0
+
+## Raw Output
+
+### lint
+**Command:** `pnpm tsc --noEmit`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>
+
+### test
+**Command:** `pnpm vitest run`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+ RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/cross-repo
+
+ ✓ tests/state.test.ts (50 tests) 46ms
+ ✓ tests/logger.test.ts (32 tests) 78ms
+ ✓ tests/context/skills-rendering.test.ts (45 tests) 66ms
+ ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 58ms
+ ✓ tests/phases/gate.test.ts (27 tests) 116ms
+ ✓ tests/commands/inner.test.ts (22 tests) 262ms
+ ✓ tests/runners/claude-usage.test.ts (17 tests) 168ms
+ ✓ tests/integration/logging.test.ts (15 tests) 360ms
+ ✓ tests/commands/footer-ticker.test.ts (10 tests) 161ms
+ ✓ tests/phases/gate-resume.test.ts (13 tests) 243ms
+[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/signal.test.ts (16 tests) 630ms
+[2J[H[2J[H[2J[H ✓ tests/lock.test.ts (20 tests) 436ms
+ ✓ tests/phases/runner.test.ts (76 tests) 714ms
+ ✓ tests/phases/terminal-ui.test.ts (17 tests) 208ms
+ ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 5ms
+ ✓ tests/phases/verify.test.ts (14 tests) 46ms
+ ✓ tests/orphan-cleanup.test.ts (20 tests) 70ms
+ ✓ tests/runners/codex.test.ts (17 tests) 78ms
+ ✓ tests/integration/light-flow.test.ts (4 tests) 191ms
+ ✓ tests/preflight.test.ts (27 tests | 1 skipped) 216ms
+ ✓ tests/integration/codex-session-resume.test.ts (6 tests) 59ms
+ ✓ tests/resume-light.test.ts (10 tests) 42ms
+ ✓ tests/commands/inner-footer.test.ts (2 tests) 21ms
+ ✓ tests/phases/runner-token-capture.test.ts (6 tests) 20ms
+ ✓ tests/runners/codex-resume.test.ts (8 tests) 56ms
+ ✓ tests/context/assembler.test.ts (70 tests) 1909ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 688ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 594ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 430ms
+ ✓ tests/context/assembler-resume.test.ts (9 tests) 58ms
+ ✓ tests/tmux.test.ts (33 tests) 816ms
+   ✓ pollForPidFile > returns null on timeout when file never appears 403ms
+   ✓ pollForPidFile > returns null when file contains non-numeric content 404ms
+ ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 9ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui.test.ts (8 tests) 4ms
+ ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 67ms
+ ✓ tests/runners/codex-isolation.test.ts (8 tests) 92ms
+ ✓ tests/state-invalidation.test.ts (5 tests) 6ms
+ ✓ tests/runners/claude.test.ts (4 tests) 5ms
+ ✓ tests/phases/verdict.test.ts (16 tests) 7ms
+ ✓ tests/commands/resume-cmd.test.ts (12 tests) 1875ms
+ ✓ tests/root.test.ts (10 tests) 201ms
+ ✓ tests/resume.test.ts (11 tests) 2876ms
+   ✓ resumeRun > exits with code 1 and non-interactive message on paused run with null pendingAction (D4b) 570ms
+   ✓ completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8) > returns true and sets implHead when any repo advanced 306ms
+ ✓ tests/commands/status-list.test.ts (7 tests) 633ms
+ ✓ tests/context/reviewer-contract.test.ts (4 tests) 54ms
+ ✓ tests/phases/gate-resume-escalation.test.ts (1 test) 48ms
+ ✓ tests/ui-footer.test.ts (9 tests) 4ms
+ ✓ tests/git.test.ts (20 tests) 1798ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-HaajgW/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-HaajgW/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-5lvcsh/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-5lvcsh/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-cqPPZe/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-cqPPZe/.claude/skills:
+  phase-harness-codex-gate-review
+No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-tewLfk/.claude/skills. Nothing to uninstall.
+ ✓ tests/uninstall-skills.test.ts (6 tests) 24ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-xF1fb4/.claude/skills:
+  phase-harness-codex-gate-review
+ ✓ tests/input.test.ts (12 tests) 3ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-UkMci2/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-DkXv0B/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-x7ITcc/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-UPK7ku/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-UPK7ku/.claude/skills:
+  phase-harness-codex-gate-review
+ ✓ tests/install-skills.test.ts (7 tests) 17ms
+ ✓ tests/multi-worktree.test.ts (11 tests) 2471ms
+   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 489ms
+   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 381ms
+   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 450ms
+   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 424ms
+   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 503ms
+ ✓ tests/integration/lifecycle.test.ts (11 tests) 1399ms
+ ✓ tests/task-prompt.test.ts (7 tests) 2ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui-prompt-model-config.test.ts (3 tests) 4ms
+ ✓ tests/terminal.test.ts (5 tests) 4ms
+ ✓ tests/conformance/phase-models.test.ts (9 tests) 3ms
+ ✓ tests/commands/jump.test.ts (6 tests) 774ms
+ ✓ tests/preflight-claude-at-file.test.ts (2 tests) 3ms
+ ✓ tests/ui-separator.test.ts (5 tests) 3ms
+ ✓ tests/process.test.ts (6 tests) 25ms
+ ✓ tests/config.test.ts (8 tests) 2ms
+ ✓ tests/resolve-skills-root.test.ts (4 tests) 2ms
+ ✓ tests/phases/interactive.test.ts (47 tests) 4295ms
+   ✓ preparePhase — Phase 5 implRetryBase > updates implRetryBase to HEAD for Phase 5 303ms
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
+⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-PXDUH8/phase-5-carryover-missing.md
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+fatal: not a git repository (or any of the parent directories): .git
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+ℹ Received control signal (SIGUSR1). Applying pending action...
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+✓ Applied: skip. Phase loop re-entering.
+ℹ Received control signal (SIGUSR1). Applying pending action...
+✓ Applied: jump → phase 3. Phase loop re-entering.
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+ℹ Received control signal (SIGUSR1). Applying pending action...
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+
+Recent events:
+(events.jsonl not present — logging disabled)
+```
+
+</details>
+
+### build
+**Command:** `pnpm build`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+> phase-harness@0.3.0 build /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/cross-repo
+> tsc -p tsconfig.build.json && node scripts/copy-assets.mjs
+
+[copy-assets] copied src/context/prompts -> dist/src/context/prompts
+[copy-assets] copied src/context/skills -> dist/src/context/skills
+[copy-assets] copied src/context/skills-standalone -> dist/src/context/skills-standalone
+[copy-assets] copied src/context/playbooks -> dist/src/context/playbooks
+[copy-assets] copied scripts/harness-verify.sh -> dist/scripts/harness-verify.sh
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>

--- a/docs/process/evals/2026-04-21-untitled-662d-eval.md
+++ b/docs/process/evals/2026-04-21-untitled-662d-eval.md
@@ -50,103 +50,103 @@
 
  RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/cross-repo
 
- ✓ tests/state.test.ts (50 tests) 46ms
- ✓ tests/logger.test.ts (32 tests) 78ms
- ✓ tests/context/skills-rendering.test.ts (45 tests) 66ms
- ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 58ms
- ✓ tests/phases/gate.test.ts (27 tests) 116ms
- ✓ tests/commands/inner.test.ts (22 tests) 262ms
- ✓ tests/runners/claude-usage.test.ts (17 tests) 168ms
- ✓ tests/integration/logging.test.ts (15 tests) 360ms
- ✓ tests/commands/footer-ticker.test.ts (10 tests) 161ms
- ✓ tests/phases/gate-resume.test.ts (13 tests) 243ms
-[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/signal.test.ts (16 tests) 630ms
-[2J[H[2J[H[2J[H ✓ tests/lock.test.ts (20 tests) 436ms
- ✓ tests/phases/runner.test.ts (76 tests) 714ms
- ✓ tests/phases/terminal-ui.test.ts (17 tests) 208ms
- ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 5ms
- ✓ tests/phases/verify.test.ts (14 tests) 46ms
- ✓ tests/orphan-cleanup.test.ts (20 tests) 70ms
- ✓ tests/runners/codex.test.ts (17 tests) 78ms
- ✓ tests/integration/light-flow.test.ts (4 tests) 191ms
- ✓ tests/preflight.test.ts (27 tests | 1 skipped) 216ms
- ✓ tests/integration/codex-session-resume.test.ts (6 tests) 59ms
- ✓ tests/resume-light.test.ts (10 tests) 42ms
- ✓ tests/commands/inner-footer.test.ts (2 tests) 21ms
- ✓ tests/phases/runner-token-capture.test.ts (6 tests) 20ms
- ✓ tests/runners/codex-resume.test.ts (8 tests) 56ms
- ✓ tests/context/assembler.test.ts (70 tests) 1909ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 688ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 594ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 430ms
- ✓ tests/context/assembler-resume.test.ts (9 tests) 58ms
- ✓ tests/tmux.test.ts (33 tests) 816ms
+ ✓ tests/state.test.ts (50 tests) 35ms
+ ✓ tests/context/skills-rendering.test.ts (45 tests) 37ms
+ ✓ tests/logger.test.ts (32 tests) 57ms
+ ✓ tests/phases/gate.test.ts (27 tests) 74ms
+ ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 43ms
+ ✓ tests/commands/inner.test.ts (22 tests) 242ms
+ ✓ tests/runners/claude-usage.test.ts (17 tests) 208ms
+ ✓ tests/integration/logging.test.ts (15 tests) 334ms
+ ✓ tests/commands/footer-ticker.test.ts (10 tests) 183ms
+[2J[H[2J[H[2J[H[2J[H ✓ tests/phases/gate-resume.test.ts (13 tests) 241ms
+[2J[H[2J[H[2J[H[2J[H ✓ tests/phases/terminal-ui.test.ts (17 tests) 108ms
+ ✓ tests/signal.test.ts (16 tests) 533ms
+ ✓ tests/lock.test.ts (20 tests) 323ms
+ ✓ tests/phases/runner.test.ts (76 tests) 571ms
+ ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 9ms
+ ✓ tests/orphan-cleanup.test.ts (20 tests) 12ms
+ ✓ tests/runners/codex.test.ts (17 tests) 103ms
+ ✓ tests/phases/verify.test.ts (14 tests) 17ms
+ ✓ tests/preflight.test.ts (27 tests | 1 skipped) 204ms
+ ✓ tests/integration/light-flow.test.ts (4 tests) 216ms
+ ✓ tests/integration/codex-session-resume.test.ts (6 tests) 56ms
+ ✓ tests/resume-light.test.ts (10 tests) 10ms
+ ✓ tests/phases/runner-token-capture.test.ts (6 tests) 5ms
+ ✓ tests/commands/inner-footer.test.ts (2 tests) 12ms
+ ✓ tests/runners/codex-resume.test.ts (8 tests) 63ms
+ ✓ tests/tmux.test.ts (33 tests) 812ms
    ✓ pollForPidFile > returns null on timeout when file never appears 403ms
-   ✓ pollForPidFile > returns null when file contains non-numeric content 404ms
- ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 9ms
-[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui.test.ts (8 tests) 4ms
- ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 67ms
- ✓ tests/runners/codex-isolation.test.ts (8 tests) 92ms
+   ✓ pollForPidFile > returns null when file contains non-numeric content 402ms
+ ✓ tests/context/assembler-resume.test.ts (9 tests) 66ms
+ ✓ tests/context/assembler.test.ts (72 tests) 1731ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 409ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 550ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 442ms
+ ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 8ms
+ ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 63ms
+ ✓ tests/runners/codex-isolation.test.ts (8 tests) 61ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui.test.ts (8 tests) 7ms
  ✓ tests/state-invalidation.test.ts (5 tests) 6ms
- ✓ tests/runners/claude.test.ts (4 tests) 5ms
- ✓ tests/phases/verdict.test.ts (16 tests) 7ms
- ✓ tests/commands/resume-cmd.test.ts (12 tests) 1875ms
- ✓ tests/root.test.ts (10 tests) 201ms
- ✓ tests/resume.test.ts (11 tests) 2876ms
-   ✓ resumeRun > exits with code 1 and non-interactive message on paused run with null pendingAction (D4b) 570ms
-   ✓ completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8) > returns true and sets implHead when any repo advanced 306ms
- ✓ tests/commands/status-list.test.ts (7 tests) 633ms
- ✓ tests/context/reviewer-contract.test.ts (4 tests) 54ms
- ✓ tests/phases/gate-resume-escalation.test.ts (1 test) 48ms
+ ✓ tests/runners/claude.test.ts (4 tests) 9ms
+ ✓ tests/phases/verdict.test.ts (16 tests) 3ms
+ ✓ tests/commands/resume-cmd.test.ts (12 tests) 2050ms
+   ✓ resumeCommand > resumeCommand — loggingEnabled inheritance > resume defaults to false when state has loggingEnabled=false 325ms
+ ✓ tests/root.test.ts (10 tests) 149ms
+ ✓ tests/resume.test.ts (11 tests) 2884ms
+   ✓ resumeRun > exits with code 1 and non-interactive message on paused run with null pendingAction (D4b) 360ms
+   ✓ resumeRun > skip_phase Phase 6 with gitignored eval report: skips commit and leaves evalCommit null 388ms
+   ✓ completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8) > returns true and sets implHead when any repo advanced 440ms
+ ✓ tests/commands/status-list.test.ts (7 tests) 650ms
+ ✓ tests/context/reviewer-contract.test.ts (4 tests) 62ms
  ✓ tests/ui-footer.test.ts (9 tests) 4ms
- ✓ tests/git.test.ts (20 tests) 1798ms
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-HaajgW/.claude/skills:
+ ✓ tests/phases/gate-resume-escalation.test.ts (1 test) 39ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-Ln7sz4/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-HaajgW/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-dV31q3/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-5lvcsh/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-VlI1IE/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-5lvcsh/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-meGt3h/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-cqPPZe/.claude/skills:
+ ✓ tests/git.test.ts (20 tests) 2130ms
+   ✓ isAncestor > returns false when not an ancestor 377ms
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-meGt3h/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-cqPPZe/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-ve4ceJ/.claude/skills:
   phase-harness-codex-gate-review
-No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-tewLfk/.claude/skills. Nothing to uninstall.
- ✓ tests/uninstall-skills.test.ts (6 tests) 24ms
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-xF1fb4/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-e1lJBv/.claude/skills:
   phase-harness-codex-gate-review
- ✓ tests/input.test.ts (12 tests) 3ms
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-UkMci2/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-cYWmCi/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-DkXv0B/.claude/skills:
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-e1lJBv/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-x7ITcc/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-cYWmCi/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-UPK7ku/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-FKwBrf/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-UPK7ku/.claude/skills:
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-FKwBrf/.claude/skills:
   phase-harness-codex-gate-review
- ✓ tests/install-skills.test.ts (7 tests) 17ms
- ✓ tests/multi-worktree.test.ts (11 tests) 2471ms
-   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 489ms
-   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 381ms
-   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 450ms
-   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 424ms
-   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 503ms
- ✓ tests/integration/lifecycle.test.ts (11 tests) 1399ms
- ✓ tests/task-prompt.test.ts (7 tests) 2ms
-[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui-prompt-model-config.test.ts (3 tests) 4ms
- ✓ tests/terminal.test.ts (5 tests) 4ms
+No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-JKACcO/.claude/skills. Nothing to uninstall.
+ ✓ tests/install-skills.test.ts (7 tests) 31ms
+ ✓ tests/uninstall-skills.test.ts (6 tests) 19ms
+ ✓ tests/multi-worktree.test.ts (11 tests) 2752ms
+   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 502ms
+   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 432ms
+   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 680ms
+   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 361ms
+   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 547ms
+ ✓ tests/integration/lifecycle.test.ts (11 tests) 1249ms
+ ✓ tests/input.test.ts (12 tests) 4ms
+ ✓ tests/task-prompt.test.ts (7 tests) 3ms
+ ✓ tests/commands/jump.test.ts (6 tests) 795ms
+ ✓ tests/terminal.test.ts (5 tests) 2ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui-prompt-model-config.test.ts (3 tests) 5ms
+ ✓ tests/preflight-claude-at-file.test.ts (2 tests) 4ms
+ ✓ tests/phases/interactive.test.ts (47 tests) 4019ms
+   ✓ runInteractivePhase — Claude dispatch command shape > sendKeysToPane command includes --dangerously-skip-permissions and --effort 1617ms
+   ✓ validatePhaseArtifacts — Phase 5 multi-repo (FR-6, ADR-D4) > returns true when any repo advanced; sets implHead on advanced repos only 538ms
  ✓ tests/conformance/phase-models.test.ts (9 tests) 3ms
- ✓ tests/commands/jump.test.ts (6 tests) 774ms
- ✓ tests/preflight-claude-at-file.test.ts (2 tests) 3ms
- ✓ tests/ui-separator.test.ts (5 tests) 3ms
- ✓ tests/process.test.ts (6 tests) 25ms
- ✓ tests/config.test.ts (8 tests) 2ms
- ✓ tests/resolve-skills-root.test.ts (4 tests) 2ms
- ✓ tests/phases/interactive.test.ts (47 tests) 4295ms
-   ✓ preparePhase — Phase 5 implRetryBase > updates implRetryBase to HEAD for Phase 5 303ms
 ```
 
 </details>
@@ -156,9 +156,9 @@ Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install
 
 ```
 ⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
+⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-tmDIxc/phase-5-carryover-missing.md
 ⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
 ⚠️  claude session resume fallback: no prior attempt id
-⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-PXDUH8/phase-5-carryover-missing.md
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: jsonl missing
@@ -181,7 +181,6 @@ Working tree:
 (git not available)
 
 [R] Resume   [J] Jump to phase   [Q] Quit
-ℹ Received control signal (SIGUSR1). Applying pending action...
 
 Recent events:
 (events.jsonl not present — logging disabled)
@@ -190,21 +189,22 @@ Working tree:
 (git not available)
 
 [R] Resume   [J] Jump to phase   [Q] Quit
-✓ Applied: skip. Phase loop re-entering.
-ℹ Received control signal (SIGUSR1). Applying pending action...
-✓ Applied: jump → phase 3. Phase loop re-entering.
 
 Recent events:
 (events.jsonl not present — logging disabled)
 
 Working tree:
-ℹ Received control signal (SIGUSR1). Applying pending action...
 (git not available)
 
 [R] Resume   [J] Jump to phase   [Q] Quit
 
 Recent events:
 (events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
 ```
 
 </details>

--- a/docs/specs/2026-04-21-untitled-662d-design.md
+++ b/docs/specs/2026-04-21-untitled-662d-design.md
@@ -1,0 +1,130 @@
+# Cross-Repo Phase-1/6 Regressions on 0.3.0 — Design Spec (Light)
+
+> Cross-references
+> - Task brief: `.harness/2026-04-21-untitled-662d/task.md`
+> - Decision log (alternatives & trade-offs): `.harness/2026-04-21-untitled-662d/decisions.md`
+> - Eval checklist: `.harness/2026-04-21-untitled-662d/checklist.json`
+> - Prior related design: `docs/specs/2026-04-20-task-outer-cwd-n-sub-a808-design.md` (multi-worktree ADR set)
+
+## Complexity
+
+Small — three surgical fixes + focused tests, no schema migration, no prompt-template restructuring.
+
+## Context & Decisions
+
+### Observed failure (runId `2026-04-21-untitled-e777`, harness 0.3.0)
+
+- Outer cwd = `/Users/daniel/.grove/missions/72e829dd/` (not a git repo). Two tracked sibling repos: `identity-gateway-backend`, `identity-gateway-dashboard`.
+- `state.json` shows `trackedRepos[]` correctly populated (auto-detect + per-repo `baseCommit`). Mirror invariants intact.
+- Phase 1 sentinel `phase-1.done` was written by Claude, **but** `phases["1"] = "failed"`.
+- Spec file was placed at `<outer>/docs/specs/<runId>-design.md` — i.e. cwd-relative — instead of `<trackedRepos[0]>/docs/specs/...`.
+- User-visible error: "not a git repository" — surfaced by Claude's own `git add docs/…` call in the outer (non-git) cwd per the Phase-1 wrapper-skill step 3.
+
+### Root causes (two independent bugs; one caused the Phase-1 failure, one latent)
+
+**RC-1 (Phase 1 failure).** `src/context/assembler.ts:assembleInteractivePrompt` injects prompt variables `{{spec_path}} {{plan_path}} {{checklist_path}} {{decisions_path}}` as the **relative** strings stored in `state.artifacts.*` (e.g. `docs/specs/<runId>-design.md`). Claude's tmux process is pinned to outer cwd (`src/runners/claude.ts:75`). When `outer !== trackedRepos[0].path`, Claude resolves the relative path against its own cwd and writes the file at the **wrong root**. `validatePhaseArtifacts` (interactive.ts:157) then looks at `resolveArtifact(...) = <trackedRepos[0]>/docs/specs/...`, the file is absent, and Phase 1 is marked failed. The visible "not a git repository" message comes from Claude's `git add` attempt in the non-git outer, per the wrapper-skill "필요 시 `git add` + `git commit`" instruction. The prior multi-worktree PR (#59) wired `resolveArtifact` into every **harness-side** consumer, but missed the prompt-variable injection site — the only place where the path is handed to the external agent.
+
+**RC-2 (latent Phase 6 / resume crash).** `src/phases/verify.ts:97` calls `runPhase6Preconditions(evalReportPath, runId, cwd)` with the **outer** cwd. `runPhase6Preconditions` runs `git status --porcelain` at that cwd; in non-git outer this throws "not a git repository" before verification starts. Symmetric bug in `src/resume.ts`: line 191 (`join(cwd, state.artifacts.evalReport)`), 194 (`commitEvalReport(state, cwd)`), 196 (`getHead(cwd)`), 238, 244 — all use outer cwd instead of `docsRoot = state.trackedRepos[0].path`. Single-repo users haven't hit these because outer ≡ `trackedRepos[0]`.
+
+### Decisions (rationale & alternatives in `decisions.md`)
+
+- **D1.** Fix RC-1 by **resolving the four docs-anchored prompt variables to absolute paths** inside `assembleInteractivePrompt`. Rejected: (a) launching Claude with cwd = `trackedRepos[0]` (would break `.harness/<runId>/` anchoring and codex gate cwd assumption); (b) teaching Claude via prompt to prefix a docsRoot (brittle and already-fragile across skills).
+- **D2.** Fix RC-2 by passing `docsRoot = state.trackedRepos?.[0]?.path || cwd` to `runPhase6Preconditions` and every cwd-stamped call in `resume.ts`'s Phase 6 recovery path. Rejected: making `runPhase6Preconditions` iterate all tracked repos — ADR-N8 explicitly scopes eval-report commit to `trackedRepos[0]`, and per-repo worktree cleanliness is checklist-author responsibility.
+- **D3.** Drop the "필요 시 `git add` + `git commit`" line from the Phase-1/3/5 wrapper skills. `normalizeInteractiveArtifacts` (runner.ts:170) already auto-commits post-phase with the correct `docsRoot`. Removing the Claude-side step eliminates the noise error, is idempotent, and ADR-compliant.
+- **D4.** Scope out `harness-verify.sh` multi-repo changes — ADR-N8 explicitly assigns per-repo command targeting to plan/checklist authors. The fix bundle does not touch `scripts/harness-verify.sh`.
+
+## Requirements / Scope
+
+### Functional
+
+- **FR-1** After fix, `assembleInteractivePrompt` emits absolute paths for `{{spec_path}}`, `{{plan_path}}`, `{{checklist_path}}`, `{{decisions_path}}`. The absolute path is computed via `resolveArtifact(state, state.artifacts.*, cwd)` (which already anchors `docs/…` to `trackedRepos[0].path` and `.harness/…` to outer cwd).
+- **FR-2** In single-repo (`trackedRepos.length === 1 && trackedRepos[0].path === cwd`), the emitted string may be absolute but must be byte-comparable to `path.join(cwd, relPath)`. No new template changes.
+- **FR-3** `runPhase6Preconditions` is invoked with `docsRoot`, not outer cwd. `src/resume.ts` Phase-6 recovery uses `docsRoot` for `commitEvalReport`, `getHead`, and eval-report path joins.
+- **FR-4** Phase-1/3/5 wrapper skills (`src/context/skills/harness-phase-{1,3,5}-*.md`) no longer instruct Claude to run `git add` / `git commit`. The final sentinel-write step is unchanged.
+- **FR-5** Integration-style unit test: multi-repo fixture (`cwd` dir not git, two sub-repos as `trackedRepos`) asserts that the rendered Phase-1 prompt contains the **absolute path** of `docs/specs/<runId>-design.md` under `trackedRepos[0].path` and that `validatePhaseArtifacts` finds the spec when written at that absolute path.
+- **FR-6** Unit test: `runPhase6Preconditions` called from `runVerifyPhase` receives a non-git outer cwd; test asserts it runs against `trackedRepos[0].path` instead (no "not a git repository" throw, precondition passes on clean docsRoot).
+
+### Non-functional
+
+- Regression gate: full `pnpm vitest run` green. Existing single-repo fixtures unchanged.
+- Golden prompt fixture (N=1 single-repo): **byte-identical** after substitution — tests must explicitly verify this to avoid accidental wrapper drift.
+
+### Out of scope
+
+- `harness-verify.sh` multi-repo awareness (ADR-N8 stands).
+- Any state-schema migration (trackedRepos schema is unchanged).
+- Documentation rewrite — only sync HOW-IT-WORKS if user-observable behavior changes (it doesn't for single-repo; one-liner added for multi-repo path resolution).
+
+## Design
+
+### Change 1 — `src/context/assembler.ts` (RC-1)
+
+Inside `assembleInteractivePrompt`, before the `vars` object is built, compute:
+
+```
+const absSpec      = resolveArtifact(state, state.artifacts.spec,        cwd);
+const absPlan      = resolveArtifact(state, state.artifacts.plan,        cwd);
+const absChecklist = resolveArtifact(state, state.artifacts.checklist,   cwd);
+const absDecisions = resolveArtifact(state, state.artifacts.decisionLog, cwd);
+```
+
+Populate `vars` with those four absolute strings in place of the current relative reads. The signature of `assembleInteractivePrompt` already has `cwd` available via the `harnessDir` parameter path: since `harnessDir = <outer>/.harness`, `cwd` can be derived as `path.join(harnessDir, '..')` (same expression already used at line 580). Add `cwd` as an explicit parameter to keep intent clear and drop the repeated `path.join(harnessDir, '..')` derivations.
+
+`task_path` stays as-is (`.harness/<runId>/task.md`) — it's already outer-anchored and Claude resolves it against cwd correctly.
+
+### Change 2 — `src/phases/verify.ts:97` + `src/resume.ts` (RC-2)
+
+`verify.ts:97` becomes:
+
+```
+const docsRoot = state.trackedRepos?.[0]?.path || cwd;
+runPhase6Preconditions(state.artifacts.evalReport, state.runId, docsRoot);
+```
+
+Step 5 (the verify-script spawn) keeps `cwd: cwd` — the script intentionally runs at the outer anchor so plan-written `cd <repo>` prefixes work per ADR-N8.
+
+`resume.ts` — replace the five cwd usages in the Phase-6 recovery/apply paths with `docsRoot`:
+
+- L191: `join(docsRoot, state.artifacts.evalReport)`
+- L194: `commitEvalReport(state, docsRoot)`
+- L196: `getHead(docsRoot)`
+- L238, L244 in `applyStoredVerifyResult`: same substitution.
+
+Add `const docsRoot = state.trackedRepos?.[0]?.path || cwd;` at the top of each function that needs it (rather than a helper — only two call sites).
+
+### Change 3 — Wrapper skills (D3)
+
+Strip the "필요 시 `git add` + `git commit`" line (step 3 in phase 1, and the analogous steps in phase-3 and phase-5 wrappers). Renumber the remaining steps. No other wrapper edits. The light flow prompts (`src/context/prompts/phase-{1,5}-light.md`) already do not instruct Claude to run git — no change there.
+
+### Control flow diagram (multi-repo, fixed)
+
+```
+outer cwd (non-git)
+ └── .harness/<runId>/          ← sentinels, state, prompts
+ └── docs/                      ← may exist but NOT used by harness
+ └── trackedRepos[0]/ (git)
+      └── docs/specs/…-design.md    ← spec lands here (absolute path in prompt)
+      └── docs/plans/…
+      └── docs/process/evals/…
+ └── trackedRepos[1]/ (git)
+
+prompt assembly: vars[spec_path] = trackedRepos[0]/docs/specs/…  (absolute)
+Claude writes → correct file
+validator reads via resolveArtifact → same absolute path → passes
+```
+
+## Implementation Plan
+
+- **Task 1 — Prompt absolutization (RC-1, FR-1/2/5).** Add explicit `cwd` parameter to `assembleInteractivePrompt`; compute `absSpec/absPlan/absChecklist/absDecisions` via `resolveArtifact`; swap into `vars`. Update all call sites (`phases/interactive.ts`, any passing through `runInteractivePhase → assembleInteractivePrompt`) to forward `cwd`. Add a vitest fixture with non-git outer + two sub-repos that asserts (a) the rendered Phase-1 prompt contains the absolute docsRoot path, (b) single-repo fixture still renders with the same absolute (= `join(cwd, relPath)`) value.
+- **Task 2 — Phase 6 docsRoot (RC-2, FR-3/6).** Change `verify.ts:97` to pass `docsRoot`. Replace the five `cwd` usages in `resume.ts` Phase-6 recovery with `docsRoot`. Add a vitest that drives `runVerifyPhase` with a non-git outer + single-repo docsRoot and asserts precondition succeeds (previously threw). Existing resume tests updated to cover the docsRoot branch (at least one new case where outer ≠ docsRoot).
+- **Task 3 — Drop Claude-side git step + full-suite regression (D3, FR-4).** Strip the `git add`/`git commit` step from `src/context/skills/harness-phase-{1,3,5}-*.md`. Run `pnpm tsc --noEmit`, `pnpm vitest run`, `pnpm build` and confirm green. If a snapshot/golden fixture captures the wrapper-skill body, regenerate it and verify byte-delta matches only the removed step + renumber.
+
+## Eval Checklist Summary
+
+Three automated checks committed to `.harness/2026-04-21-untitled-662d/checklist.json`:
+
+1. `lint` — `pnpm tsc --noEmit` (catches the assembler signature / param-forwarding change).
+2. `test` — `pnpm vitest run` (covers the two new multi-repo tests + full regression).
+3. `build` — `pnpm build` (ensures asset copy still produces the expected dist/ layout).
+
+No Phase-6 checklist uses `cd <repo>` because this fix is being validated inside harness-cli itself (single-repo, cwd = worktree = git).

--- a/docs/specs/2026-04-21-untitled-662d-design.md
+++ b/docs/specs/2026-04-21-untitled-662d-design.md
@@ -38,16 +38,15 @@ Small — three surgical fixes + focused tests, no schema migration, no prompt-t
 ### Functional
 
 - **FR-1** After fix, `assembleInteractivePrompt` emits absolute paths for `{{spec_path}}`, `{{plan_path}}`, `{{checklist_path}}`, `{{decisions_path}}`. The absolute path is computed via `resolveArtifact(state, state.artifacts.*, cwd)` (which already anchors `docs/…` to `trackedRepos[0].path` and `.harness/…` to outer cwd).
-- **FR-2** In single-repo (`trackedRepos.length === 1 && trackedRepos[0].path === cwd`), the emitted string may be absolute but must be byte-comparable to `path.join(cwd, relPath)`. No new template changes.
-- **FR-3** `runPhase6Preconditions` is invoked with `docsRoot`, not outer cwd. `src/resume.ts` Phase-6 recovery uses `docsRoot` for `commitEvalReport`, `getHead`, and eval-report path joins.
+- **FR-2** In single-repo (`trackedRepos.length === 1 && trackedRepos[0].path === cwd`), the rendered string equals `path.join(cwd, relPath)` — **semantically equivalent** to the prior relative form (Claude resolves identically against its cwd) but **textually different** (now absolute). Any golden fixture that captured the verbatim rendered prompt must be regenerated; byte-identity is explicitly not required.
+- **FR-3** `runPhase6Preconditions` is invoked with `docsRoot`, not outer cwd. Its signature and first-argument contract are **unchanged**: it still receives the repo-relative eval-report path (`state.artifacts.evalReport`) as arg 1 and resolves it against the `cwd` argument internally. Only the third argument's anchor (outer → `trackedRepos[0].path`) changes. `src/resume.ts` Phase-6 recovery uses `docsRoot` for `commitEvalReport`, `getHead`, and eval-report path joins.
 - **FR-4** Phase-1/3/5 wrapper skills (`src/context/skills/harness-phase-{1,3,5}-*.md`) no longer instruct Claude to run `git add` / `git commit`. The final sentinel-write step is unchanged.
-- **FR-5** Integration-style unit test: multi-repo fixture (`cwd` dir not git, two sub-repos as `trackedRepos`) asserts that the rendered Phase-1 prompt contains the **absolute path** of `docs/specs/<runId>-design.md` under `trackedRepos[0].path` and that `validatePhaseArtifacts` finds the spec when written at that absolute path.
+- **FR-5** Integration-style unit test: multi-repo fixture (`cwd` dir not git, two sub-repos as `trackedRepos`) asserts that the rendered Phase-1 prompt contains the **absolute path** for **all four** substituted variables (`{{spec_path}}`, `{{plan_path}}`, `{{checklist_path}}`, `{{decisions_path}}`) — each anchored per `resolveArtifact` rules (docs→`trackedRepos[0]`, `.harness/…`→outer) — and that `validatePhaseArtifacts` finds the spec when Claude writes it at the rendered absolute path.
 - **FR-6** Unit test: `runPhase6Preconditions` called from `runVerifyPhase` receives a non-git outer cwd; test asserts it runs against `trackedRepos[0].path` instead (no "not a git repository" throw, precondition passes on clean docsRoot).
 
 ### Non-functional
 
-- Regression gate: full `pnpm vitest run` green. Existing single-repo fixtures unchanged.
-- Golden prompt fixture (N=1 single-repo): **byte-identical** after substitution — tests must explicitly verify this to avoid accidental wrapper drift.
+- Regression gate: full `pnpm vitest run` green. Single-repo **behavioral** tests remain green unchanged. Any test that captured the literal rendered prompt string (golden/snapshot) gets regenerated to match the new absolute form — these are textual-not-behavioral changes and acceptable per FR-2.
 
 ### Out of scope
 
@@ -80,6 +79,8 @@ Populate `vars` with those four absolute strings in place of the current relativ
 const docsRoot = state.trackedRepos?.[0]?.path || cwd;
 runPhase6Preconditions(state.artifacts.evalReport, state.runId, docsRoot);
 ```
+
+**Contract note (addressing gate-2 P2):** `runPhase6Preconditions(evalReportPath, runId, cwd)` keeps its existing signature and arg-1 semantics — `state.artifacts.evalReport` is the repo-relative path that was already being passed at `verify.ts:97` before this change. The only substantive edit is the third argument: outer cwd → `docsRoot`. Internal resolution (`join(resolvedCwd, evalReportPath)` in `artifact.ts:107`) is unchanged; it now joins against `docsRoot` instead of outer. No new resolver behavior, no new argument.
 
 Step 5 (the verify-script spawn) keeps `cwd: cwd` — the script intentionally runs at the outer anchor so plan-written `cd <repo>` prefixes work per ADR-N8.
 
@@ -115,7 +116,7 @@ validator reads via resolveArtifact → same absolute path → passes
 
 ## Implementation Plan
 
-- **Task 1 — Prompt absolutization (RC-1, FR-1/2/5).** Add explicit `cwd` parameter to `assembleInteractivePrompt`; compute `absSpec/absPlan/absChecklist/absDecisions` via `resolveArtifact`; swap into `vars`. Update all call sites (`phases/interactive.ts`, any passing through `runInteractivePhase → assembleInteractivePrompt`) to forward `cwd`. Add a vitest fixture with non-git outer + two sub-repos that asserts (a) the rendered Phase-1 prompt contains the absolute docsRoot path, (b) single-repo fixture still renders with the same absolute (= `join(cwd, relPath)`) value.
+- **Task 1 — Prompt absolutization (RC-1, FR-1/2/5).** Add explicit `cwd` parameter to `assembleInteractivePrompt`; compute `absSpec/absPlan/absChecklist/absDecisions` via `resolveArtifact`; swap into `vars`. Update all call sites (`phases/interactive.ts`, any passing through `runInteractivePhase → assembleInteractivePrompt`) to forward `cwd`. Add a vitest fixture with non-git outer + two sub-repos that asserts the rendered Phase-1 prompt contains the expected **absolute value for all four variables** (`{{spec_path}}`, `{{plan_path}}`, `{{checklist_path}}`, `{{decisions_path}}`) — each matched against `resolveArtifact(state, state.artifacts.*, cwd)` — and a single-repo companion assertion that each of the same four rendered values equals `join(cwd, relPath)`.
 - **Task 2 — Phase 6 docsRoot (RC-2, FR-3/6).** Change `verify.ts:97` to pass `docsRoot`. Replace the five `cwd` usages in `resume.ts` Phase-6 recovery with `docsRoot`. Add a vitest that drives `runVerifyPhase` with a non-git outer + single-repo docsRoot and asserts precondition succeeds (previously threw). Existing resume tests updated to cover the docsRoot branch (at least one new case where outer ≠ docsRoot).
 - **Task 3 — Drop Claude-side git step + full-suite regression (D3, FR-4).** Strip the `git add`/`git commit` step from `src/context/skills/harness-phase-{1,3,5}-*.md`. Run `pnpm tsc --noEmit`, `pnpm vitest run`, `pnpm build` and confirm green. If a snapshot/golden fixture captures the wrapper-skill body, regenerate it and verify byte-delta matches only the removed step + renumber.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phase-harness",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "AI agent harness orchestrator — multi-phase brainstorm/spec/plan/implement/verify lifecycle with gate reviews",
   "type": "module",
   "bin": {

--- a/src/context/assembler.ts
+++ b/src/context/assembler.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import type { HarnessState, FlowMode, TrackedRepo } from '../types.js';
+import { resolveArtifact } from '../artifact.js';
 import {
   MAX_FILE_SIZE_KB,
   MAX_PROMPT_SIZE_KB,
@@ -532,7 +533,8 @@ function buildGatePromptPhase7(state: HarnessState, cwd: string): string | { err
 export function assembleInteractivePrompt(
   phase: 1 | 3 | 5,
   state: HarnessState,
-  harnessDir: string
+  harnessDir: string,
+  cwd: string = path.join(harnessDir, '..')
 ): string {
   const phaseAttemptId = state.phaseAttemptId[String(phase)] ?? '';
 
@@ -575,9 +577,7 @@ export function assembleInteractivePrompt(
   // unexpected and must surface, not silently downgrade to Medium.
   let complexityDirective = '';
   if (phase === 3) {
-    const specAbs = path.isAbsolute(state.artifacts.spec)
-      ? state.artifacts.spec
-      : path.join(harnessDir, '..', state.artifacts.spec);
+    const specAbs = resolveArtifact(state, state.artifacts.spec, cwd);
     let specText: string | null = null;
     try {
       specText = fs.readFileSync(specAbs, 'utf-8');
@@ -593,12 +593,17 @@ export function assembleInteractivePrompt(
     complexityDirective = buildComplexityDirective(level);
   }
 
+  const absSpec      = resolveArtifact(state, state.artifacts.spec,        cwd);
+  const absPlan      = resolveArtifact(state, state.artifacts.plan,        cwd);
+  const absChecklist = resolveArtifact(state, state.artifacts.checklist,   cwd);
+  const absDecisions = resolveArtifact(state, state.artifacts.decisionLog, cwd);
+
   const vars: Record<string, string | undefined> = {
     task_path: taskMdPath,
-    spec_path: state.artifacts.spec,
-    decisions_path: state.artifacts.decisionLog,
-    plan_path: state.artifacts.plan,
-    checklist_path: state.artifacts.checklist,
+    spec_path: absSpec,
+    decisions_path: absDecisions,
+    plan_path: absPlan,
+    checklist_path: absChecklist,
     runId: state.runId,
     phaseAttemptId,
     feedback_path: feedbackPath,

--- a/src/context/skills/harness-phase-1-spec.md
+++ b/src/context/skills/harness-phase-1-spec.md
@@ -35,9 +35,8 @@ description: Use during phase-harness Phase 1 to brainstorm and write a spec tha
    - `"Skip the 'User reviews written spec' step — Codex gate (Phase 2) replaces it"`
    - `"After spec is written, proceed immediately to step 2 (decisions log) below"`
 2. Decision log를 `{{decisions_path}}`에 작성한다. spec의 "Context & Decisions" 섹션과 **중복되지 않도록** 각 결정의 *trade-off*와 *고려된 대안*을 기록한다.
-3. 필요 시 `git add` + `git commit`. 커밋 메시지: `spec: <subject>`.
-4. **Pre-sentinel self-audit** — sentinel 쓰기 직전, 방금 작성한 spec을 다시 읽고 spec의 `## Success Criteria` / `## Invariants` 섹션과 대조한다. grep 또는 정규식 스캔 규칙이 적혀 있으면 모두 직접 확인하고, hit이 있으면 gate로 넘기지 말고 이번 pass에서 바로 수정한다. 각 gate round는 대략 40× local grep 비용이므로 여기서 먼저 정리한다. 수정이 있었다면 한 번 더 같은 검증을 반복(rerun)하고 clean 상태를 확인한 뒤에만 sentinel 단계로 이동한다.
-5. **가장 마지막에** `.harness/{{runId}}/phase-1.done`을 생성하고 내용으로 `{{phaseAttemptId}}` 한 줄만 기록한다.
+3. **Pre-sentinel self-audit** — sentinel 쓰기 직전, 방금 작성한 spec을 다시 읽고 spec의 `## Success Criteria` / `## Invariants` 섹션과 대조한다. grep 또는 정규식 스캔 규칙이 적혀 있으면 모두 직접 확인하고, hit이 있으면 gate로 넘기지 말고 이번 pass에서 바로 수정한다. 각 gate round는 대략 40× local grep 비용이므로 여기서 먼저 정리한다. 수정이 있었다면 한 번 더 같은 검증을 반복(rerun)하고 clean 상태를 확인한 뒤에만 sentinel 단계로 이동한다.
+4. **가장 마지막에** `.harness/{{runId}}/phase-1.done`을 생성하고 내용으로 `{{phaseAttemptId}}` 한 줄만 기록한다.
 
 ## Invariants
 - sentinel 파일 생성 이후 하네스가 다음 단계로 넘어간다. 추가 작업 금지.

--- a/src/context/skills/harness-phase-3-plan.md
+++ b/src/context/skills/harness-phase-3-plan.md
@@ -48,9 +48,8 @@ Phase 4에서 Codex가 다음 축으로 평가한다:
    - 각 항목은 `name`(string), `command`(string) 필수. 다른 키 금지.
    - 각 `command`는 **격리된 셸 환경에서 실행**된다. 절대경로 바이너리(`.venv/bin/pytest`) 또는 env-aware 래퍼(`make test`)를 사용할 것. 글로벌 PATH에만 있는 도구는 피함 (qa-observations #4 대응).
    - UI/시각적 변경이 있는 태스크가 있다면 스크린샷/시각 검증 항목을 적어도 한 건 추가.
-3. 필요 시 `git commit -m "plan: <subject>"`.
-4. **Pre-sentinel self-audit** — sentinel 쓰기 직전, 방금 작성한 plan을 다시 읽고 spec의 `## Success Criteria` / `## Invariants` 섹션과 대조한다. eval checklist도 함께 읽어 spec의 grep-rule / 정규식 규칙이 빠짐없이 들어갔는지 확인한다. hit이 있으면 gate로 넘기지 말고 이번 pass에서 바로 수정한다. 각 gate round는 대략 40× local grep 비용이므로 여기서 먼저 정리한다. 수정이 있었다면 한 번 더 같은 검증을 반복(rerun)하고 clean 상태를 확인한 뒤에만 sentinel 단계로 이동한다.
-5. **가장 마지막에** `.harness/{{runId}}/phase-3.done`을 생성하고 `{{phaseAttemptId}}` 한 줄만 기록.
+3. **Pre-sentinel self-audit** — sentinel 쓰기 직전, 방금 작성한 plan을 다시 읽고 spec의 `## Success Criteria` / `## Invariants` 섹션과 대조한다. eval checklist도 함께 읽어 spec의 grep-rule / 정규식 규칙이 빠짐없이 들어갔는지 확인한다. hit이 있으면 gate로 넘기지 말고 이번 pass에서 바로 수정한다. 각 gate round는 대략 40× local grep 비용이므로 여기서 먼저 정리한다. 수정이 있었다면 한 번 더 같은 검증을 반복(rerun)하고 clean 상태를 확인한 뒤에만 sentinel 단계로 이동한다.
+4. **가장 마지막에** `.harness/{{runId}}/phase-3.done`을 생성하고 `{{phaseAttemptId}}` 한 줄만 기록.
 
 ## Invariants
 - sentinel 이후 추가 작업 금지.

--- a/src/context/skills/harness-phase-5-implement.md
+++ b/src/context/skills/harness-phase-5-implement.md
@@ -38,7 +38,6 @@ superpowers가 커버하지 않는 두 원칙을 지킨다:
 ## Process
 0. **(Scaffolding only — prevention-first gitignore)** 구현을 시작하기 전에 대상 언어·프레임워크의 표준 `.gitignore` 엔트리(예: `__pycache__/`, `.pytest_cache/`, `.venv/`, `node_modules/`, `dist/`, `build/`, `.DS_Store`)를 프로젝트 루트 `.gitignore`에 보강한다. 기존 `.gitignore`가 이미 해당 엔트리를 포함하면 no-op. 이 변경은 `chore: add standard gitignore entries` 등 **독립된 scaffolding commit**으로 두고, impl 커밋과 섞지 않는다. Sentinel 직전에 `git status --porcelain`을 셀프 체크해 tracked 파일이 전부 커밋된 상태인지 확인한다. 하네스에 자동 recovery가 있어도 이 단계는 효율성과 로그 가독성 측면에서 값어치가 있다.
 1. 기본 sub-skill로 `superpowers:subagent-driven-development`를 invoke한다. 단일 세션 구현이 plan에서 적합하다고 판단되면 `superpowers:executing-plans`를 대안으로 쓸 수 있다. 어느 경우든 다음 오버라이드를 전달한다:
-   - `"After each task completes, git commit the changes. Do not defer commits to the end."`
    - `"Do NOT create .harness/{{runId}}/phase-5.done until ALL tasks in the plan are committed."`
    - `"If Content Filter rejects a subagent dispatch, fall back to direct in-session implementation and record the fallback in the task note."`
 2. 구현 중 위 Auxiliary playbooks의 원칙(원자적 커밋, 수직 슬라이스, 컨텍스트 prune)을 적용한다.

--- a/src/phases/interactive.ts
+++ b/src/phases/interactive.ts
@@ -235,7 +235,7 @@ export async function runInteractivePhase(
   }
 
   // Assemble prompt and write to file
-  const prompt = assembleInteractivePrompt(phase, updatedState, harnessDir);
+  const prompt = assembleInteractivePrompt(phase, updatedState, harnessDir, cwd);
   const promptFile = path.join(runDir, `phase-${phase}-init-prompt.md`);
   fs.writeFileSync(promptFile, prompt, 'utf-8');
 

--- a/src/phases/verify.ts
+++ b/src/phases/verify.ts
@@ -94,7 +94,8 @@ export async function runVerifyPhase(
   }
 
   // Step 2: Run preconditions while phase is still pending
-  runPhase6Preconditions(state.artifacts.evalReport, state.runId, cwd);
+  const docsRoot = state.trackedRepos?.[0]?.path || cwd;
+  runPhase6Preconditions(state.artifacts.evalReport, state.runId, docsRoot);
 
   // Step 3: Resolve verify script path BEFORE advancing phase state.
   // If the script is missing, fail fast while the phase is still pending —

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -188,12 +188,13 @@ async function recoverGeneralState(
   // Phase 6 error + eval report exists → retry normalize_artifact_commit
   // (eval report was written, normalize failed, and we should retry the commit only)
   if (phase === 6 && phaseStatus === 'error') {
-    const evalReportPath = join(cwd, state.artifacts.evalReport);
+    const docsRoot = state.trackedRepos?.[0]?.path || cwd;
+    const evalReportPath = join(docsRoot, state.artifacts.evalReport);
     if (isEvalReportValid(evalReportPath)) {
       try {
-        const result = commitEvalReport(state, cwd);
+        const result = commitEvalReport(state, docsRoot);
         if (result === 'committed') {
-          const head = getHead(cwd);
+          const head = getHead(docsRoot);
           state.evalCommit = head;
           state.verifiedAtHead = head;
         } else {
@@ -235,13 +236,14 @@ async function applyStoredVerifyResult(
   runDir: string,
   cwd: string
 ): Promise<void> {
-  const evalReportPath = join(cwd, state.artifacts.evalReport);
+  const docsRoot = state.trackedRepos?.[0]?.path || cwd;
+  const evalReportPath = join(docsRoot, state.artifacts.evalReport);
 
   if (result.exitCode === 0 && isEvalReportValid(evalReportPath)) {
     // PASS: commit the eval report (normalize_artifact_commit), set anchors, advance
     let evalCommitResult: 'committed' | 'skipped';
     try {
-      evalCommitResult = commitEvalReport(state, cwd);
+      evalCommitResult = commitEvalReport(state, docsRoot);
     } catch {
       // Commit failed — leave as error for runner to handle
       state.phases['6'] = 'error';

--- a/tests/artifact.test.ts
+++ b/tests/artifact.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { writeFileSync, existsSync, mkdirSync } from 'fs';
+import { writeFileSync, existsSync, mkdirSync, mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
+import { tmpdir } from 'os';
 import { execSync } from 'child_process';
 import { createTestRepo } from './helpers/test-repo.js';
 import { normalizeArtifactCommit, runPhase6Preconditions, commitEvalReport } from '../src/artifact.js';
@@ -204,6 +205,27 @@ describe('runPhase6Preconditions', () => {
 
     const status = execSync('git status --porcelain', { cwd: repo.path, encoding: 'utf-8' }).trim();
     expect(status).toBe('');
+  });
+
+  it('FR-3/6: succeeds with git docsRoot even when outer cwd is a non-git directory', () => {
+    // Simulates the multi-repo case: outer dir is not a git repo (e.g. a bare workspace root),
+    // but docsRoot (trackedRepos[0].path) is a valid git repo.
+    // Pre-fix: verify.ts passed outer cwd to runPhase6Preconditions → git status threw.
+    // Post-fix: verify.ts derives docsRoot = trackedRepos[0].path and passes that.
+    const outer = mkdtempSync(join(tmpdir(), 'nongit-outer-'));
+    try {
+      // outer is NOT a git repo — calling runPhase6Preconditions with it must throw
+      expect(() =>
+        runPhase6Preconditions(evalReportPath, 'my-run', outer)
+      ).toThrow();
+
+      // The fix: pass docsRoot (the real git repo) — must succeed
+      expect(() =>
+        runPhase6Preconditions(evalReportPath, 'my-run', repo.path)
+      ).not.toThrow();
+    } finally {
+      rmSync(outer, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/context/assembler.test.ts
+++ b/tests/context/assembler.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../../src/context/assembler.js';
 import { createInitialState } from '../../src/state.js';
 import { resolveArtifact } from '../../src/artifact.js';
+import { validatePhaseArtifacts } from '../../src/phases/interactive.js';
 import type { HarnessState } from '../../src/types.js';
 
 const tmpDirs: string[] = [];
@@ -145,13 +146,16 @@ describe('Phase 3 interactive prompt', () => {
 });
 
 describe('Phase 5 interactive prompt', () => {
-  it('includes commit instruction', () => {
+  it('includes pre-sentinel self-audit step, no standalone git-commit override (D3)', () => {
     const state = makeState({
       phaseAttemptId: { '1': null, '3': null, '5': 'attempt-phase5' },
     });
     const prompt = assembleInteractivePrompt(5, state, '/tmp/harness');
 
-    expect(prompt).toContain('git commit');
+    // D3: standalone git-commit override removed — harness auto-commits via normalizeInteractiveArtifacts
+    expect(prompt).not.toContain('After each task completes, git commit');
+    // Pre-sentinel self-audit step (step 3) remains
+    expect(prompt).toContain('git diff');
     expect(prompt).toContain('phase-5.done');
     expect(prompt).toContain('attempt-phase5');
   });
@@ -1069,5 +1073,65 @@ describe('assembleInteractivePrompt — absolute prompt vars (FR-1/2/5)', () => 
     // spec_path and decisions_path rendered in Phase 1 wrapper — both equal join(cwd, relPath) for single-repo
     expect(prompt).toContain(path.join(cwd, state.artifacts.spec));
     expect(prompt).toContain(path.join(cwd, state.artifacts.decisionLog));
+  });
+
+  it('multi-repo: Phase-3 prompt contains all four vars as absolute paths anchored correctly', () => {
+    const outer = makeTmpDir();
+    const repo0 = path.join(outer, 'repo-backend');
+    fs.mkdirSync(repo0);
+
+    const state = makeState({
+      phaseAttemptId: { '1': null, '3': 'uuid-phase3-all4', '5': null },
+      trackedRepos: [
+        { path: repo0, baseCommit: 'abc', implRetryBase: 'abc', implHead: null },
+      ],
+    });
+
+    const harnessDir = path.join(outer, '.harness');
+    const prompt = assembleInteractivePrompt(3, state, harnessDir, outer);
+
+    const expSpec      = resolveArtifact(state, state.artifacts.spec,        outer);
+    const expPlan      = resolveArtifact(state, state.artifacts.plan,        outer);
+    const expChecklist = resolveArtifact(state, state.artifacts.checklist,   outer);
+    const expDecisions = resolveArtifact(state, state.artifacts.decisionLog, outer);
+
+    expect(prompt).toContain(expSpec);
+    expect(prompt).toContain(expPlan);
+    expect(prompt).toContain(expChecklist);
+    expect(prompt).toContain(expDecisions);
+
+    // docs/* anchored to trackedRepos[0], not outer
+    expect(expSpec).toContain(repo0);
+    expect(expPlan).toContain(repo0);
+    // .harness/* anchored to outer cwd, not repo0
+    expect(expChecklist).toContain(outer);
+    expect(expDecisions).toContain(outer);
+  });
+
+  it('validatePhaseArtifacts returns true when artifacts are written to the rendered absolute paths (FR-5 end-to-end)', () => {
+    const outer = makeTmpDir();
+    const repo0 = path.join(outer, 'repo-backend');
+    fs.mkdirSync(repo0);
+
+    const state = makeState({
+      phaseAttemptId: { '1': 'uuid-validate-fr5', '3': null, '5': null },
+      trackedRepos: [
+        { path: repo0, baseCommit: 'abc', implRetryBase: 'abc', implHead: null },
+      ],
+    });
+
+    // Phase 1 (full) checks ['spec', 'decisionLog'] via getPhaseArtifactFiles.
+    // resolveArtifact anchors docs/* to trackedRepos[0] and .harness/* to outer.
+    const absSpecPath      = resolveArtifact(state, state.artifacts.spec,        outer);
+    const absDecisionsPath = resolveArtifact(state, state.artifacts.decisionLog, outer);
+
+    fs.mkdirSync(path.dirname(absSpecPath),      { recursive: true });
+    fs.mkdirSync(path.dirname(absDecisionsPath), { recursive: true });
+    fs.writeFileSync(absSpecPath,      '# Spec\n\n## Complexity\n\nSmall\n');
+    fs.writeFileSync(absDecisionsPath, '# Decisions\n');
+
+    const runDir = path.join(outer, '.harness', 'my-run');
+    const result = validatePhaseArtifacts(1, state, outer, runDir);
+    expect(result).toBe(true);
   });
 });

--- a/tests/context/assembler.test.ts
+++ b/tests/context/assembler.test.ts
@@ -11,6 +11,7 @@ import {
   __resetComplexityWarning,
 } from '../../src/context/assembler.js';
 import { createInitialState } from '../../src/state.js';
+import { resolveArtifact } from '../../src/artifact.js';
 import type { HarnessState } from '../../src/types.js';
 
 const tmpDirs: string[] = [];
@@ -988,5 +989,85 @@ describe('assembleGatePrompt(2) — light flow + full-flow regression (SC#3 / In
     expect(prompt).toContain('Phase 2 — spec gate');
     expect(prompt).not.toContain('5-phase light harness lifecycle');
     expect(prompt).not.toContain('Phase 2 — design gate, light flow');
+  });
+});
+
+// ─── FR-1/2/5: assembleInteractivePrompt emits absolute artifact paths ─────────
+
+describe('assembleInteractivePrompt — absolute prompt vars (FR-1/2/5)', () => {
+  it('multi-repo: Phase-1 prompt contains absolute paths — spec anchored to trackedRepos[0], .harness vars anchored to outer cwd', () => {
+    const outer = makeTmpDir();
+    const repo0 = path.join(outer, 'repo-backend');
+    const repo1 = path.join(outer, 'repo-frontend');
+    fs.mkdirSync(repo0);
+    fs.mkdirSync(repo1);
+
+    const state = makeState({
+      phaseAttemptId: { '1': 'uuid-multi', '3': null, '5': null },
+      trackedRepos: [
+        { path: repo0, baseCommit: 'abc', implRetryBase: 'abc', implHead: null },
+        { path: repo1, baseCommit: 'def', implRetryBase: 'def', implHead: null },
+      ],
+    });
+
+    const harnessDir = path.join(outer, '.harness');
+    const prompt = assembleInteractivePrompt(1, state, harnessDir, outer);
+
+    // Compute expected absolute values via resolveArtifact (same function used in assembler)
+    const expSpec      = resolveArtifact(state, state.artifacts.spec,        outer);
+    const expDecisions = resolveArtifact(state, state.artifacts.decisionLog, outer);
+
+    // spec_path and decisions_path are rendered in the Phase 1 wrapper
+    expect(prompt).toContain(expSpec);
+    expect(prompt).toContain(expDecisions);
+
+    // docs vars (spec) anchor to trackedRepos[0].path, not outer
+    expect(expSpec).toContain(repo0);
+    expect(expSpec).not.toContain(path.join(outer, 'docs'));
+    // .harness vars anchor to outer cwd, not repo0
+    expect(expDecisions).toContain(outer);
+    expect(expDecisions).not.toContain(repo0);
+  });
+
+  it('resolveArtifact anchors all four vars correctly for multi-repo state', () => {
+    const outer = makeTmpDir();
+    const repo0 = path.join(outer, 'repo-backend');
+    fs.mkdirSync(repo0);
+
+    const state = makeState({
+      phaseAttemptId: { '1': 'uuid-multi2', '3': null, '5': null },
+      trackedRepos: [
+        { path: repo0, baseCommit: 'abc', implRetryBase: 'abc', implHead: null },
+      ],
+    });
+
+    const expSpec      = resolveArtifact(state, state.artifacts.spec,        outer);
+    const expPlan      = resolveArtifact(state, state.artifacts.plan,        outer);
+    const expChecklist = resolveArtifact(state, state.artifacts.checklist,   outer);
+    const expDecisions = resolveArtifact(state, state.artifacts.decisionLog, outer);
+
+    // docs/* paths anchor to trackedRepos[0].path (repo0)
+    expect(expSpec).toBe(path.join(repo0, state.artifacts.spec));
+    expect(expPlan).toBe(path.join(repo0, state.artifacts.plan));
+    // .harness/* paths anchor to outer cwd
+    expect(expChecklist).toBe(path.join(outer, state.artifacts.checklist));
+    expect(expDecisions).toBe(path.join(outer, state.artifacts.decisionLog));
+  });
+
+  it('single-repo: Phase-1 prompt contains absolute paths equal to path.join(cwd, relPath)', () => {
+    const cwd = makeTmpDir();
+    const state = makeState({
+      phaseAttemptId: { '1': 'uuid-single', '3': null, '5': null },
+      trackedRepos: [
+        { path: cwd, baseCommit: 'abc', implRetryBase: 'abc', implHead: null },
+      ],
+    });
+
+    const harnessDir = path.join(cwd, '.harness');
+    const prompt = assembleInteractivePrompt(1, state, harnessDir, cwd);
+
+    // spec_path and decisions_path rendered in Phase 1 wrapper — both equal join(cwd, relPath) for single-repo
+    expect(prompt).toContain(path.join(cwd, state.artifacts.spec));
+    expect(prompt).toContain(path.join(cwd, state.artifacts.decisionLog));
   });
 });

--- a/tests/context/skills-rendering.test.ts
+++ b/tests/context/skills-rendering.test.ts
@@ -143,13 +143,15 @@ describe('wrapper contract invariants — literal (per spec §4/§5)', () => {
     expect(prompt).toMatch(/격리된 셸 환경/);
   });
 
-  it('phase 5 — commit-per-task rule + sentinel-after-all-commits + playbook absolute refs', () => {
+  it('phase 5 — no git-commit override (D3) + sentinel-after-all-commits + playbook absolute refs', () => {
     const state = stubState(tmp);
     state.runId = 'rid-5';
     const prompt = assembleInteractivePrompt(5, state, '/tmp/harness');
     expect(prompt).toMatch(/\.harness\/rid-5\/phase-5\.done/);
-    // "After each task completes, git commit" override literal
-    expect(prompt).toMatch(/After each task completes, git commit/);
+    // D3: standalone git-commit override removed — harness auto-commits
+    expect(prompt).not.toMatch(/After each task completes, git commit/);
+    // Pre-sentinel self-audit (step 3) still present
+    expect(prompt).toMatch(/git diff/);
     // "sentinel 이전에 모든 변경사항이 git에 커밋" invariant literal
     expect(prompt).toMatch(/sentinel 이전에 모든 변경사항이.*커밋/);
     // playbook @-references resolved literally (context-engineering + git-workflow)

--- a/tests/phases/verify.test.ts
+++ b/tests/phases/verify.test.ts
@@ -222,3 +222,57 @@ describe('runVerifyPhase — script resolution', () => {
     spy.mockRestore();
   });
 });
+
+describe('runVerifyPhase — docsRoot (FR-3/6)', () => {
+  it('passes trackedRepos[0].path as docsRoot to runPhase6Preconditions when outer cwd differs', async () => {
+    const outerCwd = tmpDir();
+    const docsRootDir = path.join(outerCwd, 'repo-backend');
+    fs.mkdirSync(docsRootDir);
+
+    const { runPhase6Preconditions } = await import('../../src/artifact.js');
+    const mockPreconditions = vi.mocked(runPhase6Preconditions);
+    mockPreconditions.mockClear();
+
+    const state = {
+      runId: 'test-run',
+      phases: {},
+      artifacts: { checklist: 'checklist.json', evalReport: 'eval.md' },
+      trackedRepos: [{ path: docsRootDir, baseCommit: 'abc', implRetryBase: 'abc', implHead: null }],
+    } as unknown as HarnessState;
+
+    vi.spyOn(preflightModule, 'resolveVerifyScriptPath').mockReturnValue(null);
+
+    try {
+      await runVerifyPhase(state, outerCwd, outerCwd, outerCwd);
+    } catch {
+      // expected — resolveVerifyScriptPath returns null → throws after preconditions
+    }
+
+    expect(mockPreconditions).toHaveBeenCalledWith('eval.md', 'test-run', docsRootDir);
+  });
+
+  it('falls back to outer cwd when trackedRepos is empty or path is empty', async () => {
+    const outerCwd = tmpDir();
+
+    const { runPhase6Preconditions } = await import('../../src/artifact.js');
+    const mockPreconditions = vi.mocked(runPhase6Preconditions);
+    mockPreconditions.mockClear();
+
+    const state = {
+      runId: 'test-run',
+      phases: {},
+      artifacts: { checklist: 'checklist.json', evalReport: 'eval.md' },
+      trackedRepos: [{ path: '', baseCommit: 'abc', implRetryBase: 'abc', implHead: null }],
+    } as unknown as HarnessState;
+
+    vi.spyOn(preflightModule, 'resolveVerifyScriptPath').mockReturnValue(null);
+
+    try {
+      await runVerifyPhase(state, outerCwd, outerCwd, outerCwd);
+    } catch {
+      // expected
+    }
+
+    expect(mockPreconditions).toHaveBeenCalledWith('eval.md', 'test-run', outerCwd);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two independent bugs that break multi-repo runs when the outer cwd is not a git repo (i.e. `outer !== trackedRepos[0].path`). Single-repo users are unaffected.

- **RC-1 (Phase-1 failure, user-facing)**: `assembleInteractivePrompt` injected the four docs-anchored vars (`spec_path`, `plan_path`, `checklist_path`, `decisions_path`) as **relative** strings. Claude's tmux process is pinned to outer cwd, so Claude wrote the spec at `<outer>/docs/specs/...` instead of `<trackedRepos[0]>/docs/specs/...`. `validatePhaseArtifacts` then failed, and Claude's own `git add` in the non-git outer surfaced the "not a git repository" error. Fix: resolve the four vars through `resolveArtifact(...)` before injection (`src/context/assembler.ts`).
- **RC-2 (latent Phase-6 / resume crash)**: `runPhase6Preconditions` and the Phase-6 recovery paths in `resume.ts` ran git ops against the **outer** cwd. Fix: derive `docsRoot = state.trackedRepos?.[0]?.path || cwd` and pass it to every git-touching call — `runPhase6Preconditions`, `commitEvalReport`, `getHead`, and `evalReportPath` resolution (`src/phases/verify.ts`, `src/resume.ts`).
- **D3 (noise-error cleanup)**: Dropped the "git add + git commit" step from all three Phase-1/3/5 wrapper skills. `normalizeInteractiveArtifacts` (runner.ts) already auto-commits post-phase with the correct `docsRoot`; the wrapper step was belt-and-suspenders leftover that actively misled Claude in multi-repo runs.

## Scope

- `src/context/assembler.ts` — absolutize the four prompt vars via `resolveArtifact`; `assembleInteractivePrompt` now accepts an explicit `cwd` (defaults preserve backward compat)
- `src/phases/verify.ts`, `src/resume.ts` — threaded `docsRoot` through Phase-6 preconditions and resume recovery
- `src/context/skills/harness-phase-{1,3,5}-*.md` — removed claude-side git commit step; surrounding steps renumbered
- Tests: FR-5 assembler tests for all four vars (relative + absolute), FR-6 integration test for `validatePhaseArtifacts` end-to-end, FR-3/6 regression test in `artifact.test.ts` covering `runPhase6Preconditions` with non-git outer
- Docs: `docs/specs/2026-04-21-untitled-662d-design.md` (rationale + alternatives) and `docs/process/evals/2026-04-21-untitled-662d-eval.md`

## Test plan

- [x] `pnpm tsc --noEmit` (lint alias) — pass
- [x] `pnpm vitest run` — full suite pass (recorded in eval report)
- [x] `pnpm build`
- [x] FR-5 all-four-vars absolute-path assembler test
- [x] FR-6 validatePhaseArtifacts integration test against rendered path
- [x] FR-3/6 `runPhase6Preconditions` regression test (non-git outer, git docsRoot)
- [ ] Real multi-repo dogfood re-run on the original failing setup (identity-gateway-backend + identity-gateway-dashboard under non-git outer)