### PR TITLE
fix(ink): pass process.stdin instead of undefined to Ink render

### DIFF
--- a/src/ink/render.ts
+++ b/src/ink/render.ts
@@ -45,7 +45,7 @@ export function renderInkControlPanel(
   if (!mounted) {
     process.stdout.write('\x1b[2J\x1b[H');
     inkInstance = render(React.createElement(App), {
-      stdin: undefined,
+      stdin: process.stdin,
       exitOnCtrlC: false,
       patchConsole: false,
     });


### PR DESCRIPTION
## Summary

- `stdin: undefined`을 Ink `render()`에 넘기면 기본값 `process.stdin`이 덮어써져 Ink 내부 `App.js`에서 `undefined.isTTY` 접근 시 크래시 발생
- `stdin: process.stdin`으로 교체하여 수정
- App 컴포넌트 트리에 `useInput`을 사용하는 곳이 없으므로 Ink가 stdin 이벤트를 소비하지 않아 InputManager와 충돌 없음

## Test plan

- [x] `pnpm lint` — typecheck 통과
- [x] `pnpm vitest run` — 1006/1007 통과 (1 skipped, 0 failed)
- [x] `pnpm build` — dist 빌드 성공