### PR TITLE
fix(verify): skip git rm for gitignored eval report in Phase 6 preconditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phase-harness",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "AI agent harness orchestrator — multi-phase brainstorm/spec/plan/implement/verify lifecycle with gate reviews",
   "type": "module",
   "bin": {

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -103,9 +103,13 @@ export function runPhase6Preconditions(evalReportPath: string, runId: string, cw
   if (isStagedDeletion(evalReportPath, cwd)) {
     // Already reset — no-op
   } else if (fileStatus === '') {
-    // Either not present or tracked and clean — check physical existence
+    // Either not present, tracked and clean, or gitignored — check physical existence
     if (!existsSync(join(resolvedCwd, evalReportPath))) {
       // Not present → no-op
+    } else if (isPathGitignored(evalReportPath, cwd)) {
+      // Gitignored file that exists physically: git never tracked it so
+      // `git rm -f` would error ("did not match any files"). Just unlink.
+      unlinkSync(join(resolvedCwd, evalReportPath));
     } else {
       // Tracked and clean → git rm
       exec(`git rm -f "${evalReportPath}"`, cwd);

--- a/tests/artifact.test.ts
+++ b/tests/artifact.test.ts
@@ -207,6 +207,39 @@ describe('runPhase6Preconditions', () => {
     expect(status).toBe('');
   });
 
+  it('tolerates gitignored eval report: unlinks physical file without invoking git rm', () => {
+    // Repro of the field bug: user's docsRoot has `docs` (or `docs/`) in .gitignore,
+    // so the eval report at docs/process/evals/<id>-eval.md is ignored and never tracked.
+    // Pre-fix: getFileStatus → '', existsSync → true → `git rm -f` fires → exit 128
+    //   ("did not match any files") → runPhase6Preconditions throws on every resume.
+    // Post-fix: isPathGitignored short-circuits to unlinkSync; no git rm attempted.
+    const gitignoredEvalPath = 'docs/process/evals/ignored-run-eval.md';
+    writeFileSync(join(repo.path, '.gitignore'), 'docs\n');
+    execSync('git add .gitignore && git commit -m "ignore docs dir"', { cwd: repo.path });
+
+    // Physically create the file under the gitignored path
+    writeRepoFile(repo.path, gitignoredEvalPath, '# partial report\n');
+    const fullPath = join(repo.path, gitignoredEvalPath);
+    expect(existsSync(fullPath)).toBe(true);
+
+    // Sanity: git treats the file as ignored (porcelain empty, check-ignore hits)
+    const porcelain = execSync('git status --porcelain', {
+      cwd: repo.path,
+      encoding: 'utf-8',
+    }).trim();
+    expect(porcelain).toBe('');
+
+    // Must not throw — this is the regression path
+    expect(() =>
+      runPhase6Preconditions(gitignoredEvalPath, 'ignored-run', repo.path)
+    ).not.toThrow();
+
+    // File gone, tree still clean
+    expect(existsSync(fullPath)).toBe(false);
+    const after = execSync('git status --porcelain', { cwd: repo.path, encoding: 'utf-8' }).trim();
+    expect(after).toBe('');
+  });
+
   it('FR-3/6: succeeds with git docsRoot even when outer cwd is a non-git directory', () => {
     // Simulates the multi-repo case: outer dir is not a git repo (e.g. a bare workspace root),
     // but docsRoot (trackedRepos[0].path) is a valid git repo.


### PR DESCRIPTION
## Summary
- **Bug**: When the eval report path is covered by `.gitignore` (e.g. project has `docs` or `docs/process/**` ignored), `runPhase6Preconditions` calls `git rm -f <evalReport>` because `getFileStatus` returns `''` for ignored paths while the file exists physically. `git rm -f` fails with `fatal: pathspec … did not match any files` (exit 128), `execSync` throws, and `handleVerifyPhase` catches it as `verify_throw`. Phase 6 fails in ~80ms on every resume attempt — run permanently stuck at the eval gate.
- **Fix**: Add `isPathGitignored` short-circuit to the `fileStatus === ''` branch. If the file exists physically but the path is gitignored, `unlinkSync` it directly. Aligns the precondition with the existing `commitEvalReport` contract (which already skips gitignored commits).
- **Test**: New case in `tests/artifact.test.ts` replicates the exact field scenario — `.gitignore` contains `docs`, eval report sits under `docs/process/evals/`, precondition must not throw and must leave tree clean. Confirmed it FAILS on unpatched `src/artifact.ts` with the exact error from the user's `verify-error.md`, and PASSES after the fix.
- **Version**: 0.3.1 → 0.3.2.

## Background — real session that hit this
`~/.harness/sessions/a3ccd2237323/2026-04-21-untitled-a4f9/` — Phase 5 completed, Phase 6 failed twice in 148 ms / 82 ms. The first failure was Bug #1 (`eval \"\$COMMAND\"` letting a checklist `exit 0` kill `harness-verify.sh`, addressed in #61). That killed driver left a header-only eval report on disk at `docs/process/evals/…-eval.md`. Because `docs` is gitignored in that project, every resume re-entered `runPhase6Preconditions`, tried `git rm -f` on the untracked-but-present file, and threw with the exact error this PR's test reproduces.

Both fixes (this PR + #61) are needed for the stuck session to recover — this PR alone is not sufficient, but it is independently correct and required.

## Impact surface
- Single-file code change (`src/artifact.ts`) — 5 new lines inside the existing `fileStatus === ''` branch.
- No CLI flag / phase flow / preset / state-schema / tmux / logging change.
- `commitEvalReport` (`src/artifact.ts:148`) already performs this same gitignore-skip on the commit side; this PR brings the precondition side into alignment.

## Risk assessment
- `isPathGitignored` uses `git check-ignore -q`, returns `false` conservatively on any error (non-git repo, git unavailable). In a non-git repo `runPhase6Preconditions` already throws earlier at `git status --porcelain` (line 78), so the new branch is unreachable there.
- Force-added (`git add -f`) ignored files end up with non-empty porcelain status → fall into the existing `A ` / non-empty branches → `git rm -f` works (file is actually tracked). Unchanged behavior.
- Final `git status --porcelain` cleanliness check (step 4) still passes after `unlinkSync` because ignored files are not reported.
- No regressions across 936 tests (full `pnpm vitest run` green).

## Verification performed
- `pnpm lint` (= `tsc --noEmit`) — clean
- `pnpm vitest run` — 936 passed / 1 skipped
- Stashed the `src/artifact.ts` change and re-ran the new test alone: it FAILS with `fatal: pathspec 'docs/process/evals/ignored-run-eval.md' did not match any files` — the exact error captured in the field `verify-error.md`.
- `pnpm build` — dist regenerated

## Docs
README / HOW-IT-WORKS 검토 결과 문서 변경 불필요. The gitignored-commit-skip contract is already documented at `docs/HOW-IT-WORKS.md:223` / `docs/HOW-IT-WORKS.ko.md:206`; this change restores the precondition side to match that contract rather than introducing new observable behavior.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm vitest run` (all green)
- [x] new regression test fails on pre-fix code with the exact field error
- [x] `pnpm build`