### PR TITLE
Stabilize gate retries and interactive sentinel paths

### DIFF
--- a/docs/plans/2026-04-24-gate-escalation-forensics.md
+++ b/docs/plans/2026-04-24-gate-escalation-forensics.md
@@ -1,0 +1,100 @@
+# Gate Escalation Forensics for Issue #66
+
+Use this checklist before enabling any fresh-session fallback for Codex gate reviewers after a developer chooses **Continue (C)** at the gate retry limit.
+
+## Purpose
+
+A repeated reject after a C-boundary can come from two different causes:
+
+1. **Reviewer anchoring** — the resumed Codex session repeats prior critique even though current artifacts changed enough to resolve it.
+2. **Artifact non-compliance** — the current spec/plan/eval still contains the cited flaw, so the reviewer is correctly rejecting.
+
+The first patch for #66 intentionally keeps normal session reuse and injects an escalation reset notice. Only use the fresh-session fallback when the evidence below points to reviewer anchoring.
+
+## Evidence Inputs
+
+Collect these files from the run directory:
+
+- `gate-<phase>-cycle-<n>-retry-<r>-feedback.md` for the rejected pre-C cycle.
+- `gate-<phase>-feedback.md` or the post-C `gate-<phase>-cycle-<n+1>-retry-<r>-feedback.md` for the reset-notice cycle.
+- The exact gate artifacts used by the prompt:
+  - Gate 2: `spec`.
+  - Gate 4: `spec` + `plan`.
+  - Gate 7 full: `spec` + `plan` + `eval_report` + diff/metadata prompt sections.
+  - Gate 7 light: combined `spec` + `eval_report` + diff/metadata prompt sections.
+- Isolated Codex transcripts/logs under the run's `codex-home` or session logging directory when available.
+
+## Normalized Reject-Feedback Hash
+
+Hash the reviewer comments after normalization. The goal is to detect semantically identical feedback while ignoring run noise.
+
+Remove or normalize:
+
+- Timestamps and datestamps.
+- Retry and cycle numbers.
+- Absolute temporary paths, home-directory paths, and run IDs.
+- Whitespace-only differences.
+- Markdown code-fence wrapper noise that does not change the enclosed finding.
+
+Retain:
+
+- Severity labels (`P0`, `P1`, `P2`, `P3`).
+- `Location`, `Issue`, `Suggestion`, and `Evidence` bodies.
+- Cited identifiers, helper names, endpoint names, file names, and assertions.
+- Summary text when it carries a rejection reason.
+
+## Artifact Hash Comparison
+
+Compute content hashes for the exact artifacts supplied to the relevant gate prompt before and after the C-boundary cycle.
+
+- If the artifact hash did **not** change, repeated feedback is not evidence of anchoring.
+- If the artifact hash changed, inspect whether the changed region addresses the cited finding.
+- For Gate 7, include the rendered diff/metadata section or record the implementation commit range used to produce it.
+
+## Cited-Identifier Absence Check
+
+Extract concrete identifiers from the prior rejection and search current artifacts for them.
+
+For the original #66 report, check for:
+
+- `mintToken()`
+- `mockVerificationService.getVerificationClaims.mockResolvedValueOnce`
+- Any future code-like token called out by `Location`, `Issue`, `Suggestion`, or `Evidence`.
+
+Decision rule:
+
+- Identifiers still present in the same rejected role/path usually indicate artifact non-compliance.
+- Identifiers absent or materially replaced, combined with unchanged reject-feedback hash, supports anchoring.
+
+## Transcript Anchoring Scan
+
+Inspect the resumed Codex transcript for memory-presupposition phrases and evidence of stale reasoning.
+
+Flag phrases such as:
+
+- `as I noted earlier`
+- `again`
+- `previously`
+- `still`
+- `already pointed out`
+- `this remains`
+
+Then compare whether the reasoning quotes current artifact content verbatim or recycles prior wording without current-artifact evidence.
+
+## Fresh-Session Fallback Trigger
+
+Implement the C-boundary fresh-session fallback only when **all** conditions are true after the reset-notice patch is in place:
+
+1. The post-banner C-boundary retry produces the same normalized reject-feedback hash as the pre-C rejection.
+2. The relevant artifact hash changed across the C boundary.
+3. The prior rejection's concrete cited identifiers are absent or materially replaced in the current artifacts.
+4. Transcript scan indicates prior-context anchoring rather than fresh artifact analysis.
+
+When the trigger is met, clear only the affected gate at the C boundary:
+
+```ts
+state.phaseCodexSessions[key] = null;
+deleteGateSidecars(runDir, phase);
+```
+
+Do not clear sessions for normal reject retries; session reuse remains intentional there for cost, latency, and delta-review continuity.

--- a/src/context/assembler.ts
+++ b/src/context/assembler.ts
@@ -563,8 +563,13 @@ export function assembleInteractivePrompt(
 ): string {
   const phaseAttemptId = state.phaseAttemptId[String(phase)] ?? '';
 
-  // Phase 1 uses task.md file path (not raw task string) per spec
-  const taskMdPath = path.join('.harness', state.runId, 'task.md');
+  // Prompt-visible run artifacts must point at the same runDir watched by
+  // the harness. Use path.resolve so even a relative --root cannot render
+  // cwd-relative `.harness/<runId>/...` instructions (issue #75).
+  const promptRunDir = path.resolve(harnessDir, state.runId);
+  // Phase 1 uses task.md file path (not raw task string) per spec.
+  const taskMdPath = path.join(promptRunDir, 'task.md');
+  const sentinelPath = path.join(promptRunDir, `phase-${phase}.done`);
 
   // Merge pendingAction.feedbackPaths with carryoverFeedback.paths when the
   // carryover targets this phase. Carryover paths are dropped with a warning
@@ -633,6 +638,7 @@ export function assembleInteractivePrompt(
     phaseAttemptId,
     feedback_path: feedbackPath,
     feedback_paths: feedbackPathsList.length > 0 ? feedbackPathsList : undefined,
+    sentinel_path: sentinelPath,
     harnessDir,
     playbookDir,
     complexity_directive: complexityDirective,
@@ -724,6 +730,25 @@ function buildResumeSections(
   return body;
 }
 
+function buildEscalationResetNotice(
+  phase: 2 | 4 | 7,
+  state: HarnessState,
+): string {
+  const phaseKey = String(phase) as '2' | '4' | '7';
+  const cycle = state.gateEscalationCycles?.[phaseKey] ?? 0;
+  if (cycle <= 0) return '';
+
+  return [
+    '## Escalation Cycle Reset Notice',
+    '',
+    `Escalation cycle ${cycle}: the developer chose Continue after the gate retry limit. ` +
+      'Prior feedback is reference only, not an anchor. ' +
+      'Re-read the current artifacts from scratch; ' +
+      'approve if the current artifacts now satisfy the gate contract, and reject only for issues still present in the current artifacts.',
+    '',
+  ].join('\n');
+}
+
 export function assembleGateResumePrompt(
   phase: 2 | 4 | 7,
   state: HarnessState,
@@ -755,6 +780,7 @@ export function assembleGateResumePrompt(
       ? previousFeedback
       : '(feedback file missing despite lastOutcome=reject — spec anomaly)';
     prompt =
+      buildEscalationResetNotice(phase, state) +
       '## Updated Artifacts (Re-Review Requested)\n\n' +
       'The artifacts have been updated based on your previous feedback. Re-review the new versions and verify your prior concerns were addressed.\n\n' +
       sections +

--- a/src/context/prompts/phase-1-light.md
+++ b/src/context/prompts/phase-1-light.md
@@ -38,7 +38,7 @@ Eval Checklist는 "{{checklist_path}}" 경로에 아래 JSON 스키마로 저장
 
 각 check command는 격리된 셸 환경에서 실행된다. venv/node_modules 등 의존성을 요구하는 검증은 절대경로 바이너리(`.venv/bin/python -m pytest`, `./node_modules/.bin/eslint`)나 env-aware 래퍼(`make test`, `pnpm test`)를 사용하라.
 
-작업을 모두 마친 뒤 `.harness/{{runId}}/phase-1.done` 파일을 생성하되 내용으로 '{{phaseAttemptId}}' 한 줄만 기록하라.
+작업을 모두 마친 뒤 `{{sentinel_path}}` 파일을 생성하되 내용으로 '{{phaseAttemptId}}' 한 줄만 기록하라.
 
 **CRITICAL: sentinel 파일(phase-1.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 이후 하네스는 다음 단계(impl)로 넘어가므로 추가 작업을 하지 말 것.**
 

--- a/src/context/prompts/phase-5-light.md
+++ b/src/context/prompts/phase-5-light.md
@@ -10,7 +10,7 @@
 
 각 태스크 완료 시 반드시 변경사항을 git commit하라. commit 없이 세션을 종료하면 eval gate에서 변경분을 볼 수 없어 run이 실패한다.
 
-구현 완료 후 `.harness/{{runId}}/phase-5.done` 파일을 생성하되 내용으로 '{{phaseAttemptId}}' 한 줄만 기록하라.
+구현 완료 후 `{{sentinel_path}}` 파일을 생성하되 내용으로 '{{phaseAttemptId}}' 한 줄만 기록하라.
 
 **CRITICAL: sentinel 파일(phase-5.done)은 모든 작업(파일 작성, git commit 포함)이 완료된 후 가장 마지막에 생성하라. sentinel 생성 이후 하네스는 다음 단계(리뷰/피드백)로 넘어가므로 추가 작업을 하지 말 것.**
 

--- a/src/context/skills/harness-phase-1-spec.md
+++ b/src/context/skills/harness-phase-1-spec.md
@@ -36,7 +36,7 @@ description: Use during phase-harness Phase 1 to brainstorm and write a spec tha
    - `"After spec is written, proceed immediately to step 2 (decisions log) below"`
 2. Decision log를 `{{decisions_path}}`에 작성한다. spec의 "Context & Decisions" 섹션과 **중복되지 않도록** 각 결정의 *trade-off*와 *고려된 대안*을 기록한다.
 3. **Pre-sentinel self-audit** — sentinel 쓰기 직전, 방금 작성한 spec을 다시 읽고 spec의 `## Success Criteria` / `## Invariants` 섹션과 대조한다. grep 또는 정규식 스캔 규칙이 적혀 있으면 모두 직접 확인하고, hit이 있으면 gate로 넘기지 말고 이번 pass에서 바로 수정한다. 각 gate round는 대략 40× local grep 비용이므로 여기서 먼저 정리한다. 수정이 있었다면 한 번 더 같은 검증을 반복(rerun)하고 clean 상태를 확인한 뒤에만 sentinel 단계로 이동한다.
-4. **가장 마지막에** `.harness/{{runId}}/phase-1.done`을 생성하고 내용으로 `{{phaseAttemptId}}` 한 줄만 기록한다.
+4. **가장 마지막에** `{{sentinel_path}}`을 생성하고 내용으로 `{{phaseAttemptId}}` 한 줄만 기록한다.
 
 ## Invariants
 - sentinel 파일 생성 이후 하네스가 다음 단계로 넘어간다. 추가 작업 금지.

--- a/src/context/skills/harness-phase-3-plan.md
+++ b/src/context/skills/harness-phase-3-plan.md
@@ -49,7 +49,7 @@ Phase 4에서 Codex가 다음 축으로 평가한다:
    - 각 `command`는 **격리된 셸 환경에서 실행**된다. 절대경로 바이너리(`.venv/bin/pytest`) 또는 env-aware 래퍼(`make test`)를 사용할 것. 글로벌 PATH에만 있는 도구는 피함 (qa-observations #4 대응).
    - UI/시각적 변경이 있는 태스크가 있다면 스크린샷/시각 검증 항목을 적어도 한 건 추가.
 3. **Pre-sentinel self-audit** — sentinel 쓰기 직전, 방금 작성한 plan을 다시 읽고 spec의 `## Success Criteria` / `## Invariants` 섹션과 대조한다. eval checklist도 함께 읽어 spec의 grep-rule / 정규식 규칙이 빠짐없이 들어갔는지 확인한다. hit이 있으면 gate로 넘기지 말고 이번 pass에서 바로 수정한다. 각 gate round는 대략 40× local grep 비용이므로 여기서 먼저 정리한다. 수정이 있었다면 한 번 더 같은 검증을 반복(rerun)하고 clean 상태를 확인한 뒤에만 sentinel 단계로 이동한다.
-4. **가장 마지막에** `.harness/{{runId}}/phase-3.done`을 생성하고 `{{phaseAttemptId}}` 한 줄만 기록.
+4. **가장 마지막에** `{{sentinel_path}}`을 생성하고 `{{phaseAttemptId}}` 한 줄만 기록.
 
 ## Invariants
 - sentinel 이후 추가 작업 금지.

--- a/src/context/skills/harness-phase-5-implement.md
+++ b/src/context/skills/harness-phase-5-implement.md
@@ -38,7 +38,7 @@ superpowers가 커버하지 않는 두 원칙을 지킨다:
 ## Process
 0. **(Scaffolding only — prevention-first gitignore)** 구현을 시작하기 전에 대상 언어·프레임워크의 표준 `.gitignore` 엔트리(예: `__pycache__/`, `.pytest_cache/`, `.venv/`, `node_modules/`, `dist/`, `build/`, `.DS_Store`)를 프로젝트 루트 `.gitignore`에 보강한다. 기존 `.gitignore`가 이미 해당 엔트리를 포함하면 no-op. 이 변경은 `chore: add standard gitignore entries` 등 **독립된 scaffolding commit**으로 두고, impl 커밋과 섞지 않는다. Sentinel 직전에 `git status --porcelain`을 셀프 체크해 tracked 파일이 전부 커밋된 상태인지 확인한다. 하네스에 자동 recovery가 있어도 이 단계는 효율성과 로그 가독성 측면에서 값어치가 있다.
 1. 기본 sub-skill로 `superpowers:subagent-driven-development`를 invoke한다. 단일 세션 구현이 plan에서 적합하다고 판단되면 `superpowers:executing-plans`를 대안으로 쓸 수 있다. 어느 경우든 다음 오버라이드를 전달한다:
-   - `"Do NOT create .harness/{{runId}}/phase-5.done until ALL tasks in the plan are committed."`
+   - `"Do NOT create {{sentinel_path}} until ALL tasks in the plan are committed."`
    - `"If Content Filter rejects a subagent dispatch, fall back to direct in-session implementation and record the fallback in the task note."`
 2. 구현 중 위 Auxiliary playbooks의 원칙(원자적 커밋, 수직 슬라이스, 컨텍스트 prune)을 적용한다.
 3. **Pre-sentinel self-audit** — sentinel 쓰기 직전, 이번 phase의 commits 합집합을 다시 확인한다.
@@ -47,7 +47,7 @@ superpowers가 커버하지 않는 두 원칙을 지킨다:
    - 검증 원천은 두 가지다. (a) spec의 `## Success Criteria` / `## Invariants` 섹션에 적힌 grep/정규식 규칙은 직접 실행한다. (b) plan의 eval checklist `checks[].command`는 inspect-only로 다루고 실행하지 않는다. 대신 해당 command들이 spec의 grep/regex 규칙을 빠짐없이 커버하는지만 정적으로 검토한다.
    - hit이 구현 수정으로 해결 가능하면 이번 pass에서 바로 수정하고, 수정이 있었다면 한 번 더 같은 검증을 반복(rerun)한 뒤 clean 상태를 확인하고 넘어간다. 각 gate round는 대략 40× local grep 비용이므로 gate로 넘기기 전에 여기서 정리한다.
    - hit이 구현 수정만으로 해결 불가하면 **plan 문서 하단 `## Deferred` 섹션**에 `spec-bug: <detail>` 또는 `plan-bug: <detail>`를 append하고 `plan: append deferred item` 커밋으로 escalation한다. 해당 plan 문서에 `## Deferred` 섹션이 없으면 파일 끝에 새로 헤딩을 만든 뒤 append한다. 이 escalation 경로는 feedback 블록과 독립적이며 첫 패스에서도 동일하게 적용된다. 해결 불가 항목은 reviewer가 참고할 signal이지만 자동 완화는 없다.
-4. 모든 태스크 구현 + 커밋 완료 후 **가장 마지막에** `.harness/{{runId}}/phase-5.done`을 생성하고 `{{phaseAttemptId}}` 한 줄만 기록.
+4. 모든 태스크 구현 + 커밋 완료 후 **가장 마지막에** `{{sentinel_path}}`을 생성하고 `{{phaseAttemptId}}` 한 줄만 기록.
 
 ## Invariants
 - sentinel 이전에 모든 변경사항이 **git에 커밋**되어야 한다. Phase 7 eval은 diff 기반이므로 uncommitted 변경은 보이지 않음.

--- a/tests/context/assembler-resume.test.ts
+++ b/tests/context/assembler-resume.test.ts
@@ -168,3 +168,20 @@ describe('buildResumeSections — Phase 7 flow-aware (ADR-12)', () => {
     expect(prompt).toContain('<plan>\n');
   });
 });
+
+
+describe('assembleGateResumePrompt — escalation reset notice', () => {
+  it('subordinates prior feedback after an escalation Continue cycle', () => {
+    const cwd = 'tests/context/fixtures';
+    const state = makeState({ gateEscalationCycles: { '4': 1 } });
+    const res = assembleGateResumePrompt(4, state, cwd, 'reject', 'P1: old concern', '/tmp/harness/r1');
+
+    expect(typeof res).toBe('string');
+    if (typeof res === 'string') {
+      expect(res).toContain('Escalation cycle 1');
+      expect(res).toContain('reference only, not an anchor');
+      expect(res).toContain('Re-read the current artifacts from scratch');
+      expect(res).toContain('P1: old concern');
+    }
+  });
+});

--- a/tests/context/assembler.test.ts
+++ b/tests/context/assembler.test.ts
@@ -107,16 +107,17 @@ function makeFullEvalState(overrides: Partial<HarnessState> = {}): HarnessState 
 // ─── Interactive Phase Tests ───────────────────────────────────────────────
 
 describe('Phase 1 interactive prompt', () => {
-  it('includes task.md path from runId dir and phaseAttemptId sentinel instruction', () => {
+  it('includes absolute task.md and sentinel paths from runDir plus phaseAttemptId', () => {
     const state = makeState({
       phaseAttemptId: { '1': 'uuid-phase-1-attempt', '3': null, '5': null },
     });
-    const prompt = assembleInteractivePrompt(1, state, '/tmp/harness');
+    const harnessDir = '/tmp/harness';
+    const prompt = assembleInteractivePrompt(1, state, harnessDir);
 
-    // Phase 1 injects .harness/<runId>/task.md, not the raw task string
-    expect(prompt).toContain('.harness/my-run/task.md');
+    // Phase 1 injects the runDir task.md path, not the raw task string.
+    expect(prompt).toContain(path.join(harnessDir, 'my-run', 'task.md'));
+    expect(prompt).toContain(path.join(harnessDir, 'my-run', 'phase-1.done'));
     expect(prompt).toContain('uuid-phase-1-attempt');
-    expect(prompt).toContain('phase-1.done');
   });
 
   it('includes feedback path when pendingAction has feedbackPaths', () => {
@@ -346,6 +347,51 @@ describe('Gate size limits', () => {
 
     expect(typeof result).toBe('object');
     expect((result as { error: string }).error).toMatch(/Gate input too large/);
+  });
+});
+
+
+describe('assembleInteractivePrompt — absolute runDir paths', () => {
+  it('uses harnessDir/runId task and sentinel paths when harnessDir differs from cwd/.harness', () => {
+    const outer = makeTmpDir();
+    const cwd = path.join(outer, 'child-workspace');
+    const harnessDir = path.join(outer, '.harness');
+    fs.mkdirSync(cwd, { recursive: true });
+
+    const phases: Array<{ phase: 1 | 3 | 5; flow?: 'full' | 'light'; attempt: string }> = [
+      { phase: 1, flow: 'full', attempt: 'attempt-p1-full' },
+      { phase: 1, flow: 'light', attempt: 'attempt-p1-light' },
+      { phase: 3, flow: 'full', attempt: 'attempt-p3-full' },
+      { phase: 5, flow: 'full', attempt: 'attempt-p5-full' },
+      { phase: 5, flow: 'light', attempt: 'attempt-p5-light' },
+    ];
+
+    for (const { phase, flow, attempt } of phases) {
+      const state = makeState({
+        flow: flow ?? 'full',
+        phaseAttemptId: { '1': null, '3': null, '5': null, [String(phase)]: attempt },
+      });
+      const prompt = assembleInteractivePrompt(phase, state, harnessDir, cwd);
+      const expectedRunDir = path.join(harnessDir, state.runId);
+
+      if (phase === 1) {
+        expect(prompt).toContain(path.join(expectedRunDir, 'task.md'));
+      }
+      expect(prompt).toContain(path.join(expectedRunDir, `phase-${phase}.done`));
+      expect(prompt).not.toContain('`.harness/my-run/phase-');
+    }
+  });
+
+  it('normalizes relative harnessDir to absolute prompt paths', () => {
+    const state = makeState({
+      phaseAttemptId: { '1': 'attempt-relative-root', '3': null, '5': null },
+    });
+    const prompt = assembleInteractivePrompt(1, state, 'relative-root/.harness', process.cwd());
+    const expectedRunDir = path.resolve('relative-root/.harness', state.runId);
+
+    expect(prompt).toContain(path.join(expectedRunDir, 'task.md'));
+    expect(prompt).toContain(path.join(expectedRunDir, 'phase-1.done'));
+    expect(prompt).not.toContain('`relative-root/.harness');
   });
 });
 

--- a/tests/context/skills-rendering.test.ts
+++ b/tests/context/skills-rendering.test.ts
@@ -119,7 +119,7 @@ describe('wrapper contract invariants — literal (per spec §4/§5)', () => {
     expect(prompt).toContain('/abs/spec-out.md');
     expect(prompt).toContain('/abs/decisions-out.md');
     // sentinel literal path + run-scoped
-    expect(prompt).toMatch(/\.harness\/rid-1\/phase-1\.done/);
+    expect(prompt).toContain(path.join('/tmp/harness', 'rid-1', 'phase-1.done'));
     // "sentinel 생성 후 추가 작업 금지" invariant literal
     expect(prompt).toMatch(/sentinel.*추가 작업 금지/);
     // Context & Decisions section requirement surfaced
@@ -134,7 +134,7 @@ describe('wrapper contract invariants — literal (per spec §4/§5)', () => {
     const prompt = assembleInteractivePrompt(3, state, '/tmp/harness');
     expect(prompt).toContain('/abs/plan-out.md');
     expect(prompt).toContain('/abs/checklist-out.json');
-    expect(prompt).toMatch(/\.harness\/rid-3\/phase-3\.done/);
+    expect(prompt).toContain(path.join('/tmp/harness', 'rid-3', 'phase-3.done'));
     // checklist schema literal (checks / name / command keys)
     expect(prompt).toMatch(/"checks"\s*:/);
     expect(prompt).toMatch(/"name"/);
@@ -147,7 +147,7 @@ describe('wrapper contract invariants — literal (per spec §4/§5)', () => {
     const state = stubState(tmp);
     state.runId = 'rid-5';
     const prompt = assembleInteractivePrompt(5, state, '/tmp/harness');
-    expect(prompt).toMatch(/\.harness\/rid-5\/phase-5\.done/);
+    expect(prompt).toContain(path.join('/tmp/harness', 'rid-5', 'phase-5.done'));
     // D3: standalone git-commit override removed — harness auto-commits
     expect(prompt).not.toMatch(/After each task completes, git commit/);
     // Pre-sentinel self-audit (step 3) still present

--- a/tests/phases/gate-resume-escalation.test.ts
+++ b/tests/phases/gate-resume-escalation.test.ts
@@ -131,3 +131,38 @@ describe('resume gate escalation replay', () => {
     expect(resumedArchive).not.toContain('# Gate 2 Feedback\n\n## Reviewer Comments\n\n# Gate 2 Feedback');
   });
 });
+
+describe('gate escalation Continue policy', () => {
+  it('increments escalation cycle but preserves the affected Codex session for reset-notice resume', async () => {
+    const runDir = makeTmpDir('gate-continue-');
+    const state = makeState({
+      currentPhase: 4,
+      gateRetries: { '2': 0, '4': GATE_RETRY_LIMIT, '7': 0 },
+    });
+    state.phaseCodexSessions['4'] = {
+      sessionId: 'reviewer-session-4',
+      runner: 'codex',
+      model: 'gpt-5.5',
+      effort: 'high',
+      lastOutcome: 'reject',
+    };
+
+    vi.mocked(promptChoice).mockResolvedValueOnce('C');
+    await handleGateEscalation(
+      4,
+      'P1: continue with a reset notice, not a fresh session yet',
+      undefined,
+      2,
+      state,
+      runDir,
+      runDir,
+      createNoOpInputManager(),
+      new NoopLogger(),
+    );
+
+    expect(state.gateEscalationCycles?.['4']).toBe(1);
+    expect(state.phaseCodexSessions['4']?.sessionId).toBe('reviewer-session-4');
+    expect(state.pendingAction?.type).toBe('reopen_phase');
+    expect(state.gateRetries['4']).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Render interactive Phase 1/3/5 task and sentinel paths from the resolved runDir so non-git/upward-scan launches do not deadlock on mismatched .harness locations.
- Add an escalation-cycle reset notice to Codex gate resume prompts after retry-limit Continue while preserving normal session reuse.
- Add a gate escalation forensic playbook defining when a future fresh-session fallback is justified.
- Confirm #68 remains covered by existing dirty-baseline tests; no #68 code changes were needed.

## Issues
- Addresses #75
- Mitigates #66 with reset notice + forensic fallback criteria
- Validates #68 as already resolved on current code

## Verification
- pnpm exec vitest run tests/context/assembler.test.ts tests/context/assembler-resume.test.ts tests/context/skills-rendering.test.ts tests/phases/gate-resume-escalation.test.ts
- pnpm exec vitest run tests/artifact.test.ts tests/commands/run.test.ts
- pnpm exec tsc --noEmit
- pnpm run build
- pnpm test
- git diff --check

## Risk / Notes
- #66 does not yet clear gate Codex sessions by design. Fresh-session fallback should only be added if the trigger documented in docs/plans/2026-04-24-gate-escalation-forensics.md is met.