### PR TITLE
chore(release): bump to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phase-harness",
-  "version": "0.3.3",
+  "version": "1.0.0",
   "description": "AI agent harness orchestrator — multi-phase brainstorm/spec/plan/implement/verify lifecycle with gate reviews",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Bump `phase-harness` from `0.3.3` → `1.0.0`.

## Test plan

- [ ] `pnpm install` picks up new version
- [ ] `phase-harness --version` prints `1.0.0` after publish