### PR TITLE
fix(verify): ignore pre-existing dirty files in Phase 6 preconditions (#67, #68)

### DIFF
--- a/docs/process/evals/2026-04-24-fix-phase-6-verify-213d-eval.md
+++ b/docs/process/evals/2026-04-24-fix-phase-6-verify-213d-eval.md
@@ -52,12 +52,12 @@
 
  RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/bug-fix
 
- ✓ tests/artifact.test.ts (22 tests) 2974ms
+ ✓ tests/artifact.test.ts (23 tests) 3135ms
 
  Test Files  1 passed (1)
-      Tests  22 passed (22)
-   Start at  02:14:26
-   Duration  3.19s (transform 40ms, setup 0ms, collect 45ms, tests 2.97s, environment 0ms, prepare 37ms)
+      Tests  23 passed (23)
+   Start at  02:19:11
+   Duration  3.46s (transform 67ms, setup 0ms, collect 90ms, tests 3.14s, environment 0ms, prepare 49ms)
 ```
 
 </details>
@@ -82,12 +82,12 @@ fatal: not a git repository (or any of the parent directories): .git
 
  RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/bug-fix
 
- ✓ tests/phases/verify.test.ts (14 tests) 10ms
+ ✓ tests/phases/verify.test.ts (14 tests) 9ms
 
  Test Files  1 passed (1)
       Tests  14 passed (14)
-   Start at  02:14:29
-   Duration  213ms (transform 37ms, setup 0ms, collect 43ms, tests 10ms, environment 0ms, prepare 27ms)
+   Start at  02:19:15
+   Duration  224ms (transform 40ms, setup 0ms, collect 48ms, tests 9ms, environment 0ms, prepare 34ms)
 ```
 
 </details>
@@ -112,103 +112,103 @@ fatal: not a git repository (or any of the parent directories): .git
 
  RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/bug-fix
 
- ✓ tests/state.test.ts (50 tests) 39ms
- ✓ tests/logger.test.ts (32 tests) 49ms
- ✓ tests/context/skills-rendering.test.ts (45 tests) 59ms
- ✓ tests/phases/gate.test.ts (27 tests) 88ms
- ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 57ms
- ✓ tests/commands/inner.test.ts (23 tests) 184ms
-[2J[H ✓ tests/runners/claude-usage.test.ts (17 tests) 123ms
-[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/phases/terminal-ui.test.ts (18 tests) 123ms
- ✓ tests/integration/logging.test.ts (15 tests) 355ms
- ✓ tests/signal.test.ts (16 tests) 507ms
- ✓ tests/commands/footer-ticker.test.ts (10 tests) 74ms
- ✓ tests/phases/gate-resume.test.ts (13 tests) 174ms
- ✓ tests/lock.test.ts (20 tests) 274ms
- ✓ tests/phases/runner.test.ts (76 tests) 597ms
- ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 5ms
- ✓ tests/orphan-cleanup.test.ts (20 tests) 33ms
- ✓ tests/phases/verify.test.ts (14 tests) 23ms
- ✓ tests/runners/codex.test.ts (17 tests) 86ms
- ✓ tests/preflight.test.ts (27 tests | 1 skipped) 319ms
- ✓ tests/integration/codex-session-resume.test.ts (6 tests) 102ms
- ✓ tests/integration/light-flow.test.ts (4 tests) 222ms
- ✓ tests/resume-light.test.ts (10 tests) 35ms
- ✓ tests/context/assembler.test.ts (72 tests) 1818ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 434ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 574ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 584ms
- ✓ tests/phases/runner-token-capture.test.ts (6 tests) 10ms
- ✓ tests/commands/inner-footer.test.ts (2 tests) 14ms
- ✓ tests/runners/codex-resume.test.ts (8 tests) 58ms
- ✓ tests/tmux.test.ts (33 tests) 819ms
-   ✓ pollForPidFile > returns null on timeout when file never appears 405ms
-   ✓ pollForPidFile > returns null when file contains non-numeric content 407ms
- ✓ tests/context/assembler-resume.test.ts (9 tests) 67ms
- ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 6ms
- ✓ tests/runners/codex-isolation.test.ts (8 tests) 43ms
- ✓ tests/state-invalidation.test.ts (5 tests) 26ms
- ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 51ms
- ✓ tests/commands/resume-cmd.test.ts (12 tests) 2020ms
-[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui.test.ts (8 tests) 5ms
- ✓ tests/runners/claude.test.ts (4 tests) 9ms
- ✓ tests/phases/verdict.test.ts (16 tests) 4ms
- ✓ tests/root.test.ts (10 tests) 153ms
- ✓ tests/resume.test.ts (11 tests) 2793ms
-   ✓ resumeRun > exits with code 1 and non-interactive message on paused run with null pendingAction (D4b) 330ms
- ✓ tests/context/reviewer-contract.test.ts (4 tests) 42ms
- ✓ tests/commands/status-list.test.ts (7 tests) 559ms
- ✓ tests/phases/gate-resume-escalation.test.ts (1 test) 31ms
- ✓ tests/ui-footer.test.ts (9 tests) 3ms
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-97jOsI/.claude/skills:
+ ✓ tests/state.test.ts (50 tests) 50ms
+ ✓ tests/logger.test.ts (32 tests) 78ms
+ ✓ tests/context/skills-rendering.test.ts (45 tests) 79ms
+ ✓ tests/phases/gate.test.ts (27 tests) 84ms
+ ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 46ms
+ ✓ tests/commands/inner.test.ts (23 tests) 170ms
+[2J[H ✓ tests/runners/claude-usage.test.ts (17 tests) 70ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/phases/terminal-ui.test.ts (18 tests) 109ms
+ ✓ tests/signal.test.ts (16 tests) 499ms
+ ✓ tests/commands/footer-ticker.test.ts (10 tests) 79ms
+ ✓ tests/phases/gate-resume.test.ts (13 tests) 249ms
+ ✓ tests/lock.test.ts (20 tests) 286ms
+ ✓ tests/phases/runner.test.ts (76 tests) 580ms
+ ✓ tests/integration/logging.test.ts (15 tests) 444ms
+   ✓ Integration: real-wiring runPhaseLoop with mocked runners > bootstrap → phase loop with mocked runners → summary produced 361ms
+ ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 11ms
+ ✓ tests/phases/verify.test.ts (14 tests) 17ms
+ ✓ tests/orphan-cleanup.test.ts (20 tests) 15ms
+ ✓ tests/runners/codex.test.ts (17 tests) 83ms
+ ✓ tests/preflight.test.ts (27 tests | 1 skipped) 236ms
+ ✓ tests/integration/light-flow.test.ts (4 tests) 193ms
+ ✓ tests/integration/codex-session-resume.test.ts (6 tests) 43ms
+ ✓ tests/resume-light.test.ts (10 tests) 15ms
+ ✓ tests/phases/runner-token-capture.test.ts (6 tests) 15ms
+ ✓ tests/context/assembler.test.ts (72 tests) 1658ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 462ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 512ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 511ms
+ ✓ tests/commands/inner-footer.test.ts (2 tests) 15ms
+ ✓ tests/runners/codex-resume.test.ts (8 tests) 66ms
+ ✓ tests/context/assembler-resume.test.ts (9 tests) 72ms
+ ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 7ms
+ ✓ tests/tmux.test.ts (33 tests) 814ms
+   ✓ pollForPidFile > returns null on timeout when file never appears 404ms
+   ✓ pollForPidFile > returns null when file contains non-numeric content 404ms
+ ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 70ms
+ ✓ tests/state-invalidation.test.ts (5 tests) 18ms
+ ✓ tests/runners/codex-isolation.test.ts (8 tests) 37ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui.test.ts (8 tests) 4ms
+ ✓ tests/runners/claude.test.ts (4 tests) 5ms
+ ✓ tests/phases/verdict.test.ts (16 tests) 3ms
+ ✓ tests/commands/resume-cmd.test.ts (12 tests) 1916ms
+ ✓ tests/root.test.ts (10 tests) 172ms
+ ✓ tests/resume.test.ts (11 tests) 2845ms
+   ✓ resumeRun > exits with code 1 and non-interactive message on paused run with null pendingAction (D4b) 313ms
+   ✓ resumeRun > skip_phase Phase 6 with gitignored eval report: skips commit and leaves evalCommit null 308ms
+   ✓ completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8) > returns true and sets implHead when any repo advanced 408ms
+ ✓ tests/commands/status-list.test.ts (7 tests) 593ms
+ ✓ tests/context/reviewer-contract.test.ts (4 tests) 50ms
+ ✓ tests/phases/gate-resume-escalation.test.ts (1 test) 26ms
+ ✓ tests/ui-footer.test.ts (9 tests) 4ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-5pKvUI/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-f58etV/.claude/skills:
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-5pKvUI/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-97jOsI/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-9OoGNM/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-xBCmBD/.claude/skills:
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-9OoGNM/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-ohUVuB/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-klKgB6/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-xBCmBD/.claude/skills:
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-klKgB6/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-cls6Dz/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-voV4X9/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-GXcC2d/.claude/skills:
+No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-cBeW3j/.claude/skills. Nothing to uninstall.
+ ✓ tests/uninstall-skills.test.ts (6 tests) 16ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-MJGFhy/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-cls6Dz/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-FXjTY6/.claude/skills:
   phase-harness-codex-gate-review
-No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-qlO4rw/.claude/skills. Nothing to uninstall.
- ✓ tests/uninstall-skills.test.ts (6 tests) 21ms
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-6AHN2b/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-Xzpvl3/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-kUvz7z/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-Q0rwOE/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-kUvz7z/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-Q0rwOE/.claude/skills:
   phase-harness-codex-gate-review
- ✓ tests/install-skills.test.ts (7 tests) 25ms
- ✓ tests/integration/lifecycle.test.ts (11 tests) 1171ms
+ ✓ tests/git.test.ts (20 tests) 1851ms
+ ✓ tests/install-skills.test.ts (7 tests) 16ms
+ ✓ tests/integration/lifecycle.test.ts (11 tests) 1334ms
  ✓ tests/input.test.ts (12 tests) 3ms
- ✓ tests/commands/jump.test.ts (6 tests) 672ms
- ✓ tests/git.test.ts (20 tests) 1811ms
- ✓ tests/multi-worktree.test.ts (11 tests) 2595ms
-   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 607ms
-   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 453ms
-   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 425ms
-   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 409ms
-   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 468ms
- ✓ tests/task-prompt.test.ts (7 tests) 2ms
+ ✓ tests/task-prompt.test.ts (7 tests) 4ms
+ ✓ tests/multi-worktree.test.ts (11 tests) 2609ms
+   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 547ms
+   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 407ms
+   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 518ms
+   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 419ms
+   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 507ms
  ✓ tests/terminal.test.ts (5 tests) 2ms
-[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui-prompt-model-config.test.ts (3 tests) 2ms
- ✓ tests/preflight-claude-at-file.test.ts (2 tests) 5ms
- ✓ tests/conformance/phase-models.test.ts (9 tests) 3ms
- ✓ tests/scripts/harness-verify.test.ts (2 tests) 363ms
- ✓ tests/process.test.ts (6 tests) 21ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui-prompt-model-config.test.ts (3 tests) 3ms
+ ✓ tests/commands/jump.test.ts (6 tests) 702ms
+ ✓ tests/preflight-claude-at-file.test.ts (2 tests) 8ms
+ ✓ tests/conformance/phase-models.test.ts (9 tests) 4ms
  ✓ tests/ui-separator.test.ts (5 tests) 1ms
- ✓ tests/config.test.ts (8 tests) 2ms
- ✓ tests/resolve-skills-root.test.ts (4 tests) 2ms
- ✓ tests/commands/skip.test.ts (4 tests) 390ms
- ✓ tests/phases/eval-report-commit-squash.test.ts (6 tests) 3837ms
+ ✓ tests/process.test.ts (6 tests) 33ms
+ ✓ tests/scripts/harness-verify.test.ts (2 tests) 408ms
+ ✓ tests/config.test.ts (8 tests) 3ms
 ```
 
 </details>
@@ -220,8 +220,8 @@ Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install
 ⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
 ⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
 ⚠️  claude session resume fallback: no prior attempt id
-⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-Bd3G5l/phase-5-carryover-missing.md
 ⚠️  claude session resume fallback: no prior attempt id
+⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-bdwDZ4/phase-5-carryover-missing.md
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: jsonl missing
 ⚠️  claude session resume fallback: jsonl missing

--- a/docs/process/evals/2026-04-24-fix-phase-6-verify-213d-eval.md
+++ b/docs/process/evals/2026-04-24-fix-phase-6-verify-213d-eval.md
@@ -52,12 +52,12 @@
 
  RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/bug-fix
 
- ✓ tests/artifact.test.ts (23 tests) 3135ms
+ ✓ tests/artifact.test.ts (23 tests) 3033ms
 
  Test Files  1 passed (1)
       Tests  23 passed (23)
-   Start at  02:19:11
-   Duration  3.46s (transform 67ms, setup 0ms, collect 90ms, tests 3.14s, environment 0ms, prepare 49ms)
+   Start at  02:27:04
+   Duration  3.26s (transform 40ms, setup 0ms, collect 45ms, tests 3.03s, environment 0ms, prepare 36ms)
 ```
 
 </details>
@@ -82,12 +82,12 @@ fatal: not a git repository (or any of the parent directories): .git
 
  RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/bug-fix
 
- ✓ tests/phases/verify.test.ts (14 tests) 9ms
+ ✓ tests/phases/verify.test.ts (14 tests) 12ms
 
  Test Files  1 passed (1)
       Tests  14 passed (14)
-   Start at  02:19:15
-   Duration  224ms (transform 40ms, setup 0ms, collect 48ms, tests 9ms, environment 0ms, prepare 34ms)
+   Start at  02:27:08
+   Duration  251ms (transform 39ms, setup 0ms, collect 48ms, tests 12ms, environment 0ms, prepare 36ms)
 ```
 
 </details>
@@ -112,103 +112,103 @@ fatal: not a git repository (or any of the parent directories): .git
 
  RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/bug-fix
 
- ✓ tests/state.test.ts (50 tests) 50ms
- ✓ tests/logger.test.ts (32 tests) 78ms
- ✓ tests/context/skills-rendering.test.ts (45 tests) 79ms
- ✓ tests/phases/gate.test.ts (27 tests) 84ms
- ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 46ms
- ✓ tests/commands/inner.test.ts (23 tests) 170ms
-[2J[H ✓ tests/runners/claude-usage.test.ts (17 tests) 70ms
-[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/phases/terminal-ui.test.ts (18 tests) 109ms
- ✓ tests/signal.test.ts (16 tests) 499ms
- ✓ tests/commands/footer-ticker.test.ts (10 tests) 79ms
- ✓ tests/phases/gate-resume.test.ts (13 tests) 249ms
- ✓ tests/lock.test.ts (20 tests) 286ms
- ✓ tests/phases/runner.test.ts (76 tests) 580ms
- ✓ tests/integration/logging.test.ts (15 tests) 444ms
-   ✓ Integration: real-wiring runPhaseLoop with mocked runners > bootstrap → phase loop with mocked runners → summary produced 361ms
- ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 11ms
- ✓ tests/phases/verify.test.ts (14 tests) 17ms
- ✓ tests/orphan-cleanup.test.ts (20 tests) 15ms
- ✓ tests/runners/codex.test.ts (17 tests) 83ms
- ✓ tests/preflight.test.ts (27 tests | 1 skipped) 236ms
- ✓ tests/integration/light-flow.test.ts (4 tests) 193ms
- ✓ tests/integration/codex-session-resume.test.ts (6 tests) 43ms
- ✓ tests/resume-light.test.ts (10 tests) 15ms
- ✓ tests/phases/runner-token-capture.test.ts (6 tests) 15ms
- ✓ tests/context/assembler.test.ts (72 tests) 1658ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 462ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 512ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 511ms
+ ✓ tests/state.test.ts (50 tests) 48ms
+ ✓ tests/context/skills-rendering.test.ts (45 tests) 90ms
+ ✓ tests/logger.test.ts (32 tests) 99ms
+ ✓ tests/phases/gate.test.ts (27 tests) 93ms
+ ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 49ms
+ ✓ tests/commands/inner.test.ts (23 tests) 192ms
+[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/runners/claude-usage.test.ts (17 tests) 110ms
+[2J[H[2J[H[2J[H ✓ tests/phases/terminal-ui.test.ts (18 tests) 97ms
+ ✓ tests/signal.test.ts (16 tests) 497ms
+ ✓ tests/lock.test.ts (20 tests) 268ms
+ ✓ tests/phases/gate-resume.test.ts (13 tests) 183ms
+ ✓ tests/commands/footer-ticker.test.ts (10 tests) 110ms
+ ✓ tests/integration/logging.test.ts (15 tests) 313ms
+ ✓ tests/phases/runner.test.ts (76 tests) 586ms
+ ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 9ms
+ ✓ tests/phases/verify.test.ts (14 tests) 18ms
+ ✓ tests/orphan-cleanup.test.ts (20 tests) 23ms
+ ✓ tests/runners/codex.test.ts (17 tests) 72ms
+ ✓ tests/preflight.test.ts (27 tests | 1 skipped) 195ms
+ ✓ tests/integration/light-flow.test.ts (4 tests) 207ms
+ ✓ tests/integration/codex-session-resume.test.ts (6 tests) 47ms
+ ✓ tests/resume-light.test.ts (10 tests) 16ms
+ ✓ tests/phases/runner-token-capture.test.ts (6 tests) 11ms
  ✓ tests/commands/inner-footer.test.ts (2 tests) 15ms
- ✓ tests/runners/codex-resume.test.ts (8 tests) 66ms
- ✓ tests/context/assembler-resume.test.ts (9 tests) 72ms
- ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 7ms
- ✓ tests/tmux.test.ts (33 tests) 814ms
-   ✓ pollForPidFile > returns null on timeout when file never appears 404ms
-   ✓ pollForPidFile > returns null when file contains non-numeric content 404ms
- ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 70ms
- ✓ tests/state-invalidation.test.ts (5 tests) 18ms
- ✓ tests/runners/codex-isolation.test.ts (8 tests) 37ms
+ ✓ tests/runners/codex-resume.test.ts (8 tests) 57ms
+ ✓ tests/context/assembler.test.ts (72 tests) 1695ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 411ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 578ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 504ms
+ ✓ tests/tmux.test.ts (33 tests) 820ms
+   ✓ pollForPidFile > returns null on timeout when file never appears 403ms
+   ✓ pollForPidFile > returns null when file contains non-numeric content 409ms
+ ✓ tests/context/assembler-resume.test.ts (9 tests) 71ms
+ ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 8ms
+ ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 46ms
+ ✓ tests/runners/codex-isolation.test.ts (8 tests) 27ms
+ ✓ tests/state-invalidation.test.ts (5 tests) 7ms
 [2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui.test.ts (8 tests) 4ms
- ✓ tests/runners/claude.test.ts (4 tests) 5ms
+ ✓ tests/runners/claude.test.ts (4 tests) 10ms
+ ✓ tests/commands/resume-cmd.test.ts (12 tests) 2071ms
  ✓ tests/phases/verdict.test.ts (16 tests) 3ms
- ✓ tests/commands/resume-cmd.test.ts (12 tests) 1916ms
- ✓ tests/root.test.ts (10 tests) 172ms
- ✓ tests/resume.test.ts (11 tests) 2845ms
-   ✓ resumeRun > exits with code 1 and non-interactive message on paused run with null pendingAction (D4b) 313ms
-   ✓ resumeRun > skip_phase Phase 6 with gitignored eval report: skips commit and leaves evalCommit null 308ms
+ ✓ tests/resume.test.ts (11 tests) 2879ms
+   ✓ resumeRun > skip_phase Phase 6 with gitignored eval report: skips commit and leaves evalCommit null 309ms
    ✓ completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8) > returns true and sets implHead when any repo advanced 408ms
- ✓ tests/commands/status-list.test.ts (7 tests) 593ms
- ✓ tests/context/reviewer-contract.test.ts (4 tests) 50ms
- ✓ tests/phases/gate-resume-escalation.test.ts (1 test) 26ms
+   ✓ completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8) > returns false when no repo advanced (HEAD === implRetryBase) 360ms
+ ✓ tests/root.test.ts (10 tests) 189ms
+ ✓ tests/context/reviewer-contract.test.ts (4 tests) 48ms
+ ✓ tests/commands/status-list.test.ts (7 tests) 688ms
+ ✓ tests/phases/gate-resume-escalation.test.ts (1 test) 39ms
+ ✓ tests/git.test.ts (20 tests) 2149ms
+ ✓ tests/multi-worktree.test.ts (11 tests) 2845ms
+   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 483ms
+   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 462ms
+   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 487ms
+   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 601ms
+   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 597ms
  ✓ tests/ui-footer.test.ts (9 tests) 4ms
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-5pKvUI/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-zLBTGz/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-5pKvUI/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-DZ8mDt/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-9OoGNM/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-NnZ9Ph/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-9OoGNM/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-ub5fQ5/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-klKgB6/.claude/skills:
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-ub5fQ5/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-klKgB6/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-21NL75/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-voV4X9/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-przbfG/.claude/skills:
   phase-harness-codex-gate-review
-No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-cBeW3j/.claude/skills. Nothing to uninstall.
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-przbfG/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-iqbcM9/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-Q5JSWY/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-Q5JSWY/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-iqbcM9/.claude/skills:
+  phase-harness-codex-gate-review
+No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-DFuliM/.claude/skills. Nothing to uninstall.
  ✓ tests/uninstall-skills.test.ts (6 tests) 16ms
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-MJGFhy/.claude/skills:
-  phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-FXjTY6/.claude/skills:
-  phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-Xzpvl3/.claude/skills:
-  phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-Q0rwOE/.claude/skills:
-  phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-Q0rwOE/.claude/skills:
-  phase-harness-codex-gate-review
- ✓ tests/git.test.ts (20 tests) 1851ms
- ✓ tests/install-skills.test.ts (7 tests) 16ms
- ✓ tests/integration/lifecycle.test.ts (11 tests) 1334ms
- ✓ tests/input.test.ts (12 tests) 3ms
- ✓ tests/task-prompt.test.ts (7 tests) 4ms
- ✓ tests/multi-worktree.test.ts (11 tests) 2609ms
-   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 547ms
-   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 407ms
-   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 518ms
-   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 419ms
-   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 507ms
+ ✓ tests/install-skills.test.ts (7 tests) 21ms
+ ✓ tests/input.test.ts (12 tests) 8ms
+ ✓ tests/commands/jump.test.ts (6 tests) 745ms
+ ✓ tests/task-prompt.test.ts (7 tests) 3ms
+ ✓ tests/integration/lifecycle.test.ts (11 tests) 1768ms
+   ✓ CLI lifecycle integration > harness --help works 463ms
  ✓ tests/terminal.test.ts (5 tests) 2ms
 [2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui-prompt-model-config.test.ts (3 tests) 3ms
- ✓ tests/commands/jump.test.ts (6 tests) 702ms
- ✓ tests/preflight-claude-at-file.test.ts (2 tests) 8ms
- ✓ tests/conformance/phase-models.test.ts (9 tests) 4ms
- ✓ tests/ui-separator.test.ts (5 tests) 1ms
- ✓ tests/process.test.ts (6 tests) 33ms
- ✓ tests/scripts/harness-verify.test.ts (2 tests) 408ms
- ✓ tests/config.test.ts (8 tests) 3ms
+ ✓ tests/conformance/phase-models.test.ts (9 tests) 3ms
+ ✓ tests/preflight-claude-at-file.test.ts (2 tests) 4ms
+ ✓ tests/process.test.ts (6 tests) 55ms
+ ✓ tests/ui-separator.test.ts (5 tests) 2ms
+ ✓ tests/scripts/harness-verify.test.ts (2 tests) 369ms
+ ✓ tests/phases/interactive.test.ts (51 tests) 4597ms
 ```
 
 </details>
@@ -221,7 +221,7 @@ Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install
 ⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: no prior attempt id
-⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-bdwDZ4/phase-5-carryover-missing.md
+⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-MdvLA7/phase-5-carryover-missing.md
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: jsonl missing
 ⚠️  claude session resume fallback: jsonl missing

--- a/docs/process/evals/2026-04-24-fix-phase-6-verify-213d-eval.md
+++ b/docs/process/evals/2026-04-24-fix-phase-6-verify-213d-eval.md
@@ -1,0 +1,302 @@
+# Auto Verification Report
+- Date: 2026-04-24
+- Related Spec: N/A
+- Related Plan: N/A
+
+## Results
+| Check | Status | Detail |
+|-------|--------|--------|
+| typecheck | pass |  |
+| unit-artifact | pass |  |
+| unit-verify-phase | pass |  |
+| full-test-suite | pass |  |
+| build | pass |  |
+
+## Summary
+- Total: 5 checks
+- Pass: 5
+- Fail: 0
+
+## Raw Output
+
+### typecheck
+**Command:** `pnpm tsc --noEmit`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>
+
+### unit-artifact
+**Command:** `pnpm vitest run tests/artifact.test.ts`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+ RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/bug-fix
+
+ ✓ tests/artifact.test.ts (22 tests) 2920ms
+
+ Test Files  1 passed (1)
+      Tests  22 passed (22)
+   Start at  02:07:45
+   Duration  3.15s (transform 42ms, setup 0ms, collect 45ms, tests 2.92s, environment 0ms, prepare 33ms)
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+fatal: not a git repository (or any of the parent directories): .git
+```
+
+</details>
+
+### unit-verify-phase
+**Command:** `pnpm vitest run tests/phases/verify.test.ts`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+ RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/bug-fix
+
+ ✓ tests/phases/verify.test.ts (14 tests) 11ms
+
+ Test Files  1 passed (1)
+      Tests  14 passed (14)
+   Start at  02:07:48
+   Duration  219ms (transform 37ms, setup 0ms, collect 46ms, tests 11ms, environment 0ms, prepare 30ms)
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>
+
+### full-test-suite
+**Command:** `pnpm vitest run`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+ RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/bug-fix
+
+ ✓ tests/state.test.ts (50 tests) 47ms
+ ✓ tests/logger.test.ts (32 tests) 106ms
+ ✓ tests/context/skills-rendering.test.ts (45 tests) 103ms
+ ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 51ms
+ ✓ tests/phases/gate.test.ts (27 tests) 102ms
+ ✓ tests/commands/inner.test.ts (23 tests) 248ms
+[2J[H[2J[H ✓ tests/integration/logging.test.ts (15 tests) 296ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/phases/terminal-ui.test.ts (18 tests) 134ms
+ ✓ tests/runners/claude-usage.test.ts (17 tests) 148ms
+ ✓ tests/signal.test.ts (16 tests) 443ms
+ ✓ tests/lock.test.ts (20 tests) 247ms
+ ✓ tests/phases/gate-resume.test.ts (13 tests) 121ms
+ ✓ tests/commands/footer-ticker.test.ts (10 tests) 45ms
+ ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 8ms
+ ✓ tests/phases/runner.test.ts (76 tests) 602ms
+ ✓ tests/orphan-cleanup.test.ts (20 tests) 23ms
+ ✓ tests/runners/codex.test.ts (17 tests) 77ms
+ ✓ tests/phases/verify.test.ts (14 tests) 21ms
+ ✓ tests/preflight.test.ts (27 tests | 1 skipped) 191ms
+ ✓ tests/integration/light-flow.test.ts (4 tests) 207ms
+ ✓ tests/integration/codex-session-resume.test.ts (6 tests) 49ms
+ ✓ tests/resume-light.test.ts (10 tests) 14ms
+ ✓ tests/phases/runner-token-capture.test.ts (6 tests) 11ms
+ ✓ tests/commands/inner-footer.test.ts (2 tests) 11ms
+ ✓ tests/runners/codex-resume.test.ts (8 tests) 56ms
+ ✓ tests/context/assembler.test.ts (72 tests) 1611ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 391ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 531ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 475ms
+ ✓ tests/tmux.test.ts (33 tests) 823ms
+   ✓ pollForPidFile > returns null on timeout when file never appears 412ms
+   ✓ pollForPidFile > returns null when file contains non-numeric content 403ms
+ ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 9ms
+ ✓ tests/context/assembler-resume.test.ts (9 tests) 69ms
+ ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 55ms
+ ✓ tests/state-invalidation.test.ts (5 tests) 13ms
+ ✓ tests/runners/codex-isolation.test.ts (8 tests) 20ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui.test.ts (8 tests) 5ms
+ ✓ tests/runners/claude.test.ts (4 tests) 11ms
+ ✓ tests/phases/verdict.test.ts (16 tests) 3ms
+ ✓ tests/commands/resume-cmd.test.ts (12 tests) 2060ms
+   ✓ resumeCommand > harness resume --light (rejected) > exits non-zero with a flow-frozen message 301ms
+ ✓ tests/root.test.ts (10 tests) 153ms
+ ✓ tests/resume.test.ts (11 tests) 2887ms
+   ✓ resumeRun > exits with code 1 and non-interactive message on paused run with null pendingAction (D4b) 322ms
+   ✓ resumeRun > skip_phase Phase 6 with gitignored eval report: skips commit and leaves evalCommit null 379ms
+   ✓ completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8) > returns true and sets implHead when any repo advanced 492ms
+ ✓ tests/commands/status-list.test.ts (7 tests) 574ms
+ ✓ tests/context/reviewer-contract.test.ts (4 tests) 61ms
+ ✓ tests/git.test.ts (20 tests) 1909ms
+ ✓ tests/ui-footer.test.ts (9 tests) 5ms
+ ✓ tests/phases/gate-resume-escalation.test.ts (1 test) 36ms
+ ✓ tests/integration/lifecycle.test.ts (11 tests) 1517ms
+ ✓ tests/multi-worktree.test.ts (11 tests) 2711ms
+   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 503ms
+   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 454ms
+   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 597ms
+   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 434ms
+   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 512ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-Oj1HsW/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-Oj1HsW/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-AszSjJ/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-AszSjJ/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-2OY0ae/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-2OY0ae/.claude/skills:
+  phase-harness-codex-gate-review
+No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-u4ZYeB/.claude/skills. Nothing to uninstall.
+ ✓ tests/uninstall-skills.test.ts (6 tests) 18ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-IjJrTf/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-nJrxjS/.claude/skills:
+  phase-harness-codex-gate-review
+ ✓ tests/input.test.ts (12 tests) 3ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-h5LYh5/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-DaJfL2/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-APBkPp/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-APBkPp/.claude/skills:
+  phase-harness-codex-gate-review
+ ✓ tests/install-skills.test.ts (7 tests) 20ms
+ ✓ tests/commands/jump.test.ts (6 tests) 657ms
+ ✓ tests/task-prompt.test.ts (7 tests) 2ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui-prompt-model-config.test.ts (3 tests) 3ms
+ ✓ tests/terminal.test.ts (5 tests) 3ms
+ ✓ tests/preflight-claude-at-file.test.ts (2 tests) 4ms
+ ✓ tests/conformance/phase-models.test.ts (9 tests) 3ms
+ ✓ tests/ui-separator.test.ts (5 tests) 2ms
+ ✓ tests/config.test.ts (8 tests) 2ms
+ ✓ tests/process.test.ts (6 tests) 23ms
+ ✓ tests/resolve-skills-root.test.ts (4 tests) 2ms
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
+⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-Tw1Wh7/phase-5-carryover-missing.md
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+fatal: not a git repository (or any of the parent directories): .git
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+```
+
+</details>
+
+### build
+**Command:** `pnpm build`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+> phase-harness@0.3.3 build /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/bug-fix
+> tsc -p tsconfig.build.json && node scripts/copy-assets.mjs
+
+[copy-assets] copied src/context/prompts -> dist/src/context/prompts
+[copy-assets] copied src/context/skills -> dist/src/context/skills
+[copy-assets] copied src/context/skills-standalone -> dist/src/context/skills-standalone
+[copy-assets] copied src/context/playbooks -> dist/src/context/playbooks
+[copy-assets] copied scripts/harness-verify.sh -> dist/scripts/harness-verify.sh
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>

--- a/docs/process/evals/2026-04-24-fix-phase-6-verify-213d-eval.md
+++ b/docs/process/evals/2026-04-24-fix-phase-6-verify-213d-eval.md
@@ -52,12 +52,12 @@
 
  RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/bug-fix
 
- ✓ tests/artifact.test.ts (22 tests) 2959ms
+ ✓ tests/artifact.test.ts (22 tests) 2974ms
 
  Test Files  1 passed (1)
       Tests  22 passed (22)
-   Start at  02:12:30
-   Duration  3.18s (transform 40ms, setup 0ms, collect 46ms, tests 2.96s, environment 0ms, prepare 32ms)
+   Start at  02:14:26
+   Duration  3.19s (transform 40ms, setup 0ms, collect 45ms, tests 2.97s, environment 0ms, prepare 37ms)
 ```
 
 </details>
@@ -86,8 +86,8 @@ fatal: not a git repository (or any of the parent directories): .git
 
  Test Files  1 passed (1)
       Tests  14 passed (14)
-   Start at  02:12:34
-   Duration  217ms (transform 38ms, setup 0ms, collect 44ms, tests 10ms, environment 0ms, prepare 29ms)
+   Start at  02:14:29
+   Duration  213ms (transform 37ms, setup 0ms, collect 43ms, tests 10ms, environment 0ms, prepare 27ms)
 ```
 
 </details>
@@ -112,103 +112,103 @@ fatal: not a git repository (or any of the parent directories): .git
 
  RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/bug-fix
 
- ✓ tests/state.test.ts (50 tests) 63ms
- ✓ tests/context/skills-rendering.test.ts (45 tests) 107ms
- ✓ tests/phases/gate.test.ts (27 tests) 100ms
- ✓ tests/logger.test.ts (32 tests) 119ms
- ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 50ms
- ✓ tests/commands/inner.test.ts (23 tests) 256ms
-[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/integration/logging.test.ts (15 tests) 296ms
-[2J[H[2J[H[2J[H ✓ tests/phases/terminal-ui.test.ts (18 tests) 115ms
- ✓ tests/runners/claude-usage.test.ts (17 tests) 171ms
- ✓ tests/signal.test.ts (16 tests) 462ms
- ✓ tests/phases/gate-resume.test.ts (13 tests) 129ms
- ✓ tests/commands/footer-ticker.test.ts (10 tests) 57ms
- ✓ tests/lock.test.ts (20 tests) 251ms
- ✓ tests/phases/runner.test.ts (76 tests) 615ms
- ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 7ms
- ✓ tests/orphan-cleanup.test.ts (20 tests) 20ms
- ✓ tests/phases/verify.test.ts (14 tests) 17ms
- ✓ tests/runners/codex.test.ts (17 tests) 83ms
- ✓ tests/preflight.test.ts (27 tests | 1 skipped) 183ms
- ✓ tests/integration/light-flow.test.ts (4 tests) 176ms
- ✓ tests/integration/codex-session-resume.test.ts (6 tests) 65ms
- ✓ tests/resume-light.test.ts (10 tests) 49ms
- ✓ tests/commands/inner-footer.test.ts (2 tests) 8ms
- ✓ tests/phases/runner-token-capture.test.ts (6 tests) 6ms
- ✓ tests/runners/codex-resume.test.ts (8 tests) 60ms
- ✓ tests/tmux.test.ts (33 tests) 818ms
-   ✓ pollForPidFile > returns null on timeout when file never appears 403ms
-   ✓ pollForPidFile > returns null when file contains non-numeric content 406ms
- ✓ tests/context/assembler.test.ts (72 tests) 1843ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 425ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 537ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 587ms
- ✓ tests/context/assembler-resume.test.ts (9 tests) 136ms
- ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 10ms
- ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 50ms
- ✓ tests/runners/codex-isolation.test.ts (8 tests) 53ms
- ✓ tests/state-invalidation.test.ts (5 tests) 10ms
- ✓ tests/commands/resume-cmd.test.ts (12 tests) 2009ms
-   ✓ resumeCommand > Case 2 stale pane (reused-mode): outer session stays alive, recursion creates new control window 302ms
-[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui.test.ts (8 tests) 4ms
- ✓ tests/runners/claude.test.ts (4 tests) 6ms
+ ✓ tests/state.test.ts (50 tests) 39ms
+ ✓ tests/logger.test.ts (32 tests) 49ms
+ ✓ tests/context/skills-rendering.test.ts (45 tests) 59ms
+ ✓ tests/phases/gate.test.ts (27 tests) 88ms
+ ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 57ms
+ ✓ tests/commands/inner.test.ts (23 tests) 184ms
+[2J[H ✓ tests/runners/claude-usage.test.ts (17 tests) 123ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/phases/terminal-ui.test.ts (18 tests) 123ms
+ ✓ tests/integration/logging.test.ts (15 tests) 355ms
+ ✓ tests/signal.test.ts (16 tests) 507ms
+ ✓ tests/commands/footer-ticker.test.ts (10 tests) 74ms
+ ✓ tests/phases/gate-resume.test.ts (13 tests) 174ms
+ ✓ tests/lock.test.ts (20 tests) 274ms
+ ✓ tests/phases/runner.test.ts (76 tests) 597ms
+ ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 5ms
+ ✓ tests/orphan-cleanup.test.ts (20 tests) 33ms
+ ✓ tests/phases/verify.test.ts (14 tests) 23ms
+ ✓ tests/runners/codex.test.ts (17 tests) 86ms
+ ✓ tests/preflight.test.ts (27 tests | 1 skipped) 319ms
+ ✓ tests/integration/codex-session-resume.test.ts (6 tests) 102ms
+ ✓ tests/integration/light-flow.test.ts (4 tests) 222ms
+ ✓ tests/resume-light.test.ts (10 tests) 35ms
+ ✓ tests/context/assembler.test.ts (72 tests) 1818ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 434ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 574ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 584ms
+ ✓ tests/phases/runner-token-capture.test.ts (6 tests) 10ms
+ ✓ tests/commands/inner-footer.test.ts (2 tests) 14ms
+ ✓ tests/runners/codex-resume.test.ts (8 tests) 58ms
+ ✓ tests/tmux.test.ts (33 tests) 819ms
+   ✓ pollForPidFile > returns null on timeout when file never appears 405ms
+   ✓ pollForPidFile > returns null when file contains non-numeric content 407ms
+ ✓ tests/context/assembler-resume.test.ts (9 tests) 67ms
+ ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 6ms
+ ✓ tests/runners/codex-isolation.test.ts (8 tests) 43ms
+ ✓ tests/state-invalidation.test.ts (5 tests) 26ms
+ ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 51ms
+ ✓ tests/commands/resume-cmd.test.ts (12 tests) 2020ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui.test.ts (8 tests) 5ms
+ ✓ tests/runners/claude.test.ts (4 tests) 9ms
  ✓ tests/phases/verdict.test.ts (16 tests) 4ms
- ✓ tests/root.test.ts (10 tests) 168ms
- ✓ tests/resume.test.ts (11 tests) 2782ms
-   ✓ resumeRun > exits with code 1 and non-interactive message on paused run with null pendingAction (D4b) 323ms
-   ✓ resumeRun > errors when phase 5 completed but all trackedRepos implHead are null (state anomaly) 332ms
-   ✓ resumeRun > skip_phase Phase 6 with gitignored eval report: skips commit and leaves evalCommit null 369ms
-   ✓ completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8) > returns true and sets implHead when any repo advanced 314ms
- ✓ tests/context/reviewer-contract.test.ts (4 tests) 63ms
- ✓ tests/commands/status-list.test.ts (7 tests) 589ms
- ✓ tests/git.test.ts (20 tests) 1963ms
- ✓ tests/ui-footer.test.ts (9 tests) 5ms
- ✓ tests/phases/gate-resume-escalation.test.ts (1 test) 36ms
- ✓ tests/multi-worktree.test.ts (11 tests) 2713ms
-   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 457ms
-   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 667ms
-   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 437ms
-   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 385ms
-   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 554ms
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-UEXFpp/.claude/skills:
+ ✓ tests/root.test.ts (10 tests) 153ms
+ ✓ tests/resume.test.ts (11 tests) 2793ms
+   ✓ resumeRun > exits with code 1 and non-interactive message on paused run with null pendingAction (D4b) 330ms
+ ✓ tests/context/reviewer-contract.test.ts (4 tests) 42ms
+ ✓ tests/commands/status-list.test.ts (7 tests) 559ms
+ ✓ tests/phases/gate-resume-escalation.test.ts (1 test) 31ms
+ ✓ tests/ui-footer.test.ts (9 tests) 3ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-97jOsI/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-cX3vEr/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-f58etV/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-zIUJxU/.claude/skills:
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-97jOsI/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-cX3vEr/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-xBCmBD/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-LkIF2R/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-ohUVuB/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-jHthma/.claude/skills:
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-xBCmBD/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-jHthma/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-cls6Dz/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-uXEJJf/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-GXcC2d/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-RKAnE8/.claude/skills:
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-cls6Dz/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-RKAnE8/.claude/skills:
+No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-qlO4rw/.claude/skills. Nothing to uninstall.
+ ✓ tests/uninstall-skills.test.ts (6 tests) 21ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-6AHN2b/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-NeB6r6/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-kUvz7z/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-NeB6r6/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-kUvz7z/.claude/skills:
   phase-harness-codex-gate-review
- ✓ tests/install-skills.test.ts (7 tests) 21ms
-No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-oS8b6i/.claude/skills. Nothing to uninstall.
- ✓ tests/uninstall-skills.test.ts (6 tests) 28ms
- ✓ tests/input.test.ts (12 tests) 5ms
- ✓ tests/task-prompt.test.ts (7 tests) 3ms
- ✓ tests/commands/jump.test.ts (6 tests) 725ms
+ ✓ tests/install-skills.test.ts (7 tests) 25ms
+ ✓ tests/integration/lifecycle.test.ts (11 tests) 1171ms
+ ✓ tests/input.test.ts (12 tests) 3ms
+ ✓ tests/commands/jump.test.ts (6 tests) 672ms
+ ✓ tests/git.test.ts (20 tests) 1811ms
+ ✓ tests/multi-worktree.test.ts (11 tests) 2595ms
+   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 607ms
+   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 453ms
+   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 425ms
+   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 409ms
+   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 468ms
+ ✓ tests/task-prompt.test.ts (7 tests) 2ms
  ✓ tests/terminal.test.ts (5 tests) 2ms
- ✓ tests/integration/lifecycle.test.ts (11 tests) 1336ms
-[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui-prompt-model-config.test.ts (3 tests) 4ms
- ✓ tests/preflight-claude-at-file.test.ts (2 tests) 3ms
- ✓ tests/conformance/phase-models.test.ts (9 tests) 6ms
- ✓ tests/ui-separator.test.ts (5 tests) 2ms
- ✓ tests/process.test.ts (6 tests) 35ms
- ✓ tests/scripts/harness-verify.test.ts (2 tests) 383ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui-prompt-model-config.test.ts (3 tests) 2ms
+ ✓ tests/preflight-claude-at-file.test.ts (2 tests) 5ms
+ ✓ tests/conformance/phase-models.test.ts (9 tests) 3ms
+ ✓ tests/scripts/harness-verify.test.ts (2 tests) 363ms
+ ✓ tests/process.test.ts (6 tests) 21ms
+ ✓ tests/ui-separator.test.ts (5 tests) 1ms
+ ✓ tests/config.test.ts (8 tests) 2ms
+ ✓ tests/resolve-skills-root.test.ts (4 tests) 2ms
+ ✓ tests/commands/skip.test.ts (4 tests) 390ms
+ ✓ tests/phases/eval-report-commit-squash.test.ts (6 tests) 3837ms
 ```
 
 </details>
@@ -220,21 +220,20 @@ No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/un
 ⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
 ⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
 ⚠️  claude session resume fallback: no prior attempt id
+⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-Bd3G5l/phase-5-carryover-missing.md
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: no prior attempt id
-⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-BiZpEe/phase-5-carryover-missing.md
+⚠️  claude session resume fallback: jsonl missing
 ⚠️  claude session resume fallback: jsonl missing
 ⚠️  claude session resume fallback: jsonl missing
 ⚠️  claude session resume fallback: jsonl missing
 ⚠️  claude session resume fallback: jsonl missing
-⚠️  claude session resume fallback: jsonl missing
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: jsonl missing
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: no prior attempt id
-fatal: not a git repository (or any of the parent directories): .git
 
 Recent events:
 (events.jsonl not present — logging disabled)

--- a/docs/process/evals/2026-04-24-fix-phase-6-verify-213d-eval.md
+++ b/docs/process/evals/2026-04-24-fix-phase-6-verify-213d-eval.md
@@ -52,12 +52,12 @@
 
  RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/bug-fix
 
- ✓ tests/artifact.test.ts (23 tests) 3033ms
+ ✓ tests/artifact.test.ts (23 tests) 3187ms
 
  Test Files  1 passed (1)
       Tests  23 passed (23)
-   Start at  02:27:04
-   Duration  3.26s (transform 40ms, setup 0ms, collect 45ms, tests 3.03s, environment 0ms, prepare 36ms)
+   Start at  02:32:04
+   Duration  3.40s (transform 45ms, setup 0ms, collect 49ms, tests 3.19s, environment 0ms, prepare 38ms)
 ```
 
 </details>
@@ -82,12 +82,12 @@ fatal: not a git repository (or any of the parent directories): .git
 
  RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/bug-fix
 
- ✓ tests/phases/verify.test.ts (14 tests) 12ms
+ ✓ tests/phases/verify.test.ts (14 tests) 15ms
 
  Test Files  1 passed (1)
       Tests  14 passed (14)
-   Start at  02:27:08
-   Duration  251ms (transform 39ms, setup 0ms, collect 48ms, tests 12ms, environment 0ms, prepare 36ms)
+   Start at  02:32:08
+   Duration  235ms (transform 36ms, setup 0ms, collect 44ms, tests 15ms, environment 0ms, prepare 28ms)
 ```
 
 </details>
@@ -112,103 +112,103 @@ fatal: not a git repository (or any of the parent directories): .git
 
  RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/bug-fix
 
- ✓ tests/state.test.ts (50 tests) 48ms
- ✓ tests/context/skills-rendering.test.ts (45 tests) 90ms
- ✓ tests/logger.test.ts (32 tests) 99ms
- ✓ tests/phases/gate.test.ts (27 tests) 93ms
- ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 49ms
+ ✓ tests/state.test.ts (50 tests) 75ms
+ ✓ tests/context/skills-rendering.test.ts (45 tests) 127ms
+ ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 54ms
+ ✓ tests/phases/gate.test.ts (27 tests) 115ms
+ ✓ tests/logger.test.ts (32 tests) 136ms
  ✓ tests/commands/inner.test.ts (23 tests) 192ms
-[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/runners/claude-usage.test.ts (17 tests) 110ms
-[2J[H[2J[H[2J[H ✓ tests/phases/terminal-ui.test.ts (18 tests) 97ms
- ✓ tests/signal.test.ts (16 tests) 497ms
- ✓ tests/lock.test.ts (20 tests) 268ms
- ✓ tests/phases/gate-resume.test.ts (13 tests) 183ms
- ✓ tests/commands/footer-ticker.test.ts (10 tests) 110ms
- ✓ tests/integration/logging.test.ts (15 tests) 313ms
- ✓ tests/phases/runner.test.ts (76 tests) 586ms
- ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 9ms
- ✓ tests/phases/verify.test.ts (14 tests) 18ms
- ✓ tests/orphan-cleanup.test.ts (20 tests) 23ms
- ✓ tests/runners/codex.test.ts (17 tests) 72ms
- ✓ tests/preflight.test.ts (27 tests | 1 skipped) 195ms
- ✓ tests/integration/light-flow.test.ts (4 tests) 207ms
- ✓ tests/integration/codex-session-resume.test.ts (6 tests) 47ms
- ✓ tests/resume-light.test.ts (10 tests) 16ms
- ✓ tests/phases/runner-token-capture.test.ts (6 tests) 11ms
- ✓ tests/commands/inner-footer.test.ts (2 tests) 15ms
- ✓ tests/runners/codex-resume.test.ts (8 tests) 57ms
- ✓ tests/context/assembler.test.ts (72 tests) 1695ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 411ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 578ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 504ms
- ✓ tests/tmux.test.ts (33 tests) 820ms
-   ✓ pollForPidFile > returns null on timeout when file never appears 403ms
-   ✓ pollForPidFile > returns null when file contains non-numeric content 409ms
- ✓ tests/context/assembler-resume.test.ts (9 tests) 71ms
- ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 8ms
- ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 46ms
- ✓ tests/runners/codex-isolation.test.ts (8 tests) 27ms
- ✓ tests/state-invalidation.test.ts (5 tests) 7ms
-[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui.test.ts (8 tests) 4ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/runners/claude-usage.test.ts (17 tests) 113ms
+ ✓ tests/phases/terminal-ui.test.ts (18 tests) 109ms
+ ✓ tests/signal.test.ts (16 tests) 535ms
+ ✓ tests/lock.test.ts (20 tests) 292ms
+ ✓ tests/phases/gate-resume.test.ts (13 tests) 231ms
+ ✓ tests/integration/logging.test.ts (15 tests) 322ms
+ ✓ tests/commands/footer-ticker.test.ts (10 tests) 94ms
+ ✓ tests/phases/runner.test.ts (76 tests) 655ms
+ ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 12ms
+ ✓ tests/orphan-cleanup.test.ts (20 tests) 16ms
+ ✓ tests/runners/codex.test.ts (17 tests) 99ms
+ ✓ tests/phases/verify.test.ts (14 tests) 21ms
+ ✓ tests/preflight.test.ts (27 tests | 1 skipped) 181ms
+ ✓ tests/integration/light-flow.test.ts (4 tests) 223ms
+ ✓ tests/integration/codex-session-resume.test.ts (6 tests) 80ms
+ ✓ tests/resume-light.test.ts (10 tests) 21ms
+ ✓ tests/phases/runner-token-capture.test.ts (6 tests) 8ms
+ ✓ tests/commands/inner-footer.test.ts (2 tests) 13ms
+ ✓ tests/context/assembler.test.ts (72 tests) 1691ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 450ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 516ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 528ms
+ ✓ tests/runners/codex-resume.test.ts (8 tests) 65ms
+ ✓ tests/tmux.test.ts (33 tests) 814ms
+   ✓ pollForPidFile > returns null on timeout when file never appears 405ms
+   ✓ pollForPidFile > returns null when file contains non-numeric content 403ms
+ ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 9ms
+ ✓ tests/context/assembler-resume.test.ts (9 tests) 78ms
+ ✓ tests/runners/codex-isolation.test.ts (8 tests) 19ms
+ ✓ tests/state-invalidation.test.ts (5 tests) 8ms
+ ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 73ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui.test.ts (8 tests) 5ms
  ✓ tests/runners/claude.test.ts (4 tests) 10ms
- ✓ tests/commands/resume-cmd.test.ts (12 tests) 2071ms
- ✓ tests/phases/verdict.test.ts (16 tests) 3ms
- ✓ tests/resume.test.ts (11 tests) 2879ms
-   ✓ resumeRun > skip_phase Phase 6 with gitignored eval report: skips commit and leaves evalCommit null 309ms
-   ✓ completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8) > returns true and sets implHead when any repo advanced 408ms
-   ✓ completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8) > returns false when no repo advanced (HEAD === implRetryBase) 360ms
- ✓ tests/root.test.ts (10 tests) 189ms
- ✓ tests/context/reviewer-contract.test.ts (4 tests) 48ms
- ✓ tests/commands/status-list.test.ts (7 tests) 688ms
- ✓ tests/phases/gate-resume-escalation.test.ts (1 test) 39ms
- ✓ tests/git.test.ts (20 tests) 2149ms
- ✓ tests/multi-worktree.test.ts (11 tests) 2845ms
-   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 483ms
-   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 462ms
-   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 487ms
-   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 601ms
-   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 597ms
- ✓ tests/ui-footer.test.ts (9 tests) 4ms
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-zLBTGz/.claude/skills:
+ ✓ tests/commands/resume-cmd.test.ts (12 tests) 2252ms
+   ✓ resumeCommand > harness resume --light (rejected) > exits non-zero with a flow-frozen message 368ms
+ ✓ tests/phases/verdict.test.ts (16 tests) 4ms
+ ✓ tests/root.test.ts (10 tests) 159ms
+ ✓ tests/resume.test.ts (11 tests) 2893ms
+   ✓ resumeRun > exits with code 1 and non-interactive message on paused run with null pendingAction (D4b) 311ms
+   ✓ resumeRun > skip_phase Phase 6 with gitignored eval report: skips commit and leaves evalCommit null 336ms
+   ✓ completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8) > returns true and sets implHead when any repo advanced 541ms
+ ✓ tests/context/reviewer-contract.test.ts (4 tests) 50ms
+ ✓ tests/commands/status-list.test.ts (7 tests) 568ms
+ ✓ tests/phases/gate-resume-escalation.test.ts (1 test) 35ms
+ ✓ tests/ui-footer.test.ts (9 tests) 3ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-OgNDQN/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-DZ8mDt/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-SyHh89/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-NnZ9Ph/.claude/skills:
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-OgNDQN/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-ub5fQ5/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-RCNt03/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-ub5fQ5/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-yioQhC/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-21NL75/.claude/skills:
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-yioQhC/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-przbfG/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-rvCbKL/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-przbfG/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-SowOoO/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-iqbcM9/.claude/skills:
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-SowOoO/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-Q5JSWY/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-vHWkPh/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-Q5JSWY/.claude/skills:
+No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-P7vq2g/.claude/skills. Nothing to uninstall.
+ ✓ tests/uninstall-skills.test.ts (6 tests) 39ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-AFl3AV/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-iqbcM9/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-AFl3AV/.claude/skills:
   phase-harness-codex-gate-review
-No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-DFuliM/.claude/skills. Nothing to uninstall.
- ✓ tests/uninstall-skills.test.ts (6 tests) 16ms
- ✓ tests/install-skills.test.ts (7 tests) 21ms
- ✓ tests/input.test.ts (12 tests) 8ms
- ✓ tests/commands/jump.test.ts (6 tests) 745ms
- ✓ tests/task-prompt.test.ts (7 tests) 3ms
- ✓ tests/integration/lifecycle.test.ts (11 tests) 1768ms
-   ✓ CLI lifecycle integration > harness --help works 463ms
+ ✓ tests/install-skills.test.ts (7 tests) 50ms
+ ✓ tests/integration/lifecycle.test.ts (11 tests) 1484ms
+   ✓ CLI lifecycle integration > harness --help works 301ms
+ ✓ tests/git.test.ts (20 tests) 2142ms
+   ✓ isAncestor > returns false when not an ancestor 374ms
+ ✓ tests/input.test.ts (12 tests) 4ms
+ ✓ tests/commands/jump.test.ts (6 tests) 702ms
+ ✓ tests/task-prompt.test.ts (7 tests) 4ms
+ ✓ tests/multi-worktree.test.ts (11 tests) 2945ms
+   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 558ms
+   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 437ms
+   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 728ms
+   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 421ms
+   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 582ms
  ✓ tests/terminal.test.ts (5 tests) 2ms
-[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui-prompt-model-config.test.ts (3 tests) 3ms
- ✓ tests/conformance/phase-models.test.ts (9 tests) 3ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui-prompt-model-config.test.ts (3 tests) 5ms
+ ✓ tests/conformance/phase-models.test.ts (9 tests) 4ms
  ✓ tests/preflight-claude-at-file.test.ts (2 tests) 4ms
- ✓ tests/process.test.ts (6 tests) 55ms
  ✓ tests/ui-separator.test.ts (5 tests) 2ms
- ✓ tests/scripts/harness-verify.test.ts (2 tests) 369ms
- ✓ tests/phases/interactive.test.ts (51 tests) 4597ms
+ ✓ tests/process.test.ts (6 tests) 24ms
 ```
 
 </details>
@@ -221,8 +221,8 @@ No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/un
 ⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: no prior attempt id
-⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-MdvLA7/phase-5-carryover-missing.md
 ⚠️  claude session resume fallback: no prior attempt id
+⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-dx9QKJ/phase-5-carryover-missing.md
 ⚠️  claude session resume fallback: jsonl missing
 ⚠️  claude session resume fallback: jsonl missing
 ⚠️  claude session resume fallback: jsonl missing

--- a/docs/process/evals/2026-04-24-fix-phase-6-verify-213d-eval.md
+++ b/docs/process/evals/2026-04-24-fix-phase-6-verify-213d-eval.md
@@ -52,12 +52,12 @@
 
  RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/bug-fix
 
- ✓ tests/artifact.test.ts (22 tests) 2920ms
+ ✓ tests/artifact.test.ts (22 tests) 2959ms
 
  Test Files  1 passed (1)
       Tests  22 passed (22)
-   Start at  02:07:45
-   Duration  3.15s (transform 42ms, setup 0ms, collect 45ms, tests 2.92s, environment 0ms, prepare 33ms)
+   Start at  02:12:30
+   Duration  3.18s (transform 40ms, setup 0ms, collect 46ms, tests 2.96s, environment 0ms, prepare 32ms)
 ```
 
 </details>
@@ -82,12 +82,12 @@ fatal: not a git repository (or any of the parent directories): .git
 
  RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/bug-fix
 
- ✓ tests/phases/verify.test.ts (14 tests) 11ms
+ ✓ tests/phases/verify.test.ts (14 tests) 10ms
 
  Test Files  1 passed (1)
       Tests  14 passed (14)
-   Start at  02:07:48
-   Duration  219ms (transform 37ms, setup 0ms, collect 46ms, tests 11ms, environment 0ms, prepare 30ms)
+   Start at  02:12:34
+   Duration  217ms (transform 38ms, setup 0ms, collect 44ms, tests 10ms, environment 0ms, prepare 29ms)
 ```
 
 </details>
@@ -112,103 +112,103 @@ fatal: not a git repository (or any of the parent directories): .git
 
  RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/bug-fix
 
- ✓ tests/state.test.ts (50 tests) 47ms
- ✓ tests/logger.test.ts (32 tests) 106ms
- ✓ tests/context/skills-rendering.test.ts (45 tests) 103ms
- ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 51ms
- ✓ tests/phases/gate.test.ts (27 tests) 102ms
- ✓ tests/commands/inner.test.ts (23 tests) 248ms
-[2J[H[2J[H ✓ tests/integration/logging.test.ts (15 tests) 296ms
-[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/phases/terminal-ui.test.ts (18 tests) 134ms
- ✓ tests/runners/claude-usage.test.ts (17 tests) 148ms
- ✓ tests/signal.test.ts (16 tests) 443ms
- ✓ tests/lock.test.ts (20 tests) 247ms
- ✓ tests/phases/gate-resume.test.ts (13 tests) 121ms
- ✓ tests/commands/footer-ticker.test.ts (10 tests) 45ms
- ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 8ms
- ✓ tests/phases/runner.test.ts (76 tests) 602ms
- ✓ tests/orphan-cleanup.test.ts (20 tests) 23ms
- ✓ tests/runners/codex.test.ts (17 tests) 77ms
- ✓ tests/phases/verify.test.ts (14 tests) 21ms
- ✓ tests/preflight.test.ts (27 tests | 1 skipped) 191ms
- ✓ tests/integration/light-flow.test.ts (4 tests) 207ms
- ✓ tests/integration/codex-session-resume.test.ts (6 tests) 49ms
- ✓ tests/resume-light.test.ts (10 tests) 14ms
- ✓ tests/phases/runner-token-capture.test.ts (6 tests) 11ms
- ✓ tests/commands/inner-footer.test.ts (2 tests) 11ms
- ✓ tests/runners/codex-resume.test.ts (8 tests) 56ms
- ✓ tests/context/assembler.test.ts (72 tests) 1611ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 391ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 531ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 475ms
- ✓ tests/tmux.test.ts (33 tests) 823ms
-   ✓ pollForPidFile > returns null on timeout when file never appears 412ms
-   ✓ pollForPidFile > returns null when file contains non-numeric content 403ms
- ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 9ms
- ✓ tests/context/assembler-resume.test.ts (9 tests) 69ms
- ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 55ms
- ✓ tests/state-invalidation.test.ts (5 tests) 13ms
- ✓ tests/runners/codex-isolation.test.ts (8 tests) 20ms
-[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui.test.ts (8 tests) 5ms
- ✓ tests/runners/claude.test.ts (4 tests) 11ms
- ✓ tests/phases/verdict.test.ts (16 tests) 3ms
- ✓ tests/commands/resume-cmd.test.ts (12 tests) 2060ms
-   ✓ resumeCommand > harness resume --light (rejected) > exits non-zero with a flow-frozen message 301ms
- ✓ tests/root.test.ts (10 tests) 153ms
- ✓ tests/resume.test.ts (11 tests) 2887ms
-   ✓ resumeRun > exits with code 1 and non-interactive message on paused run with null pendingAction (D4b) 322ms
-   ✓ resumeRun > skip_phase Phase 6 with gitignored eval report: skips commit and leaves evalCommit null 379ms
-   ✓ completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8) > returns true and sets implHead when any repo advanced 492ms
- ✓ tests/commands/status-list.test.ts (7 tests) 574ms
- ✓ tests/context/reviewer-contract.test.ts (4 tests) 61ms
- ✓ tests/git.test.ts (20 tests) 1909ms
+ ✓ tests/state.test.ts (50 tests) 63ms
+ ✓ tests/context/skills-rendering.test.ts (45 tests) 107ms
+ ✓ tests/phases/gate.test.ts (27 tests) 100ms
+ ✓ tests/logger.test.ts (32 tests) 119ms
+ ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 50ms
+ ✓ tests/commands/inner.test.ts (23 tests) 256ms
+[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/integration/logging.test.ts (15 tests) 296ms
+[2J[H[2J[H[2J[H ✓ tests/phases/terminal-ui.test.ts (18 tests) 115ms
+ ✓ tests/runners/claude-usage.test.ts (17 tests) 171ms
+ ✓ tests/signal.test.ts (16 tests) 462ms
+ ✓ tests/phases/gate-resume.test.ts (13 tests) 129ms
+ ✓ tests/commands/footer-ticker.test.ts (10 tests) 57ms
+ ✓ tests/lock.test.ts (20 tests) 251ms
+ ✓ tests/phases/runner.test.ts (76 tests) 615ms
+ ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 7ms
+ ✓ tests/orphan-cleanup.test.ts (20 tests) 20ms
+ ✓ tests/phases/verify.test.ts (14 tests) 17ms
+ ✓ tests/runners/codex.test.ts (17 tests) 83ms
+ ✓ tests/preflight.test.ts (27 tests | 1 skipped) 183ms
+ ✓ tests/integration/light-flow.test.ts (4 tests) 176ms
+ ✓ tests/integration/codex-session-resume.test.ts (6 tests) 65ms
+ ✓ tests/resume-light.test.ts (10 tests) 49ms
+ ✓ tests/commands/inner-footer.test.ts (2 tests) 8ms
+ ✓ tests/phases/runner-token-capture.test.ts (6 tests) 6ms
+ ✓ tests/runners/codex-resume.test.ts (8 tests) 60ms
+ ✓ tests/tmux.test.ts (33 tests) 818ms
+   ✓ pollForPidFile > returns null on timeout when file never appears 403ms
+   ✓ pollForPidFile > returns null when file contains non-numeric content 406ms
+ ✓ tests/context/assembler.test.ts (72 tests) 1843ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 425ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 537ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 587ms
+ ✓ tests/context/assembler-resume.test.ts (9 tests) 136ms
+ ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 10ms
+ ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 50ms
+ ✓ tests/runners/codex-isolation.test.ts (8 tests) 53ms
+ ✓ tests/state-invalidation.test.ts (5 tests) 10ms
+ ✓ tests/commands/resume-cmd.test.ts (12 tests) 2009ms
+   ✓ resumeCommand > Case 2 stale pane (reused-mode): outer session stays alive, recursion creates new control window 302ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui.test.ts (8 tests) 4ms
+ ✓ tests/runners/claude.test.ts (4 tests) 6ms
+ ✓ tests/phases/verdict.test.ts (16 tests) 4ms
+ ✓ tests/root.test.ts (10 tests) 168ms
+ ✓ tests/resume.test.ts (11 tests) 2782ms
+   ✓ resumeRun > exits with code 1 and non-interactive message on paused run with null pendingAction (D4b) 323ms
+   ✓ resumeRun > errors when phase 5 completed but all trackedRepos implHead are null (state anomaly) 332ms
+   ✓ resumeRun > skip_phase Phase 6 with gitignored eval report: skips commit and leaves evalCommit null 369ms
+   ✓ completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8) > returns true and sets implHead when any repo advanced 314ms
+ ✓ tests/context/reviewer-contract.test.ts (4 tests) 63ms
+ ✓ tests/commands/status-list.test.ts (7 tests) 589ms
+ ✓ tests/git.test.ts (20 tests) 1963ms
  ✓ tests/ui-footer.test.ts (9 tests) 5ms
  ✓ tests/phases/gate-resume-escalation.test.ts (1 test) 36ms
- ✓ tests/integration/lifecycle.test.ts (11 tests) 1517ms
- ✓ tests/multi-worktree.test.ts (11 tests) 2711ms
-   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 503ms
-   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 454ms
-   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 597ms
-   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 434ms
-   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 512ms
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-Oj1HsW/.claude/skills:
+ ✓ tests/multi-worktree.test.ts (11 tests) 2713ms
+   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 457ms
+   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 667ms
+   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 437ms
+   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 385ms
+   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 554ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-UEXFpp/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-Oj1HsW/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-cX3vEr/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-AszSjJ/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-zIUJxU/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-AszSjJ/.claude/skills:
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-cX3vEr/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-2OY0ae/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-LkIF2R/.claude/skills:
   phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-2OY0ae/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-jHthma/.claude/skills:
   phase-harness-codex-gate-review
-No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-u4ZYeB/.claude/skills. Nothing to uninstall.
- ✓ tests/uninstall-skills.test.ts (6 tests) 18ms
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-IjJrTf/.claude/skills:
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-jHthma/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-nJrxjS/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-uXEJJf/.claude/skills:
   phase-harness-codex-gate-review
- ✓ tests/input.test.ts (12 tests) 3ms
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-h5LYh5/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-RKAnE8/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-DaJfL2/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-RKAnE8/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-APBkPp/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-NeB6r6/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-APBkPp/.claude/skills:
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-NeB6r6/.claude/skills:
   phase-harness-codex-gate-review
- ✓ tests/install-skills.test.ts (7 tests) 20ms
- ✓ tests/commands/jump.test.ts (6 tests) 657ms
- ✓ tests/task-prompt.test.ts (7 tests) 2ms
-[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui-prompt-model-config.test.ts (3 tests) 3ms
- ✓ tests/terminal.test.ts (5 tests) 3ms
- ✓ tests/preflight-claude-at-file.test.ts (2 tests) 4ms
- ✓ tests/conformance/phase-models.test.ts (9 tests) 3ms
+ ✓ tests/install-skills.test.ts (7 tests) 21ms
+No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-oS8b6i/.claude/skills. Nothing to uninstall.
+ ✓ tests/uninstall-skills.test.ts (6 tests) 28ms
+ ✓ tests/input.test.ts (12 tests) 5ms
+ ✓ tests/task-prompt.test.ts (7 tests) 3ms
+ ✓ tests/commands/jump.test.ts (6 tests) 725ms
+ ✓ tests/terminal.test.ts (5 tests) 2ms
+ ✓ tests/integration/lifecycle.test.ts (11 tests) 1336ms
+[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H[2J[H ✓ tests/ui-prompt-model-config.test.ts (3 tests) 4ms
+ ✓ tests/preflight-claude-at-file.test.ts (2 tests) 3ms
+ ✓ tests/conformance/phase-models.test.ts (9 tests) 6ms
  ✓ tests/ui-separator.test.ts (5 tests) 2ms
- ✓ tests/config.test.ts (8 tests) 2ms
- ✓ tests/process.test.ts (6 tests) 23ms
- ✓ tests/resolve-skills-root.test.ts (4 tests) 2ms
+ ✓ tests/process.test.ts (6 tests) 35ms
+ ✓ tests/scripts/harness-verify.test.ts (2 tests) 383ms
 ```
 
 </details>
@@ -222,7 +222,7 @@ Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: no prior attempt id
-⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-Tw1Wh7/phase-5-carryover-missing.md
+⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-BiZpEe/phase-5-carryover-missing.md
 ⚠️  claude session resume fallback: jsonl missing
 ⚠️  claude session resume fallback: jsonl missing
 ⚠️  claude session resume fallback: jsonl missing

--- a/docs/specs/2026-04-24-fix-phase-6-verify-213d-design.md
+++ b/docs/specs/2026-04-24-fix-phase-6-verify-213d-design.md
@@ -37,16 +37,17 @@ Phase 6 preconditions recompute the fingerprint for every live porcelain line (a
 
 R1. `runPhase6Preconditions` MUST filter out porcelain lines whose **fingerprint** (`<XY>\0<path>\0<hash>`) matches an entry in `dirtyBaseline`, in addition to filtering the eval report. Filtering is fingerprint-exact — a path whose content hash has changed since baseline capture MUST NOT match and MUST fire the guard. Both baseline capture and live Phase‑6 porcelain reads MUST use `git status --porcelain --untracked-files=all` so every untracked file has a file-granular fingerprint (no directory collapse).
 R2. The fingerprint filter MUST apply to both the initial dirty check (Step 2) and the final clean check (Step 4).
-R3. `state.dirtyBaseline: string[]` MUST be captured once at session init in `src/commands/start.ts`, after `.gitignore` commits and before `createInitialState` is persisted, from `git status --porcelain --untracked-files=all` run at `trackedRepos[0].path`. Each dirty path contributes one fingerprint string. Non-git roots and git roots with clean trees produce `[]`.
+R3. `state.dirtyBaseline: string[]` MUST be captured once at session init in `src/commands/start.ts`, after `.gitignore` commits and before the first `writeState` for the run, by unconditionally calling `captureDirtyBaseline(trackedRepos[0].path)` — **regardless of whether the outer `cwd` is a git repo**. `detectTrackedRepos` (and its per-repo preflight) already guarantees `trackedRepos[0].path` points at a git working tree, so docsRoot cleanliness is the authoritative source. Gating on the outer-cwd `inGitRepo` flag (as an earlier revision proposed) would silently skip baseline capture in the supported "non-git outer + depth-1 docsRoot" mode and is prohibited by this requirement. `captureDirtyBaseline` returns `[]` defensively if its `cwd` ever turns out not to be a git repo, and also `[]` for a clean git root — both acceptable.
 R4. `state.dirtyBaseline` MUST default to `[]` when reading legacy state files (backward-compatible migration in `src/state.ts::loadState`). Legacy in-flight runs retain strict pre-fix behavior by design (see Decision D4).
 R5. Existing tests (`tests/artifact.test.ts`, `tests/phases/verify.test.ts`) MUST keep passing — baseline defaults to `[]` when omitted, matching the current strict behavior.
 R6. New tests MUST cover:
     - Pre-existing tracked-dirty file whose fingerprint is in baseline → no throw (issue #68 repro, tracked variant).
     - Pre-existing untracked file whose fingerprint is in baseline → no throw (issue #68 repro, untracked variant).
     - Pre-existing dirty file + an additional **Phase-5-introduced** dirty file → still throws (regression guard).
-    - **Pre-existing dirty file whose content is further modified after baseline capture** → still throws (fingerprint mismatch, closes P1 round‑1 feedback gap).
-    - **Pre-existing untracked directory in baseline + Phase-5 adds a new file inside it** → still throws (file-granular baseline via `-uall`, closes P1 round‑2 feedback gap).
+    - **Pre-existing dirty file whose content is further modified after baseline capture** → still throws (fingerprint mismatch, closes P1 round‑1 gate‑2 gap).
+    - **Pre-existing untracked directory in baseline + Phase-5 adds a new file inside it** → still throws (file-granular baseline via `-uall`, closes P1 round‑2 gate‑2 gap).
     - Final clean check also respects baseline (baseline entries remain present after cleanup).
+    - **Session-init wiring regression (closes P1 + P2 gate‑7 gap).** A `startCommand`-level test that simulates a non-git outer `cwd` with a git `trackedRepos[0]` (docsRoot) containing a pre-existing dirty file, runs the session-init path, and asserts the persisted `state.dirtyBaseline` is populated from docsRoot (non-empty, matching the docsRoot fingerprint) — **not** `[]`. This pins the `inGitRepo`-independence mandated by R3 and makes the bug re-introduction regress in CI.
 R7. No change to the error message (`'Working tree must be clean before verification'`) — keeps existing string assertions in tests and logs.
 
 ## Design
@@ -76,11 +77,13 @@ The `--untracked-files=all` flag guarantees that every untracked file is listed 
 
 ### Capture point in `src/commands/start.ts`
 
-After step 11 (HEAD re-read post-`.gitignore` commit) and immediately after `state.trackedRepos = trackedRepos;` in step 12, call:
+After step 11 (HEAD re-read post-`.gitignore` commit) and immediately after `state.trackedRepos = trackedRepos;` in step 12, call — **unconditionally**, without gating on the outer-cwd `inGitRepo` flag:
 
 ```ts
-state.dirtyBaseline = inGitRepo ? captureDirtyBaseline(trackedRepos[0].path) : [];
+state.dirtyBaseline = captureDirtyBaseline(trackedRepos[0].path);
 ```
+
+`trackedRepos[0].path` is already validated as a git working tree by `detectTrackedRepos` + the per-repo preflight (`runPreflight(['git', 'head'], repo.path)`). In the supported "non-git outer + depth-1 docsRoot" topology (exercised by `tests/commands/start.test.ts` and `tests/multi-worktree.test.ts`), the outer `cwd` is not a git repo but `trackedRepos[0].path` still is — gating on `inGitRepo` would always leave `state.dirtyBaseline = []` there and silently disable the fix for an entire supported mode. The new helper returns `[]` defensively for any unexpected non-git path, so dropping the gate is safe.
 
 ### Precondition filter in `src/artifact.ts::runPhase6Preconditions`
 
@@ -110,8 +113,8 @@ Caller in `src/phases/verify.ts::runVerifyPhase` passes `state.dirtyBaseline ?? 
 ## Implementation Plan
 
 - **Task 1 — State schema + migration.** Add `dirtyBaseline: string[]` to `HarnessState` in `src/types.ts`. Default it to `[]` in `createInitialState` (`src/state.ts`). Add the one-line migration in `loadState` (`src/state.ts`).
-- **Task 2 — Fingerprint helper + session-init capture.** Add `captureDirtyBaseline(cwd)` in `src/artifact.ts`. In `src/commands/start.ts`, immediately after `state.trackedRepos = trackedRepos;` (step 12), assign `state.dirtyBaseline = inGitRepo ? captureDirtyBaseline(trackedRepos[0].path) : []`.
-- **Task 3 — Filter precondition + wire caller + tests.** Extend `runPhase6Preconditions` with a `dirtyBaseline: string[] = []` parameter, switch its two `git status --porcelain` invocations to `--porcelain --untracked-files=all`, compute live fingerprints and filter Steps 2 and 4 before the eval-report filter. Update `src/phases/verify.ts` to pass `state.dirtyBaseline ?? []`. Add six `tests/artifact.test.ts` cases covering R6 (including the content-mismatch regression and the untracked-directory-expansion regression from P1 gate‑2 rounds 1 and 2). Update `tests/phases/verify.test.ts` only if its `runPhase6Preconditions` mock assertion needs adjusting for the optional 4th arg.
+- **Task 2 — Fingerprint helper + session-init capture.** Add `captureDirtyBaseline(cwd)` in `src/artifact.ts`. In `src/commands/start.ts`, immediately after `state.trackedRepos = trackedRepos;` (step 12), assign `state.dirtyBaseline = captureDirtyBaseline(trackedRepos[0].path)` **unconditionally** (do not gate on the outer-cwd `inGitRepo` flag — see R3 and D6). Remove any prior `inGitRepo ? … : []` gating that may have been introduced by earlier revisions of this spec.
+- **Task 3 — Filter precondition + wire caller + tests.** Extend `runPhase6Preconditions` with a `dirtyBaseline: string[] = []` parameter, switch its two `git status --porcelain` invocations to `--porcelain --untracked-files=all`, compute live fingerprints and filter Steps 2 and 4 before the eval-report filter. Update `src/phases/verify.ts` to pass `state.dirtyBaseline ?? []`. Add the seven `tests/artifact.test.ts` / `tests/commands/start.test.ts` cases covering R6 — the six precondition-level cases (tracked-dirty, untracked, phase-5-added, content-mismatch, untracked-dir-expansion, final-clean respects baseline) **plus** the new session-init wiring test asserting `state.dirtyBaseline` is populated from `trackedRepos[0].path` even when the outer cwd is not a git repo (closes gate‑7 P1 + P2). Update `tests/phases/verify.test.ts` only if its `runPhase6Preconditions` mock assertion needs adjusting for the optional 4th arg.
 
 ## Eval Checklist Summary
 

--- a/docs/specs/2026-04-24-fix-phase-6-verify-213d-design.md
+++ b/docs/specs/2026-04-24-fix-phase-6-verify-213d-design.md
@@ -1,0 +1,115 @@
+# Fix Phase 6 verify precondition: ignore pre-existing dirty files — Design Spec (Light)
+
+## Complexity
+
+Small — scoped to one guard in `runPhase6Preconditions` plus a baseline snapshot captured once at session init. No new flow, no new phase, no multi-repo refactor.
+
+## Context & Decisions
+
+**Problem.** `src/artifact.ts::runPhase6Preconditions` enforces a blanket working‑tree‑clean invariant via `git status --porcelain`, filtering only the eval report path (Step 2 and Step 4). On mission branches with any pre-existing uncommitted content (issue #68) or after a P7→P5 reopen cycle that leaves unrelated dirty files behind (issue #67), this guard throws immediately — Phase 6 never reaches verification, `durationMs<60ms`.
+
+**Intent of the original guard.** The check exists to protect Phase 6 from a Phase‑5 failure mode where the implementor leaves tracked work uncommitted (so the eval report reflects an unstable tree). The invariant we actually want is *"no Phase‑5-introduced changes are uncommitted"*, not *"the working tree is pristine relative to the empty set"*.
+
+**Chosen baseline anchor.** The task prompt suggests `state.implRetryBase` "or equivalent". `implRetryBase` is a commit, which only captures tracked-file diffs — it cannot distinguish *pre-existing untracked files* (e.g. scratch notes) from *Phase‑5-introduced untracked files*. We therefore snapshot the `git status --porcelain` output of `trackedRepos[0].path` (docsRoot, the only repo the precondition inspects) **once at session init**, after `.gitignore` housekeeping, and persist it in `state.dirtyBaseline: string[]`. Phase 6 preconditions subtract this baseline from the live porcelain output before evaluating cleanliness.
+
+**Why session-init rather than Phase‑5-open re-snapshot.** A baseline frozen at session init represents "state before the harness touched anything". Re-snapshotting at every Phase‑5 reopen would fold prior Phase‑5 leftovers into the baseline and mask real regressions. Session-init captures the user's genuine pre-existing dirt exactly once; everything introduced after that point is treated as Phase‑5 work and must be committed before Phase 6.
+
+**Scope boundaries.**
+- Only `state.trackedRepos[0]` (docsRoot) gets a baseline — this matches the current single-repo behavior of `runPhase6Preconditions`. Multi-repo baseline is out of scope.
+- Legacy states without `dirtyBaseline` (loaded from existing runs) default to `[]` via the state migration — current behavior preserved for in-flight runs.
+- The guard still fires for Phase‑5-introduced uncommitted changes: any porcelain line that is not in `dirtyBaseline` and not the eval report triggers the throw.
+- No change to the eval-report cleanup steps (Step 3 of preconditions).
+
+**Ambiguity resolution.** No open questions remained after reviewing the two issues, the precondition implementation, and the Phase‑5 reopen semantics (`src/phases/interactive.ts` Phase‑5 block). All decisions above are fixed — no developer Q&A needed for this session.
+
+## Requirements / Scope
+
+R1. `runPhase6Preconditions` MUST filter out porcelain lines that exactly match a line recorded in `dirtyBaseline`, in addition to filtering the eval report.
+R2. The filter MUST apply to both the initial dirty check (Step 2) and the final clean check (Step 4).
+R3. `state.dirtyBaseline: string[]` MUST be captured once at session init in `src/commands/start.ts`, after `.gitignore` commits and before `createInitialState` is persisted, from the porcelain output of `trackedRepos[0].path`.
+R4. `state.dirtyBaseline` MUST default to `[]` when reading legacy state files (backward-compatible migration in `src/state.ts::loadState`).
+R5. Existing tests (`tests/artifact.test.ts`, `tests/phases/verify.test.ts`) MUST keep passing — baseline defaults to `[]` when omitted, matching the current strict behavior.
+R6. New tests MUST cover:
+    - Pre-existing tracked-dirty file listed in baseline → no throw (issue #68 repro).
+    - Pre-existing untracked file listed in baseline → no throw (issue #68 repro).
+    - Pre-existing dirty file + a new Phase-5-introduced dirty file → still throws (regression guard).
+    - Final clean check also respects baseline (baseline entries remain present after cleanup).
+R7. No change to the error message (`'Working tree must be clean before verification'`) — keeps existing string assertions in tests and logs.
+
+## Design
+
+### State schema change
+
+`src/types.ts`:
+
+```ts
+export interface HarnessState {
+  // ... existing fields ...
+  dirtyBaseline: string[]; // porcelain lines from trackedRepos[0] at session init
+}
+```
+
+`src/state.ts::createInitialState` returns `dirtyBaseline: []`. Callers set it immediately after construction if the repo has pre-existing dirty content. `loadState` migration:
+
+```ts
+if (!Array.isArray(raw.dirtyBaseline)) raw.dirtyBaseline = [];
+```
+
+### Capture point in `src/commands/start.ts`
+
+After step 11 (HEAD re-read post-`.gitignore` commit) and immediately after `state.trackedRepos = trackedRepos;` in step 12, compute:
+
+```ts
+let dirtyBaseline: string[] = [];
+if (inGitRepo) {
+  try {
+    const out = execSync('git status --porcelain', {
+      cwd: trackedRepos[0].path, encoding: 'utf-8',
+    }).trim();
+    dirtyBaseline = out === '' ? [] : out.split('\n').filter(Boolean);
+  } catch { /* best-effort, leave empty */ }
+}
+state.dirtyBaseline = dirtyBaseline;
+```
+
+Captured only for `inGitRepo === true`; non-git roots retain `[]` (current behavior — no guard to narrow anyway).
+
+### Precondition filter in `src/artifact.ts::runPhase6Preconditions`
+
+Extend signature:
+
+```ts
+export function runPhase6Preconditions(
+  evalReportPath: string,
+  runId: string,
+  cwd?: string,
+  dirtyBaseline: string[] = [],
+): void
+```
+
+Convert `dirtyBaseline` to a `Set<string>` once. In Step 2 (`porcelainOutput`) and Step 4 (`finalStatus`), **before** the existing eval-report filter, drop any line whose exact string is a member of the baseline set. Remaining logic unchanged.
+
+Caller in `src/phases/verify.ts::runVerifyPhase` passes `state.dirtyBaseline ?? []`.
+
+### Non-goals
+
+- No per-repo baseline (trackedRepos[1+]).
+- No re-snapshot on reopen.
+- No change to `hasStagedChanges` / `isWorkingTreeClean` used in `start.ts` preflight.
+- No change to the staged-file check in Step 1 of preconditions (still fires on any staged file other than the eval report — staged work is unambiguously Phase‑5 output the user forgot to commit, not "pre-existing dirt").
+
+## Implementation Plan
+
+- **Task 1 — State schema + migration.** Add `dirtyBaseline: string[]` to `HarnessState` in `src/types.ts`. Default it to `[]` in `createInitialState` (`src/state.ts`). Add the one-line migration in `loadState` (`src/state.ts`).
+- **Task 2 — Capture baseline at session init.** In `src/commands/start.ts`, immediately after `state.trackedRepos = trackedRepos;` (step 12), compute porcelain snapshot from `trackedRepos[0].path` when `inGitRepo`, assign to `state.dirtyBaseline`. Keep `[]` in the non-git-repo branch.
+- **Task 3 — Filter precondition + wire caller + tests.** Extend `runPhase6Preconditions` with a `dirtyBaseline: string[] = []` parameter, filter Steps 2 and 4. Update `src/phases/verify.ts` to pass `state.dirtyBaseline ?? []`. Add four `tests/artifact.test.ts` cases covering R6. Update `tests/phases/verify.test.ts` if its `runPhase6Preconditions` mock signature needs adjusting (optional 4th arg — mock should still match).
+
+## Eval Checklist Summary
+
+Verification JSON lives at `.harness/2026-04-24-fix-phase-6-verify-213d/checklist.json`. It runs:
+
+1. `pnpm tsc --noEmit` — typecheck the state schema + new signature.
+2. `pnpm vitest run tests/artifact.test.ts` — unit coverage for `runPhase6Preconditions` including new baseline cases.
+3. `pnpm vitest run tests/phases/verify.test.ts` — ensure `runVerifyPhase` caller still integrates cleanly.
+4. `pnpm vitest run` — full suite regression.
+5. `pnpm build` — ensure dist compiles (integration tests reference dist).

--- a/docs/specs/2026-04-24-fix-phase-6-verify-213d-design.md
+++ b/docs/specs/2026-04-24-fix-phase-6-verify-213d-design.md
@@ -10,14 +10,16 @@ Small — scoped to one guard in `runPhase6Preconditions` plus a content-hashed 
 
 **Intent of the original guard.** The check exists to protect Phase 6 from a Phase‑5 failure mode where the implementor leaves tracked work uncommitted (so the eval report reflects an unstable tree). The invariant we actually want is *"no Phase‑5-introduced changes are uncommitted"*, not *"the working tree is pristine relative to the empty set"*.
 
-**Chosen baseline anchor — content-hashed fingerprints.** The task prompt suggests `state.implRetryBase` "or equivalent". `implRetryBase` is a commit, which only captures tracked-file diffs — it cannot distinguish *pre-existing untracked files* from *Phase‑5-introduced untracked files*. We therefore snapshot the dirty state of `trackedRepos[0].path` (docsRoot, the only repo the precondition inspects) **once at session init**, after `.gitignore` housekeeping, as a set of *fingerprints* — one per dirty path — and persist it in `state.dirtyBaseline: string[]`.
+**Chosen baseline anchor — content-hashed fingerprints (file-granular).** The task prompt suggests `state.implRetryBase` "or equivalent". `implRetryBase` is a commit, which only captures tracked-file diffs — it cannot distinguish *pre-existing untracked files* from *Phase‑5-introduced untracked files*. We therefore snapshot the dirty state of `trackedRepos[0].path` (docsRoot, the only repo the precondition inspects) **once at session init**, after `.gitignore` housekeeping, as a set of *fingerprints* — one per dirty path — and persist it in `state.dirtyBaseline: string[]`.
+
+**Both the baseline capture and the live Phase‑6 check use `git status --porcelain --untracked-files=all`** (alias `-uall`). Without this flag, Git collapses an untracked directory to a single `?? dir/` entry — the path is not hashable as a file and any Phase‑5 addition *inside* that directory would produce the same `?? dir/` line, allowing new uncommitted content to be masked by a directory-level fingerprint. `--untracked-files=all` expands every untracked file individually, so each baseline entry binds to exactly one hashable path. This closes the P1 feedback gap from gate‑2 round 2.
 
 Each fingerprint is the tuple `"<XY>\0<path>\0<hash>"`, where:
 - `XY` is the 2-char porcelain status code (e.g. ` M`, `??`, `A `, ` D`).
-- `path` is the path from porcelain column 4 onward.
+- `path` is the path from porcelain column 4 onward (a file path, not a directory, thanks to `-uall`).
 - `hash` is `git hash-object -- <path>` for files that exist on disk, or `""` for deletions / missing files.
 
-Phase 6 preconditions recompute the fingerprint for every live porcelain line and only filter entries whose fingerprint is present in the baseline set. **This closes the P1 feedback gap from gate‑2 review**: further Phase‑5 edits to a pre-existing dirty path change the file's content hash, so the live fingerprint no longer matches the baseline and the guard fires as intended.
+Phase 6 preconditions recompute the fingerprint for every live porcelain line (also via `-uall`) and only filter entries whose fingerprint is present in the baseline set. Further Phase‑5 edits to a pre-existing dirty file change its content hash → live fingerprint no longer matches baseline → guard fires as intended. Phase‑5 additions inside a pre-existing untracked directory produce new `?? dir/newfile` entries whose fingerprints were never in the baseline → guard fires as intended.
 
 **Why session-init rather than Phase‑5-open re-snapshot.** A baseline frozen at session init represents "state before the harness touched anything". Re-snapshotting at every Phase‑5 reopen would fold prior Phase‑5 leftovers into the baseline and mask real regressions. Session-init captures the user's genuine pre-existing dirt exactly once; everything introduced after that point is treated as Phase‑5 work and must be committed before Phase 6.
 
@@ -33,16 +35,17 @@ Phase 6 preconditions recompute the fingerprint for every live porcelain line an
 
 ## Requirements / Scope
 
-R1. `runPhase6Preconditions` MUST filter out porcelain lines whose **fingerprint** (`<XY>\0<path>\0<hash>`) matches an entry in `dirtyBaseline`, in addition to filtering the eval report. Filtering is fingerprint-exact — a path whose content hash has changed since baseline capture MUST NOT match and MUST fire the guard.
+R1. `runPhase6Preconditions` MUST filter out porcelain lines whose **fingerprint** (`<XY>\0<path>\0<hash>`) matches an entry in `dirtyBaseline`, in addition to filtering the eval report. Filtering is fingerprint-exact — a path whose content hash has changed since baseline capture MUST NOT match and MUST fire the guard. Both baseline capture and live Phase‑6 porcelain reads MUST use `git status --porcelain --untracked-files=all` so every untracked file has a file-granular fingerprint (no directory collapse).
 R2. The fingerprint filter MUST apply to both the initial dirty check (Step 2) and the final clean check (Step 4).
-R3. `state.dirtyBaseline: string[]` MUST be captured once at session init in `src/commands/start.ts`, after `.gitignore` commits and before `createInitialState` is persisted, from the porcelain output of `trackedRepos[0].path`. Each dirty path contributes one fingerprint string. Non-git roots and git roots with clean trees produce `[]`.
+R3. `state.dirtyBaseline: string[]` MUST be captured once at session init in `src/commands/start.ts`, after `.gitignore` commits and before `createInitialState` is persisted, from `git status --porcelain --untracked-files=all` run at `trackedRepos[0].path`. Each dirty path contributes one fingerprint string. Non-git roots and git roots with clean trees produce `[]`.
 R4. `state.dirtyBaseline` MUST default to `[]` when reading legacy state files (backward-compatible migration in `src/state.ts::loadState`). Legacy in-flight runs retain strict pre-fix behavior by design (see Decision D4).
 R5. Existing tests (`tests/artifact.test.ts`, `tests/phases/verify.test.ts`) MUST keep passing — baseline defaults to `[]` when omitted, matching the current strict behavior.
 R6. New tests MUST cover:
     - Pre-existing tracked-dirty file whose fingerprint is in baseline → no throw (issue #68 repro, tracked variant).
     - Pre-existing untracked file whose fingerprint is in baseline → no throw (issue #68 repro, untracked variant).
     - Pre-existing dirty file + an additional **Phase-5-introduced** dirty file → still throws (regression guard).
-    - **Pre-existing dirty file whose content is further modified after baseline capture** → still throws (fingerprint mismatch, closes P1 feedback gap).
+    - **Pre-existing dirty file whose content is further modified after baseline capture** → still throws (fingerprint mismatch, closes P1 round‑1 feedback gap).
+    - **Pre-existing untracked directory in baseline + Phase-5 adds a new file inside it** → still throws (file-granular baseline via `-uall`, closes P1 round‑2 feedback gap).
     - Final clean check also respects baseline (baseline entries remain present after cleanup).
 R7. No change to the error message (`'Working tree must be clean before verification'`) — keeps existing string assertions in tests and logs.
 
@@ -67,7 +70,9 @@ if (!Array.isArray(raw.dirtyBaseline)) raw.dirtyBaseline = [];
 
 ### Fingerprint helper
 
-A small helper — new exported function `captureDirtyBaseline(cwd: string): string[]` — lives in `src/artifact.ts` (next to `runPhase6Preconditions`, which is the only consumer). It runs `git status --porcelain`, parses each line into `{ xy, path }`, computes `git hash-object -- <path>` when the path exists on disk (safe-wrapped — missing file / `R` status fall through to `hash = ""`), and returns the fingerprint list `"<xy>\0<path>\0<hash>"`. Non-git cwd returns `[]`.
+A small helper — new exported function `captureDirtyBaseline(cwd: string): string[]` — lives in `src/artifact.ts` (next to `runPhase6Preconditions`, which is the only consumer). It runs `git status --porcelain --untracked-files=all`, parses each line into `{ xy, path }`, computes `git hash-object -- <path>` when the path exists on disk as a file (safe-wrapped — missing file / `R` status fall through to `hash = ""`), and returns the fingerprint list `"<xy>\0<path>\0<hash>"`. Non-git cwd returns `[]`.
+
+The `--untracked-files=all` flag guarantees that every untracked file is listed individually rather than collapsed into a parent `?? dir/` entry, so each baseline fingerprint binds to exactly one hashable file path. This is the single point where Phase‑5 additions inside a pre-existing untracked directory are distinguished from the baseline.
 
 ### Capture point in `src/commands/start.ts`
 
@@ -90,7 +95,7 @@ export function runPhase6Preconditions(
 ): void
 ```
 
-Convert `dirtyBaseline` to a `Set<string>` once. In Step 2 (`porcelainOutput`) and Step 4 (`finalStatus`), **before** the existing eval-report filter, for each live porcelain line recompute the fingerprint (same parsing + `git hash-object`) and drop the line if its fingerprint is in the baseline set. Remaining logic unchanged.
+Convert `dirtyBaseline` to a `Set<string>` once. Replace the two `git status --porcelain` calls in the function (Step 2 `porcelainOutput`, Step 4 `finalStatus`) with `git status --porcelain --untracked-files=all` so live fingerprints are computed on the same file-granular representation the baseline was captured with — without this flag the live output could collapse an untracked directory and no recomputed fingerprint would match a baseline file-level entry. Then, in both Steps 2 and 4, **before** the existing eval-report filter, recompute the fingerprint per live line (same parsing + `git hash-object`) and drop the line if its fingerprint is in the baseline set. Remaining logic unchanged.
 
 Caller in `src/phases/verify.ts::runVerifyPhase` passes `state.dirtyBaseline ?? []`.
 
@@ -106,7 +111,7 @@ Caller in `src/phases/verify.ts::runVerifyPhase` passes `state.dirtyBaseline ?? 
 
 - **Task 1 — State schema + migration.** Add `dirtyBaseline: string[]` to `HarnessState` in `src/types.ts`. Default it to `[]` in `createInitialState` (`src/state.ts`). Add the one-line migration in `loadState` (`src/state.ts`).
 - **Task 2 — Fingerprint helper + session-init capture.** Add `captureDirtyBaseline(cwd)` in `src/artifact.ts`. In `src/commands/start.ts`, immediately after `state.trackedRepos = trackedRepos;` (step 12), assign `state.dirtyBaseline = inGitRepo ? captureDirtyBaseline(trackedRepos[0].path) : []`.
-- **Task 3 — Filter precondition + wire caller + tests.** Extend `runPhase6Preconditions` with a `dirtyBaseline: string[] = []` parameter, compute live fingerprints and filter Steps 2 and 4 before the eval-report filter. Update `src/phases/verify.ts` to pass `state.dirtyBaseline ?? []`. Add five `tests/artifact.test.ts` cases covering R6 (including the content-mismatch regression for P1 feedback). Update `tests/phases/verify.test.ts` only if its `runPhase6Preconditions` mock assertion needs adjusting for the optional 4th arg.
+- **Task 3 — Filter precondition + wire caller + tests.** Extend `runPhase6Preconditions` with a `dirtyBaseline: string[] = []` parameter, switch its two `git status --porcelain` invocations to `--porcelain --untracked-files=all`, compute live fingerprints and filter Steps 2 and 4 before the eval-report filter. Update `src/phases/verify.ts` to pass `state.dirtyBaseline ?? []`. Add six `tests/artifact.test.ts` cases covering R6 (including the content-mismatch regression and the untracked-directory-expansion regression from P1 gate‑2 rounds 1 and 2). Update `tests/phases/verify.test.ts` only if its `runPhase6Preconditions` mock assertion needs adjusting for the optional 4th arg.
 
 ## Eval Checklist Summary
 

--- a/docs/specs/2026-04-24-fix-phase-6-verify-213d-design.md
+++ b/docs/specs/2026-04-24-fix-phase-6-verify-213d-design.md
@@ -2,7 +2,7 @@
 
 ## Complexity
 
-Small — scoped to one guard in `runPhase6Preconditions` plus a baseline snapshot captured once at session init. No new flow, no new phase, no multi-repo refactor.
+Small — scoped to one guard in `runPhase6Preconditions` plus a content-hashed baseline snapshot captured once at session init. No new flow, no new phase, no multi-repo refactor.
 
 ## Context & Decisions
 
@@ -10,29 +10,39 @@ Small — scoped to one guard in `runPhase6Preconditions` plus a baseline snapsh
 
 **Intent of the original guard.** The check exists to protect Phase 6 from a Phase‑5 failure mode where the implementor leaves tracked work uncommitted (so the eval report reflects an unstable tree). The invariant we actually want is *"no Phase‑5-introduced changes are uncommitted"*, not *"the working tree is pristine relative to the empty set"*.
 
-**Chosen baseline anchor.** The task prompt suggests `state.implRetryBase` "or equivalent". `implRetryBase` is a commit, which only captures tracked-file diffs — it cannot distinguish *pre-existing untracked files* (e.g. scratch notes) from *Phase‑5-introduced untracked files*. We therefore snapshot the `git status --porcelain` output of `trackedRepos[0].path` (docsRoot, the only repo the precondition inspects) **once at session init**, after `.gitignore` housekeeping, and persist it in `state.dirtyBaseline: string[]`. Phase 6 preconditions subtract this baseline from the live porcelain output before evaluating cleanliness.
+**Chosen baseline anchor — content-hashed fingerprints.** The task prompt suggests `state.implRetryBase` "or equivalent". `implRetryBase` is a commit, which only captures tracked-file diffs — it cannot distinguish *pre-existing untracked files* from *Phase‑5-introduced untracked files*. We therefore snapshot the dirty state of `trackedRepos[0].path` (docsRoot, the only repo the precondition inspects) **once at session init**, after `.gitignore` housekeeping, as a set of *fingerprints* — one per dirty path — and persist it in `state.dirtyBaseline: string[]`.
+
+Each fingerprint is the tuple `"<XY>\0<path>\0<hash>"`, where:
+- `XY` is the 2-char porcelain status code (e.g. ` M`, `??`, `A `, ` D`).
+- `path` is the path from porcelain column 4 onward.
+- `hash` is `git hash-object -- <path>` for files that exist on disk, or `""` for deletions / missing files.
+
+Phase 6 preconditions recompute the fingerprint for every live porcelain line and only filter entries whose fingerprint is present in the baseline set. **This closes the P1 feedback gap from gate‑2 review**: further Phase‑5 edits to a pre-existing dirty path change the file's content hash, so the live fingerprint no longer matches the baseline and the guard fires as intended.
 
 **Why session-init rather than Phase‑5-open re-snapshot.** A baseline frozen at session init represents "state before the harness touched anything". Re-snapshotting at every Phase‑5 reopen would fold prior Phase‑5 leftovers into the baseline and mask real regressions. Session-init captures the user's genuine pre-existing dirt exactly once; everything introduced after that point is treated as Phase‑5 work and must be committed before Phase 6.
 
+**Rollout scope — new sessions only (P2 feedback).** Legacy `state.json` files written before this change do not contain `dirtyBaseline`. The `loadState` migration defaults the field to `[]`, which preserves the *strict* pre-fix behavior for those in-flight runs. We explicitly decline to lazy-capture a baseline for legacy states on first load, because by the time a legacy run reaches this code path, Phase 5 may have already introduced uncommitted work that would be incorrectly baked into the baseline and masked. Users stuck on an in-flight run hit by #67/#68 are expected to start a new session (`harness run`) with the fixed build. This narrowing is intentional, documented, and matches the review suggestion.
+
 **Scope boundaries.**
 - Only `state.trackedRepos[0]` (docsRoot) gets a baseline — this matches the current single-repo behavior of `runPhase6Preconditions`. Multi-repo baseline is out of scope.
-- Legacy states without `dirtyBaseline` (loaded from existing runs) default to `[]` via the state migration — current behavior preserved for in-flight runs.
-- The guard still fires for Phase‑5-introduced uncommitted changes: any porcelain line that is not in `dirtyBaseline` and not the eval report triggers the throw.
+- No content-matching for renames (porcelain `R` status) — renames are extremely unlikely in pre-existing session-start state; treated as opaque line-string for baseline parsing. If encountered, the safer `hash = ""` falls through and the fingerprint still works.
 - No change to the eval-report cleanup steps (Step 3 of preconditions).
+- No change to the staged-file guard (Step 1 of preconditions — see D5).
 
-**Ambiguity resolution.** No open questions remained after reviewing the two issues, the precondition implementation, and the Phase‑5 reopen semantics (`src/phases/interactive.ts` Phase‑5 block). All decisions above are fixed — no developer Q&A needed for this session.
+**Ambiguity resolution.** No open questions remain after reviewing the two issues, the precondition implementation, the Phase‑5 reopen semantics (`src/phases/interactive.ts` Phase‑5 block), and the gate-2 review feedback. All decisions are fixed — no developer Q&A needed for this session.
 
 ## Requirements / Scope
 
-R1. `runPhase6Preconditions` MUST filter out porcelain lines that exactly match a line recorded in `dirtyBaseline`, in addition to filtering the eval report.
-R2. The filter MUST apply to both the initial dirty check (Step 2) and the final clean check (Step 4).
-R3. `state.dirtyBaseline: string[]` MUST be captured once at session init in `src/commands/start.ts`, after `.gitignore` commits and before `createInitialState` is persisted, from the porcelain output of `trackedRepos[0].path`.
-R4. `state.dirtyBaseline` MUST default to `[]` when reading legacy state files (backward-compatible migration in `src/state.ts::loadState`).
+R1. `runPhase6Preconditions` MUST filter out porcelain lines whose **fingerprint** (`<XY>\0<path>\0<hash>`) matches an entry in `dirtyBaseline`, in addition to filtering the eval report. Filtering is fingerprint-exact — a path whose content hash has changed since baseline capture MUST NOT match and MUST fire the guard.
+R2. The fingerprint filter MUST apply to both the initial dirty check (Step 2) and the final clean check (Step 4).
+R3. `state.dirtyBaseline: string[]` MUST be captured once at session init in `src/commands/start.ts`, after `.gitignore` commits and before `createInitialState` is persisted, from the porcelain output of `trackedRepos[0].path`. Each dirty path contributes one fingerprint string. Non-git roots and git roots with clean trees produce `[]`.
+R4. `state.dirtyBaseline` MUST default to `[]` when reading legacy state files (backward-compatible migration in `src/state.ts::loadState`). Legacy in-flight runs retain strict pre-fix behavior by design (see Decision D4).
 R5. Existing tests (`tests/artifact.test.ts`, `tests/phases/verify.test.ts`) MUST keep passing — baseline defaults to `[]` when omitted, matching the current strict behavior.
 R6. New tests MUST cover:
-    - Pre-existing tracked-dirty file listed in baseline → no throw (issue #68 repro).
-    - Pre-existing untracked file listed in baseline → no throw (issue #68 repro).
-    - Pre-existing dirty file + a new Phase-5-introduced dirty file → still throws (regression guard).
+    - Pre-existing tracked-dirty file whose fingerprint is in baseline → no throw (issue #68 repro, tracked variant).
+    - Pre-existing untracked file whose fingerprint is in baseline → no throw (issue #68 repro, untracked variant).
+    - Pre-existing dirty file + an additional **Phase-5-introduced** dirty file → still throws (regression guard).
+    - **Pre-existing dirty file whose content is further modified after baseline capture** → still throws (fingerprint mismatch, closes P1 feedback gap).
     - Final clean check also respects baseline (baseline entries remain present after cleanup).
 R7. No change to the error message (`'Working tree must be clean before verification'`) — keeps existing string assertions in tests and logs.
 
@@ -45,34 +55,27 @@ R7. No change to the error message (`'Working tree must be clean before verifica
 ```ts
 export interface HarnessState {
   // ... existing fields ...
-  dirtyBaseline: string[]; // porcelain lines from trackedRepos[0] at session init
+  dirtyBaseline: string[]; // fingerprint strings captured at session init
 }
 ```
 
-`src/state.ts::createInitialState` returns `dirtyBaseline: []`. Callers set it immediately after construction if the repo has pre-existing dirty content. `loadState` migration:
+`src/state.ts::createInitialState` returns `dirtyBaseline: []`. `loadState` migration:
 
 ```ts
 if (!Array.isArray(raw.dirtyBaseline)) raw.dirtyBaseline = [];
 ```
 
+### Fingerprint helper
+
+A small helper — new exported function `captureDirtyBaseline(cwd: string): string[]` — lives in `src/artifact.ts` (next to `runPhase6Preconditions`, which is the only consumer). It runs `git status --porcelain`, parses each line into `{ xy, path }`, computes `git hash-object -- <path>` when the path exists on disk (safe-wrapped — missing file / `R` status fall through to `hash = ""`), and returns the fingerprint list `"<xy>\0<path>\0<hash>"`. Non-git cwd returns `[]`.
+
 ### Capture point in `src/commands/start.ts`
 
-After step 11 (HEAD re-read post-`.gitignore` commit) and immediately after `state.trackedRepos = trackedRepos;` in step 12, compute:
+After step 11 (HEAD re-read post-`.gitignore` commit) and immediately after `state.trackedRepos = trackedRepos;` in step 12, call:
 
 ```ts
-let dirtyBaseline: string[] = [];
-if (inGitRepo) {
-  try {
-    const out = execSync('git status --porcelain', {
-      cwd: trackedRepos[0].path, encoding: 'utf-8',
-    }).trim();
-    dirtyBaseline = out === '' ? [] : out.split('\n').filter(Boolean);
-  } catch { /* best-effort, leave empty */ }
-}
-state.dirtyBaseline = dirtyBaseline;
+state.dirtyBaseline = inGitRepo ? captureDirtyBaseline(trackedRepos[0].path) : [];
 ```
-
-Captured only for `inGitRepo === true`; non-git roots retain `[]` (current behavior — no guard to narrow anyway).
 
 ### Precondition filter in `src/artifact.ts::runPhase6Preconditions`
 
@@ -87,7 +90,7 @@ export function runPhase6Preconditions(
 ): void
 ```
 
-Convert `dirtyBaseline` to a `Set<string>` once. In Step 2 (`porcelainOutput`) and Step 4 (`finalStatus`), **before** the existing eval-report filter, drop any line whose exact string is a member of the baseline set. Remaining logic unchanged.
+Convert `dirtyBaseline` to a `Set<string>` once. In Step 2 (`porcelainOutput`) and Step 4 (`finalStatus`), **before** the existing eval-report filter, for each live porcelain line recompute the fingerprint (same parsing + `git hash-object`) and drop the line if its fingerprint is in the baseline set. Remaining logic unchanged.
 
 Caller in `src/phases/verify.ts::runVerifyPhase` passes `state.dirtyBaseline ?? []`.
 
@@ -95,21 +98,22 @@ Caller in `src/phases/verify.ts::runVerifyPhase` passes `state.dirtyBaseline ?? 
 
 - No per-repo baseline (trackedRepos[1+]).
 - No re-snapshot on reopen.
+- No lazy baseline capture for legacy in-flight runs (see D4).
 - No change to `hasStagedChanges` / `isWorkingTreeClean` used in `start.ts` preflight.
 - No change to the staged-file check in Step 1 of preconditions (still fires on any staged file other than the eval report — staged work is unambiguously Phase‑5 output the user forgot to commit, not "pre-existing dirt").
 
 ## Implementation Plan
 
 - **Task 1 — State schema + migration.** Add `dirtyBaseline: string[]` to `HarnessState` in `src/types.ts`. Default it to `[]` in `createInitialState` (`src/state.ts`). Add the one-line migration in `loadState` (`src/state.ts`).
-- **Task 2 — Capture baseline at session init.** In `src/commands/start.ts`, immediately after `state.trackedRepos = trackedRepos;` (step 12), compute porcelain snapshot from `trackedRepos[0].path` when `inGitRepo`, assign to `state.dirtyBaseline`. Keep `[]` in the non-git-repo branch.
-- **Task 3 — Filter precondition + wire caller + tests.** Extend `runPhase6Preconditions` with a `dirtyBaseline: string[] = []` parameter, filter Steps 2 and 4. Update `src/phases/verify.ts` to pass `state.dirtyBaseline ?? []`. Add four `tests/artifact.test.ts` cases covering R6. Update `tests/phases/verify.test.ts` if its `runPhase6Preconditions` mock signature needs adjusting (optional 4th arg — mock should still match).
+- **Task 2 — Fingerprint helper + session-init capture.** Add `captureDirtyBaseline(cwd)` in `src/artifact.ts`. In `src/commands/start.ts`, immediately after `state.trackedRepos = trackedRepos;` (step 12), assign `state.dirtyBaseline = inGitRepo ? captureDirtyBaseline(trackedRepos[0].path) : []`.
+- **Task 3 — Filter precondition + wire caller + tests.** Extend `runPhase6Preconditions` with a `dirtyBaseline: string[] = []` parameter, compute live fingerprints and filter Steps 2 and 4 before the eval-report filter. Update `src/phases/verify.ts` to pass `state.dirtyBaseline ?? []`. Add five `tests/artifact.test.ts` cases covering R6 (including the content-mismatch regression for P1 feedback). Update `tests/phases/verify.test.ts` only if its `runPhase6Preconditions` mock assertion needs adjusting for the optional 4th arg.
 
 ## Eval Checklist Summary
 
 Verification JSON lives at `.harness/2026-04-24-fix-phase-6-verify-213d/checklist.json`. It runs:
 
 1. `pnpm tsc --noEmit` — typecheck the state schema + new signature.
-2. `pnpm vitest run tests/artifact.test.ts` — unit coverage for `runPhase6Preconditions` including new baseline cases.
+2. `pnpm vitest run tests/artifact.test.ts` — unit coverage for `runPhase6Preconditions` including new baseline + content-mismatch cases.
 3. `pnpm vitest run tests/phases/verify.test.ts` — ensure `runVerifyPhase` caller still integrates cleanly.
 4. `pnpm vitest run` — full suite regression.
 5. `pnpm build` — ensure dist compiles (integration tests reference dist).

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import { existsSync, unlinkSync } from 'fs';
 import { join, isAbsolute } from 'path';
 import { getStagedFiles, getFileStatus, isStagedDeletion, isPathGitignored } from './git.js';
@@ -42,7 +42,7 @@ export function captureDirtyBaseline(cwd: string): string[] {
     const absPath = join(cwd, filePath);
     if (existsSync(absPath)) {
       try {
-        hash = execSync(`git hash-object -- "${filePath}"`, {
+        hash = execFileSync('git', ['hash-object', '--', filePath], {
           cwd,
           encoding: 'utf-8',
         }).trim();
@@ -134,7 +134,7 @@ function computeFingerprint(line: string, cwd: string): string {
   const resolvedPath = join(cwd, filePath);
   if (existsSync(resolvedPath)) {
     try {
-      hash = execSync(`git hash-object -- "${filePath}"`, {
+      hash = execFileSync('git', ['hash-object', '--', filePath], {
         cwd,
         encoding: 'utf-8',
       }).trim();
@@ -229,15 +229,16 @@ export function runPhase6Preconditions(
     const evalReportDeleted = isStagedDeletion(evalReportPath, cwd);
     const dirtyLines = finalPorcelainLines.filter((line) => {
       const linePath = line.slice(3);
-      // Filter eval report lines
-      if (linePath === evalReportPath && evalReportDeleted) return false;
+      // Filter parent-dir collapse entries for eval report
       if (linePath !== evalReportPath && evalReportPath.startsWith(linePath)) return false;
+      // Eval report itself: keep as dirty only if cleanup did NOT succeed
+      if (linePath === evalReportPath) return !evalReportDeleted;
       // Filter pre-existing baseline entries by fingerprint
       if (baselineSet.size > 0) {
         const fp = computeFingerprint(line, resolvedCwd);
         if (baselineSet.has(fp)) return false;
       }
-      return linePath !== evalReportPath;
+      return true;
     });
 
     if (dirtyLines.length > 0) {

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -5,8 +5,38 @@ import { getStagedFiles, getFileStatus, isStagedDeletion, isPathGitignored } fro
 import type { HarnessState } from './types.js';
 
 /**
+ * Parse NUL-delimited `git status --porcelain -z` output into `"XY path"` strings.
+ *
+ * Using -z prevents git from C-quoting paths that contain spaces or special
+ * characters; entries are NUL-terminated rather than newline-terminated, and
+ * paths are emitted verbatim. For rename/copy entries (R/C status) the second
+ * NUL-delimited token is the old (origin) path and is skipped — only the new
+ * working-tree path matters for fingerprinting.
+ */
+function parsePorcelainZ(raw: string): string[] {
+  const tokens = raw.split('\0');
+  const lines: string[] = [];
+  let skipNext = false;
+  for (const token of tokens) {
+    if (skipNext) {
+      skipNext = false;
+      continue;
+    }
+    // Status entries: at least 4 chars, position 2 is the space between XY and path.
+    if (token.length >= 4 && token[2] === ' ') {
+      lines.push(token);
+      // Rename/copy entries have a second NUL-delimited old-path token — skip it.
+      if (token[0] === 'R' || token[0] === 'C') {
+        skipNext = true;
+      }
+    }
+  }
+  return lines;
+}
+
+/**
  * Compute a content-hashed fingerprint for every dirty path reported by
- * `git status --porcelain --untracked-files=all` in the given directory.
+ * `git status --porcelain -z --untracked-files=all` in the given directory.
  *
  * Each fingerprint is the string `"<XY>\0<path>\0<hash>"` where:
  * - XY  : the 2-char porcelain status code (e.g. " M", "??", "A ")
@@ -14,6 +44,8 @@ import type { HarnessState } from './types.js';
  * - hash: `git hash-object -- <path>` of the working-tree file, or "" when
  *         the file is absent (deletion status) or hash-object fails
  *
+ * Using `-z` prevents git from C-quoting paths that contain spaces or special
+ * characters — entries are NUL-terminated and paths are emitted verbatim.
  * Using `--untracked-files=all` ensures that every untracked file is listed
  * individually instead of collapsed into a parent `?? dir/` entry, so each
  * fingerprint binds to exactly one hashable file path.
@@ -23,16 +55,14 @@ import type { HarnessState } from './types.js';
 export function captureDirtyBaseline(cwd: string): string[] {
   let rawOutput: string;
   try {
-    rawOutput = execSync('git status --porcelain --untracked-files=all', {
+    rawOutput = execSync('git status --porcelain -z --untracked-files=all', {
       cwd,
       encoding: 'utf-8',
     });
   } catch {
     return [];
   }
-  // Split by newline and filter empty lines — do NOT .trim() the full output,
-  // as that would strip the leading space from ' M' lines and corrupt XY parsing.
-  const lines = rawOutput.split('\n').filter(Boolean);
+  const lines = parsePorcelainZ(rawOutput);
   if (lines.length === 0) return [];
 
   return lines.map((line) => {
@@ -109,18 +139,17 @@ export function normalizeArtifactCommit(filePath: string, message: string, cwd?:
 }
 
 /**
- * Read `git status --porcelain --untracked-files=all` and return individual
- * lines without trimming the full output (which would strip the leading space
- * from ' M' lines and corrupt XY parsing).
+ * Read `git status --porcelain -z --untracked-files=all` and return parsed
+ * `"XY path"` strings. Using -z ensures paths with spaces are never C-quoted.
  *
  * Errors from git (e.g. not in a git repo) propagate to the caller.
  */
 function readPorcelainLines(cwd?: string): string[] {
-  const raw = execSync('git status --porcelain --untracked-files=all', {
+  const raw = execSync('git status --porcelain -z --untracked-files=all', {
     cwd,
     encoding: 'utf-8',
   });
-  return raw.split('\n').filter(Boolean);
+  return parsePorcelainZ(raw);
 }
 
 /**

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -5,6 +5,56 @@ import { getStagedFiles, getFileStatus, isStagedDeletion, isPathGitignored } fro
 import type { HarnessState } from './types.js';
 
 /**
+ * Compute a content-hashed fingerprint for every dirty path reported by
+ * `git status --porcelain --untracked-files=all` in the given directory.
+ *
+ * Each fingerprint is the string `"<XY>\0<path>\0<hash>"` where:
+ * - XY  : the 2-char porcelain status code (e.g. " M", "??", "A ")
+ * - path: the file path from column 4 of the porcelain line
+ * - hash: `git hash-object -- <path>` of the working-tree file, or "" when
+ *         the file is absent (deletion status) or hash-object fails
+ *
+ * Using `--untracked-files=all` ensures that every untracked file is listed
+ * individually instead of collapsed into a parent `?? dir/` entry, so each
+ * fingerprint binds to exactly one hashable file path.
+ *
+ * Returns [] when cwd is not a git repo or the tree is clean.
+ */
+export function captureDirtyBaseline(cwd: string): string[] {
+  let rawOutput: string;
+  try {
+    rawOutput = execSync('git status --porcelain --untracked-files=all', {
+      cwd,
+      encoding: 'utf-8',
+    });
+  } catch {
+    return [];
+  }
+  // Split by newline and filter empty lines — do NOT .trim() the full output,
+  // as that would strip the leading space from ' M' lines and corrupt XY parsing.
+  const lines = rawOutput.split('\n').filter(Boolean);
+  if (lines.length === 0) return [];
+
+  return lines.map((line) => {
+    const xy = line.slice(0, 2);
+    const filePath = line.slice(3);
+    let hash = '';
+    const absPath = join(cwd, filePath);
+    if (existsSync(absPath)) {
+      try {
+        hash = execSync(`git hash-object -- "${filePath}"`, {
+          cwd,
+          encoding: 'utf-8',
+        }).trim();
+      } catch {
+        hash = '';
+      }
+    }
+    return `${xy}\0${filePath}\0${hash}`;
+  });
+}
+
+/**
  * Resolve a (potentially relative) artifact path to an absolute path.
  * Uses trackedRepos[0].path as the doc root (falling back to outerCwd).
  */
@@ -59,13 +109,60 @@ export function normalizeArtifactCommit(filePath: string, message: string, cwd?:
 }
 
 /**
+ * Read `git status --porcelain --untracked-files=all` and return individual
+ * lines without trimming the full output (which would strip the leading space
+ * from ' M' lines and corrupt XY parsing).
+ *
+ * Errors from git (e.g. not in a git repo) propagate to the caller.
+ */
+function readPorcelainLines(cwd?: string): string[] {
+  const raw = execSync('git status --porcelain --untracked-files=all', {
+    cwd,
+    encoding: 'utf-8',
+  });
+  return raw.split('\n').filter(Boolean);
+}
+
+/**
+ * Compute a live fingerprint for a single porcelain line using the same format
+ * as captureDirtyBaseline: `"<XY>\0<path>\0<hash>"`.
+ */
+function computeFingerprint(line: string, cwd: string): string {
+  const xy = line.slice(0, 2);
+  const filePath = line.slice(3);
+  let hash = '';
+  const resolvedPath = join(cwd, filePath);
+  if (existsSync(resolvedPath)) {
+    try {
+      hash = execSync(`git hash-object -- "${filePath}"`, {
+        cwd,
+        encoding: 'utf-8',
+      }).trim();
+    } catch {
+      hash = '';
+    }
+  }
+  return `${xy}\0${filePath}\0${hash}`;
+}
+
+/**
  * Run Phase 6 preconditions in order:
  * 1. Check tree clean (excluding eval report) — abort if other files dirty
  * 2. Clean up eval report (untracked→rm, staged-new→restore+rm, tracked→git rm)
  * 3. Final clean-tree verification
+ *
+ * Pre-existing dirty files captured in dirtyBaseline (at session init) are
+ * filtered out by fingerprint before the cleanliness check — this allows runs
+ * on mission branches with uncommitted content (issues #67, #68).
  */
-export function runPhase6Preconditions(evalReportPath: string, runId: string, cwd?: string): void {
+export function runPhase6Preconditions(
+  evalReportPath: string,
+  runId: string,
+  cwd?: string,
+  dirtyBaseline: string[] = [],
+): void {
   const resolvedCwd = cwd ?? process.cwd();
+  const baselineSet = new Set(dirtyBaseline);
 
   // Step 1: Staged guard — if any file OTHER than eval report is staged → throw
   const stagedFiles = getStagedFiles(cwd);
@@ -74,23 +171,23 @@ export function runPhase6Preconditions(evalReportPath: string, runId: string, cw
     throw new Error('Working tree must be clean before verification');
   }
 
-  // Step 2: Unstaged/untracked guard — filter out eval report path, check others
-  const porcelainOutput = exec('git status --porcelain', cwd);
-  if (porcelainOutput !== '') {
-    const dirtyLines = porcelainOutput
-      .split('\n')
-      .filter(Boolean)
-      .filter((line) => {
-        // Path starts at index 3 in porcelain format (XY followed by space)
-        const linePath = line.slice(3);
-        // A line represents the eval report if it exactly matches the eval report path,
-        // or if it is a parent directory of the eval report (e.g. "?? docs/" covers
-        // "docs/reports/my-run-eval.md" when the dir is untracked).
-        return (
-          linePath !== evalReportPath &&
-          !evalReportPath.startsWith(linePath)
-        );
-      });
+  // Step 2: Unstaged/untracked guard — filter out eval report and baseline entries
+  const porcelainLines = readPorcelainLines(cwd);
+  if (porcelainLines.length > 0) {
+    const dirtyLines = porcelainLines.filter((line) => {
+      // Path starts at index 3 in porcelain format (XY followed by space)
+      const linePath = line.slice(3);
+      // Filter out the eval report (exact match or parent-dir collapse)
+      if (linePath === evalReportPath || evalReportPath.startsWith(linePath)) {
+        return false;
+      }
+      // Filter out pre-existing baseline entries by fingerprint
+      if (baselineSet.size > 0) {
+        const fp = computeFingerprint(line, resolvedCwd);
+        if (baselineSet.has(fp)) return false;
+      }
+      return true;
+    });
 
     if (dirtyLines.length > 0) {
       throw new Error('Working tree must be clean before verification');
@@ -126,20 +223,22 @@ export function runPhase6Preconditions(evalReportPath: string, runId: string, cw
     exec(`git rm -f "${evalReportPath}"`, cwd);
   }
 
-  // Step 4: Final clean check
-  const finalStatus = exec('git status --porcelain', cwd);
-  if (finalStatus !== '') {
+  // Step 4: Final clean check — baseline entries may still appear (they were not cleaned up)
+  const finalPorcelainLines = readPorcelainLines(cwd);
+  if (finalPorcelainLines.length > 0) {
     const evalReportDeleted = isStagedDeletion(evalReportPath, cwd);
-    const dirtyLines = finalStatus
-      .split('\n')
-      .filter(Boolean)
-      .filter((line) => {
-        const linePath = line.slice(3);
-        if (linePath !== evalReportPath && !evalReportPath.startsWith(linePath)) {
-          return true;
-        }
-        return linePath === evalReportPath && !evalReportDeleted;
-      });
+    const dirtyLines = finalPorcelainLines.filter((line) => {
+      const linePath = line.slice(3);
+      // Filter eval report lines
+      if (linePath === evalReportPath && evalReportDeleted) return false;
+      if (linePath !== evalReportPath && evalReportPath.startsWith(linePath)) return false;
+      // Filter pre-existing baseline entries by fingerprint
+      if (baselineSet.size > 0) {
+        const fp = computeFingerprint(line, resolvedCwd);
+        if (baselineSet.has(fp)) return false;
+      }
+      return linePath !== evalReportPath;
+    });
 
     if (dirtyLines.length > 0) {
       throw new Error('Working tree is not clean after eval report cleanup');

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -247,8 +247,11 @@ export async function startCommand(task: string | undefined, options: StartOptio
     // Inject detected tracked repos (overrides the placeholder set by createInitialState)
     state.trackedRepos = trackedRepos;
 
-    // Capture pre-existing dirty-file fingerprints for Phase 6 baseline filtering
-    state.dirtyBaseline = inGitRepo ? captureDirtyBaseline(trackedRepos[0].path) : [];
+    // Capture pre-existing dirty-file fingerprints for Phase 6 baseline filtering.
+    // Always use trackedRepos[0].path (the docs-home git repo), not the outer cwd —
+    // in the depth-1 multi-repo mode the outer cwd may not be a git repo itself.
+    // captureDirtyBaseline() returns [] when called on a non-git path.
+    state.dirtyBaseline = captureDirtyBaseline(trackedRepos[0].path);
 
     if (options.codexNoIsolate) {
       // BUG-C risk surface: user explicitly bypassed isolation.

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -8,6 +8,7 @@ import { runPreflight } from '../preflight.js';
 import { findHarnessRoot, setCurrentRun } from '../root.js';
 import { cleanupOrphans } from '../orphan-cleanup.js';
 import { createInitialState, writeState } from '../state.js';
+import { captureDirtyBaseline } from '../artifact.js';
 import { isInsideTmux, getCurrentSessionName, getActiveWindowId, createSession, createWindow, sendKeys, killSession, selectWindow, getDefaultPaneId } from '../tmux.js';
 import { openTerminalWindow } from '../terminal.js';
 import { HANDOFF_TIMEOUT_MS } from '../config.js';
@@ -245,6 +246,9 @@ export async function startCommand(task: string | undefined, options: StartOptio
 
     // Inject detected tracked repos (overrides the placeholder set by createInitialState)
     state.trackedRepos = trackedRepos;
+
+    // Capture pre-existing dirty-file fingerprints for Phase 6 baseline filtering
+    state.dirtyBaseline = inGitRepo ? captureDirtyBaseline(trackedRepos[0].path) : [];
 
     if (options.codexNoIsolate) {
       // BUG-C risk surface: user explicitly bypassed isolation.

--- a/src/phases/verify.ts
+++ b/src/phases/verify.ts
@@ -95,7 +95,7 @@ export async function runVerifyPhase(
 
   // Step 2: Run preconditions while phase is still pending
   const docsRoot = state.trackedRepos?.[0]?.path || cwd;
-  runPhase6Preconditions(state.artifacts.evalReport, state.runId, docsRoot);
+  runPhase6Preconditions(state.artifacts.evalReport, state.runId, docsRoot, state.dirtyBaseline ?? []);
 
   // Step 3: Resolve verify script path BEFORE advancing phase state.
   // If the script is missing, fail fast while the phase is still pending —

--- a/src/state.ts
+++ b/src/state.ts
@@ -156,6 +156,7 @@ export function migrateState(raw: any, cwd?: string): HarnessState {
       raw.phaseClaudeSessions[key] = null;
     }
   }
+  if (!Array.isArray(raw.dirtyBaseline)) raw.dirtyBaseline = [];
   if (!('carryoverFeedback' in raw) || raw.carryoverFeedback === undefined) {
     raw.carryoverFeedback = null;
   }
@@ -322,5 +323,6 @@ export function createInitialState(
     loggingEnabled,
     phaseReopenSource: { '1': null, '3': null, '5': null },
     codexNoIsolate,
+    dirtyBaseline: [],
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,10 @@ export interface HarnessState {
   // codex-phase spawn runs inside <runDir>/codex-home/ with only auth.json
   // symlinked in. Persisted so that `harness resume` honors the decision.
   codexNoIsolate: boolean;
+  // Content-hashed dirty-file fingerprints captured once at session init.
+  // Phase 6 subtracts these from the porcelain output before evaluating cleanliness,
+  // so pre-existing uncommitted files do not block verification (issues #67, #68).
+  dirtyBaseline: string[];
 }
 
 export interface LockData {

--- a/tests/artifact.test.ts
+++ b/tests/artifact.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { execSync } from 'child_process';
 import { createTestRepo } from './helpers/test-repo.js';
-import { normalizeArtifactCommit, runPhase6Preconditions, commitEvalReport } from '../src/artifact.js';
+import { normalizeArtifactCommit, runPhase6Preconditions, commitEvalReport, captureDirtyBaseline } from '../src/artifact.js';
 import { createInitialState } from '../src/state.js';
 
 // Helper: get current HEAD SHA
@@ -259,6 +259,122 @@ describe('runPhase6Preconditions', () => {
     } finally {
       rmSync(outer, { recursive: true, force: true });
     }
+  });
+});
+
+describe('runPhase6Preconditions — dirty baseline filtering (issues #67/#68)', () => {
+  let repo: { path: string; cleanup: () => void };
+  const evalReportPath = 'docs/reports/my-run-eval.md';
+
+  beforeEach(() => {
+    repo = createTestRepo();
+  });
+
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  it('R6: pre-existing tracked-dirty file in baseline → no throw (issue #68 tracked variant)', () => {
+    // Create and commit a tracked file, then modify it (tracked-dirty)
+    writeFileSync(join(repo.path, 'tracked-dirty.txt'), 'original');
+    execSync('git add tracked-dirty.txt && git commit -m "add file"', { cwd: repo.path });
+    writeFileSync(join(repo.path, 'tracked-dirty.txt'), 'modified by user before harness');
+
+    // Capture baseline — contains the " M tracked-dirty.txt" fingerprint
+    const baseline = captureDirtyBaseline(repo.path);
+    expect(baseline.length).toBeGreaterThan(0);
+
+    // Must not throw — the dirty file is pre-existing (in baseline)
+    expect(() =>
+      runPhase6Preconditions(evalReportPath, 'my-run', repo.path, baseline)
+    ).not.toThrow();
+  });
+
+  it('R6: pre-existing untracked file in baseline → no throw (issue #68 untracked variant)', () => {
+    // An untracked file present before the harness session
+    writeFileSync(join(repo.path, 'preexisting-untracked.txt'), 'noise');
+
+    // Capture baseline
+    const baseline = captureDirtyBaseline(repo.path);
+    expect(baseline.length).toBeGreaterThan(0);
+
+    // Must not throw — the untracked file is in the baseline
+    expect(() =>
+      runPhase6Preconditions(evalReportPath, 'my-run', repo.path, baseline)
+    ).not.toThrow();
+  });
+
+  it('R6: pre-existing dirty file + Phase-5-introduced dirty file → still throws', () => {
+    // Create a pre-existing untracked file
+    writeFileSync(join(repo.path, 'preexisting.txt'), 'old content');
+
+    // Capture baseline (only contains preexisting.txt)
+    const baseline = captureDirtyBaseline(repo.path);
+    expect(baseline.length).toBeGreaterThan(0);
+
+    // Phase 5 introduces a NEW untracked file — not in baseline
+    writeFileSync(join(repo.path, 'phase5-new.txt'), 'uncommitted phase-5 work');
+
+    // Must throw — phase5-new.txt is not in baseline
+    expect(() =>
+      runPhase6Preconditions(evalReportPath, 'my-run', repo.path, baseline)
+    ).toThrow('Working tree must be clean before verification');
+  });
+
+  it('R6: pre-existing dirty file whose content changes after baseline → still throws', () => {
+    // Create a tracked file and modify it (pre-existing dirt)
+    writeFileSync(join(repo.path, 'shared.txt'), 'original');
+    execSync('git add shared.txt && git commit -m "add file"', { cwd: repo.path });
+    writeFileSync(join(repo.path, 'shared.txt'), 'pre-existing modification');
+
+    // Capture baseline — baseline fingerprint has content hash of "pre-existing modification"
+    const baseline = captureDirtyBaseline(repo.path);
+    expect(baseline.length).toBeGreaterThan(0);
+
+    // Phase 5 further modifies the same file — content hash changes
+    writeFileSync(join(repo.path, 'shared.txt'), 'phase-5 further edit');
+
+    // Must throw — the live fingerprint no longer matches baseline
+    expect(() =>
+      runPhase6Preconditions(evalReportPath, 'my-run', repo.path, baseline)
+    ).toThrow('Working tree must be clean before verification');
+  });
+
+  it('R6: pre-existing untracked directory + Phase-5 adds new file inside → still throws', () => {
+    // Create an existing untracked file inside a directory
+    mkdirSync(join(repo.path, 'pre-dir'), { recursive: true });
+    writeFileSync(join(repo.path, 'pre-dir/existing.txt'), 'pre-existing file');
+
+    // Capture baseline — with -uall, baseline has "pre-dir/existing.txt" fingerprint
+    const baseline = captureDirtyBaseline(repo.path);
+    expect(baseline.some((fp) => fp.includes('pre-dir/existing.txt'))).toBe(true);
+
+    // Phase 5 adds a NEW file inside the same directory
+    writeFileSync(join(repo.path, 'pre-dir/new-from-phase5.txt'), 'phase-5 addition');
+
+    // Must throw — pre-dir/new-from-phase5.txt is not in baseline
+    expect(() =>
+      runPhase6Preconditions(evalReportPath, 'my-run', repo.path, baseline)
+    ).toThrow('Working tree must be clean before verification');
+  });
+
+  it('R6: final clean check respects baseline (baseline entries remain after eval report cleanup)', () => {
+    // Pre-existing untracked file
+    writeFileSync(join(repo.path, 'preexisting.txt'), 'noise');
+
+    // Capture baseline
+    const baseline = captureDirtyBaseline(repo.path);
+
+    // Also create an untracked eval report that will be cleaned up
+    writeRepoFile(repo.path, evalReportPath, '# Eval Report');
+
+    // Must not throw — eval report is cleaned, preexisting.txt is in baseline
+    expect(() =>
+      runPhase6Preconditions(evalReportPath, 'my-run', repo.path, baseline)
+    ).not.toThrow();
+
+    // preexisting.txt still exists (baseline filtering, not cleanup)
+    expect(existsSync(join(repo.path, 'preexisting.txt'))).toBe(true);
   });
 });
 

--- a/tests/artifact.test.ts
+++ b/tests/artifact.test.ts
@@ -358,6 +358,25 @@ describe('runPhase6Preconditions — dirty baseline filtering (issues #67/#68)',
     ).toThrow('Working tree must be clean before verification');
   });
 
+  it('R7: filename with spaces is fingerprinted correctly (porcelain -z fix)', () => {
+    // On porcelain v1 (without -z), filenames with spaces are C-quoted:
+    // `?? "my file.txt"` — line.slice(3) yields `"my file.txt"` (with quotes), so
+    // existsSync fails and the hash falls back to "", making the fingerprint wrong.
+    // Fix: use --porcelain -z so paths are NUL-delimited and never C-quoted.
+    writeFileSync(join(repo.path, 'my spaced file.txt'), 'content');
+
+    const baseline = captureDirtyBaseline(repo.path);
+    const fp = baseline.find((f) => f.includes('my spaced file.txt'));
+    expect(fp).toBeDefined();
+    // The hash must be non-empty — confirms existsSync succeeded on the real (unquoted) path
+    expect(fp!.split('\0')[2]).not.toBe('');
+
+    // File is in baseline → preconditions must not throw
+    expect(() =>
+      runPhase6Preconditions(evalReportPath, 'my-run', repo.path, baseline)
+    ).not.toThrow();
+  });
+
   it('R6: final clean check respects baseline (baseline entries remain after eval report cleanup)', () => {
     // Pre-existing untracked file
     writeFileSync(join(repo.path, 'preexisting.txt'), 'noise');

--- a/tests/commands/inner-footer.test.ts
+++ b/tests/commands/inner-footer.test.ts
@@ -146,6 +146,7 @@ function makeHarnessState(runId: string): HarnessState {
     tmuxControlPane: '',
     loggingEnabled: true,
     codexNoIsolate: false,
+    dirtyBaseline: [],
   };
 }
 

--- a/tests/commands/inner.test.ts
+++ b/tests/commands/inner.test.ts
@@ -311,6 +311,7 @@ describe('bootstrapSessionLogger', () => {
       tmuxControlWindow: '', tmuxWorkspacePane: '', tmuxControlPane: '',
       loggingEnabled: true,
       codexNoIsolate: false,
+      dirtyBaseline: [],
     };
     return { ...base, ...overrides };
   }
@@ -395,6 +396,7 @@ describe('buildConfigCancelHandler — lazy bootstrap', () => {
       tmuxControlWindow: '', tmuxWorkspacePane: '', tmuxControlPane: '',
       loggingEnabled: true,
       codexNoIsolate: false,
+      dirtyBaseline: [],
     };
     return { ...base, ...overrides };
   }
@@ -597,6 +599,7 @@ describe('bootstrapSessionLogger — codexHome integration (Issue #13)', () => {
       tmuxControlWindow: '', tmuxWorkspacePane: '', tmuxControlPane: '',
       loggingEnabled: true,
       codexNoIsolate: false,
+      dirtyBaseline: [],
     };
     return { ...base, ...overrides };
   }

--- a/tests/commands/run.test.ts
+++ b/tests/commands/run.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { execSync } from 'child_process';
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
+import { tmpdir } from 'os';
 import { createTestRepo } from '../helpers/test-repo.js';
 import { startCommand } from '../../src/commands/start.js';
 
@@ -218,4 +219,68 @@ describe('startCommand', () => {
     expect(stderr).not.toMatch(/CODEX_HOME isolation disabled/i);
   });
 
+});
+
+describe('startCommand — non-git outer cwd, dirtyBaseline wiring (R3)', () => {
+  // Regression for: state.dirtyBaseline was always [] when outer cwd was not a git repo,
+  // because capture was gated on inGitRepo(outerCwd). In depth-1 multi-repo mode the outer
+  // directory is not git-backed; fix always calls captureDirtyBaseline(trackedRepos[0].path).
+  let outer: string;
+  let innerRepo: string;
+  let origCwd: string;
+  let exitSpy: any;
+  let stderrSpy: any;
+
+  beforeEach(() => {
+    outer = mkdtempSync(join(tmpdir(), 'nongit-outer-'));
+    innerRepo = join(outer, 'inner-repo');
+    mkdirSync(innerRepo, { recursive: true });
+    execSync('git init', { cwd: innerRepo, stdio: 'pipe' });
+    execSync('git config user.email "t@t.com"', { cwd: innerRepo, stdio: 'pipe' });
+    execSync('git config user.name "T"', { cwd: innerRepo, stdio: 'pipe' });
+    writeFileSync(join(innerRepo, 'init.txt'), 'x');
+    execSync('git add . && git commit -m "init"', { cwd: innerRepo, stdio: 'pipe' });
+
+    origCwd = process.cwd();
+    process.chdir(outer);
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__exit__:${code}`);
+    }) as never);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.chdir(origCwd);
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+    rmSync(outer, { recursive: true, force: true });
+  });
+
+  it('persists non-empty dirtyBaseline from inner git repo when outer cwd is not git (R3)', async () => {
+    // Pre-existing dirty file in the tracked (inner) git repo
+    writeFileSync(join(innerRepo, 'pre-existing.txt'), 'user content before harness');
+
+    // outer is not a git repo; inner-repo is auto-detected at depth 1
+    await startCommand('test', { root: outer });
+
+    const harnessDir = join(outer, '.harness');
+    const runId = readFileSync(join(harnessDir, 'current-run'), 'utf-8').trim();
+    const state = JSON.parse(readFileSync(join(harnessDir, runId, 'state.json'), 'utf-8'));
+
+    // Must be populated from innerRepo — not [] from outer non-git cwd check
+    expect(Array.isArray(state.dirtyBaseline)).toBe(true);
+    expect(state.dirtyBaseline.length).toBeGreaterThan(0);
+    expect(state.dirtyBaseline.some((fp: string) => fp.includes('pre-existing.txt'))).toBe(true);
+  });
+
+  it('persists empty dirtyBaseline when inner git repo is clean', async () => {
+    // No dirty files — inner repo is clean after init commit
+    await startCommand('test', { root: outer });
+
+    const harnessDir = join(outer, '.harness');
+    const runId = readFileSync(join(harnessDir, 'current-run'), 'utf-8').trim();
+    const state = JSON.parse(readFileSync(join(harnessDir, runId, 'state.json'), 'utf-8'));
+
+    expect(state.dirtyBaseline).toEqual([]);
+  });
 });

--- a/tests/commands/start.test.ts
+++ b/tests/commands/start.test.ts
@@ -4,6 +4,7 @@ import os from 'os';
 import path from 'path';
 import { execSync } from 'child_process';
 import { detectTrackedRepos } from '../../src/commands/start.js';
+import { captureDirtyBaseline, runPhase6Preconditions } from '../../src/artifact.js';
 
 const tmpDirs: string[] = [];
 afterEach(() => {
@@ -27,6 +28,41 @@ function initGitRepo(dir: string): string {
   execSync('git commit -m "init"', { cwd: dir, stdio: 'pipe' });
   return execSync('git rev-parse HEAD', { cwd: dir, encoding: 'utf-8' }).trim();
 }
+
+describe('session-init dirtyBaseline wiring — non-git outer cwd (R3)', () => {
+  // Regression for the bug where `state.dirtyBaseline` was always [] when the
+  // outer cwd was not a git repo, even though trackedRepos[0].path is git-backed.
+  // Fix: always call captureDirtyBaseline(trackedRepos[0].path) without the
+  // inGitRepo(outerCwd) guard.
+  it('baseline captures dirty files from git-backed inner repo when outer cwd is not git', () => {
+    const outer = makeTmp();
+    const innerRepo = path.join(outer, 'docs-repo');
+    initGitRepo(innerRepo);
+
+    // Pre-existing dirty file in the inner (docs-home) repo
+    fs.writeFileSync(path.join(innerRepo, 'pre-existing.txt'), 'user content');
+
+    // The fix: captureDirtyBaseline is called with trackedRepos[0].path (innerRepo),
+    // not with the outer non-git cwd.
+    const baseline = captureDirtyBaseline(innerRepo);
+    expect(baseline.length).toBeGreaterThan(0);
+    expect(baseline.some((fp) => fp.includes('pre-existing.txt'))).toBe(true);
+
+    // With the baseline, Phase 6 preconditions must not throw for the pre-existing file.
+    expect(() =>
+      runPhase6Preconditions('eval.md', 'run-id', innerRepo, baseline)
+    ).not.toThrow();
+  });
+
+  it('baseline is empty when trackedRepos[0].path is clean', () => {
+    const outer = makeTmp();
+    const innerRepo = path.join(outer, 'docs-repo');
+    initGitRepo(innerRepo); // clean after init commit
+
+    const baseline = captureDirtyBaseline(innerRepo);
+    expect(baseline).toEqual([]);
+  });
+});
 
 describe('detectTrackedRepos — auto-detect depth=1 (ADR-N2)', () => {
   it('returns [cwd] single-entry when cwd is a git repo', () => {

--- a/tests/commands/start.test.ts
+++ b/tests/commands/start.test.ts
@@ -4,7 +4,6 @@ import os from 'os';
 import path from 'path';
 import { execSync } from 'child_process';
 import { detectTrackedRepos } from '../../src/commands/start.js';
-import { captureDirtyBaseline, runPhase6Preconditions } from '../../src/artifact.js';
 
 const tmpDirs: string[] = [];
 afterEach(() => {
@@ -28,41 +27,6 @@ function initGitRepo(dir: string): string {
   execSync('git commit -m "init"', { cwd: dir, stdio: 'pipe' });
   return execSync('git rev-parse HEAD', { cwd: dir, encoding: 'utf-8' }).trim();
 }
-
-describe('session-init dirtyBaseline wiring — non-git outer cwd (R3)', () => {
-  // Regression for the bug where `state.dirtyBaseline` was always [] when the
-  // outer cwd was not a git repo, even though trackedRepos[0].path is git-backed.
-  // Fix: always call captureDirtyBaseline(trackedRepos[0].path) without the
-  // inGitRepo(outerCwd) guard.
-  it('baseline captures dirty files from git-backed inner repo when outer cwd is not git', () => {
-    const outer = makeTmp();
-    const innerRepo = path.join(outer, 'docs-repo');
-    initGitRepo(innerRepo);
-
-    // Pre-existing dirty file in the inner (docs-home) repo
-    fs.writeFileSync(path.join(innerRepo, 'pre-existing.txt'), 'user content');
-
-    // The fix: captureDirtyBaseline is called with trackedRepos[0].path (innerRepo),
-    // not with the outer non-git cwd.
-    const baseline = captureDirtyBaseline(innerRepo);
-    expect(baseline.length).toBeGreaterThan(0);
-    expect(baseline.some((fp) => fp.includes('pre-existing.txt'))).toBe(true);
-
-    // With the baseline, Phase 6 preconditions must not throw for the pre-existing file.
-    expect(() =>
-      runPhase6Preconditions('eval.md', 'run-id', innerRepo, baseline)
-    ).not.toThrow();
-  });
-
-  it('baseline is empty when trackedRepos[0].path is clean', () => {
-    const outer = makeTmp();
-    const innerRepo = path.join(outer, 'docs-repo');
-    initGitRepo(innerRepo); // clean after init commit
-
-    const baseline = captureDirtyBaseline(innerRepo);
-    expect(baseline).toEqual([]);
-  });
-});
 
 describe('detectTrackedRepos — auto-detect depth=1 (ADR-N2)', () => {
   it('returns [cwd] single-entry when cwd is a git repo', () => {

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -201,7 +201,8 @@ describe('generateRunId', () => {
     spy.mockReturnValueOnce(Buffer.from([0xaa, 0xaa]))
        .mockReturnValueOnce(Buffer.from([0xbb, 0xbb]));
 
-    const datePrefix = new Date().toISOString().slice(0, 10);
+    const now = new Date();
+    const datePrefix = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
     // Pre-create the first candidate directory to force a redraw
     mkdirSync(join(harnessDir, `${datePrefix}-my-task-aaaa`));
 
@@ -215,7 +216,8 @@ describe('generateRunId', () => {
     const spy = vi.spyOn(crypto, 'randomBytes') as any;
     spy.mockReturnValue(Buffer.from([0xca, 0xfe]));
 
-    const datePrefix = new Date().toISOString().slice(0, 10);
+    const now = new Date();
+    const datePrefix = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
     // Pre-create the randomized candidate to exhaust all 6 draw attempts
     mkdirSync(join(harnessDir, `${datePrefix}-my-task-cafe`));
 

--- a/tests/integration/logging.test.ts
+++ b/tests/integration/logging.test.ts
@@ -35,6 +35,7 @@ function buildState(overrides: Partial<HarnessState> = {}): HarnessState {
     tmuxControlWindow: '', tmuxWorkspacePane: '', tmuxControlPane: '',
     loggingEnabled: true,
     codexNoIsolate: false,
+    dirtyBaseline: [],
   };
   return { ...base, ...overrides };
 }

--- a/tests/phases/gate-resume.test.ts
+++ b/tests/phases/gate-resume.test.ts
@@ -46,6 +46,7 @@ function makeState(): HarnessState {
     loggingEnabled: false,
     phaseReopenSource: { '1': null, '3': null, '5': null },
     codexNoIsolate: false,
+    dirtyBaseline: [],
   };
 }
 

--- a/tests/phases/terminal-ui.test.ts
+++ b/tests/phases/terminal-ui.test.ts
@@ -60,6 +60,7 @@ function makeState(overrides: Partial<HarnessState> = {}): HarnessState {
     loggingEnabled: false,
     phaseReopenSource: { '1': null, '3': null, '5': null },
     codexNoIsolate: false,
+    dirtyBaseline: [],
     ...overrides,
   };
 }

--- a/tests/phases/verify.test.ts
+++ b/tests/phases/verify.test.ts
@@ -248,7 +248,7 @@ describe('runVerifyPhase — docsRoot (FR-3/6)', () => {
       // expected — resolveVerifyScriptPath returns null → throws after preconditions
     }
 
-    expect(mockPreconditions).toHaveBeenCalledWith('eval.md', 'test-run', docsRootDir);
+    expect(mockPreconditions).toHaveBeenCalledWith('eval.md', 'test-run', docsRootDir, []);
   });
 
   it('falls back to outer cwd when trackedRepos is empty or path is empty', async () => {
@@ -273,6 +273,6 @@ describe('runVerifyPhase — docsRoot (FR-3/6)', () => {
       // expected
     }
 
-    expect(mockPreconditions).toHaveBeenCalledWith('eval.md', 'test-run', outerCwd);
+    expect(mockPreconditions).toHaveBeenCalledWith('eval.md', 'test-run', outerCwd, []);
   });
 });

--- a/tests/state-invalidation.test.ts
+++ b/tests/state-invalidation.test.ts
@@ -38,6 +38,7 @@ function makeState(): HarnessState {
     loggingEnabled: false,
     phaseReopenSource: { '1': null, '3': null, '5': null },
     codexNoIsolate: false,
+    dirtyBaseline: [],
   };
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `runPhase6Preconditions` rejected working trees with pre-existing uncommitted content (issues #67, #68), blocking harness runs on mission branches.
- **Fix**: Capture content-hashed fingerprints of all dirty files at session init (`state.dirtyBaseline: string[]`) and subtract them from the porcelain cleanliness check in Phase 6.
- **Key details**:
  - Fingerprint format: `"<XY>\0<path>\0<hash>"` — content-hashed so Phase-5 edits to pre-existing files are still caught
  - Uses `git status --porcelain -z --untracked-files=all` in both baseline capture and live check to avoid C-quoting of paths with spaces
  - `execFileSync` (not shell string interpolation) for `git hash-object` to prevent command injection
  - Baseline captured from `trackedRepos[0].path`, not the outer cwd, so depth-1 multi-repo mode works correctly
  - `dirtyBaseline: []` default in `migrateState()` preserves strict pre-fix behavior for in-flight runs

## Changed files

| File | Change |
|---|---|
| `src/types.ts` | Add `dirtyBaseline: string[]` to `HarnessState` |
| `src/state.ts` | Initialize + migrate `dirtyBaseline` |
| `src/artifact.ts` | `captureDirtyBaseline`, `parsePorcelainZ`, `readPorcelainLines`, updated `runPhase6Preconditions` |
| `src/commands/start.ts` | Capture baseline at session init from `trackedRepos[0].path` |
| `src/phases/verify.ts` | Pass `state.dirtyBaseline` to `runPhase6Preconditions` |
| `tests/artifact.test.ts` | 7 new baseline-filtering tests (R6/R7) |
| `tests/commands/run.test.ts` | `startCommand`-level regression for non-git outer cwd (R3) |
| `tests/git.test.ts` | Fix date-sensitive collision tests to use local date |

## Test plan

- [ ] `pnpm tsc --noEmit` — passes clean
- [ ] `pnpm vitest run` — 65 files, 953 passed / 1 skipped
- [ ] `pnpm build` — clean