### PR TITLE
Fix interactive phase sentinel stalls

### DIFF
--- a/src/ink/components/ActionMenu.tsx
+++ b/src/ink/components/ActionMenu.tsx
@@ -8,12 +8,37 @@ interface Props {
   callsite: RenderCallsite | undefined;
 }
 
-export function ActionMenu({ state: _state, callsite }: Props): React.ReactElement {
+export function ActionMenu({ state, callsite }: Props): React.ReactElement {
   const prominent = callsite === 'terminal-failed';
   if (!prominent) {
+    if (callsite === 'terminal-complete' || state.status === 'completed') {
+      return (
+        <Box>
+          <Text dimColor>  Run complete — press Ctrl+C to exit</Text>
+        </Box>
+      );
+    }
+
+    const phaseStatus = state.phases[String(state.currentPhase)];
+    if (phaseStatus === 'in_progress') {
+      return (
+        <Box>
+          <Text dimColor>  Running — waiting for phase completion</Text>
+        </Box>
+      );
+    }
+
+    if (phaseStatus === 'failed' || phaseStatus === 'error') {
+      return (
+        <Box>
+          <Text dimColor>  Phase stopped — terminal actions will appear below</Text>
+        </Box>
+      );
+    }
+
     return (
       <Box>
-        <Text dimColor>  [R] Resume  [J] Jump  [Q] Quit</Text>
+        <Text dimColor>  Starting phase…</Text>
       </Box>
     );
   }

--- a/src/phases/interactive.ts
+++ b/src/phases/interactive.ts
@@ -315,6 +315,7 @@ export async function waitForPhaseCompletion(
   return new Promise<InteractiveResult>((resolve) => {
     let settled = false;
     let watcher: ReturnType<typeof chokidar.watch> | null = null;
+    let sentinelPollInterval: ReturnType<typeof setInterval> | null = null;
     let pidPollInterval: ReturnType<typeof setInterval> | null = null;
     let interruptPollInterval: ReturnType<typeof setInterval> | null = null;
     let nullPidTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -325,6 +326,10 @@ export async function waitForPhaseCompletion(
       if (watcher) {
         void watcher.close();
         watcher = null;
+      }
+      if (sentinelPollInterval !== null) {
+        clearInterval(sentinelPollInterval);
+        sentinelPollInterval = null;
       }
       if (pidPollInterval !== null) {
         clearInterval(pidPollInterval);
@@ -362,6 +367,12 @@ export async function waitForPhaseCompletion(
 
     watcher.on('add', onSentinelDetected);
     watcher.on('change', onSentinelDetected);
+
+    // Backstop for watcher misses. In tmux-based interactive phases Claude
+    // normally stays alive after writing phase-N.done, so PID death is not a
+    // completion signal. Polling the sentinel path keeps the harness advancing
+    // even if a chokidar event is missed or delayed for a newly-created file.
+    sentinelPollInterval = setInterval(onSentinelDetected, 500);
 
     // PID death polling (1s): when Claude exits, check sentinel one last time
     if (claudePid !== null) {

--- a/tests/ink/components/ActionMenu.test.tsx
+++ b/tests/ink/components/ActionMenu.test.tsx
@@ -10,11 +10,16 @@ function makeState(overrides: Partial<HarnessState> = {}): HarnessState {
 }
 
 describe('ActionMenu', () => {
-  it('shows hint form at non-terminal callsite', () => {
-    const { lastFrame } = render(<ActionMenu state={makeState()} callsite="loop-top" />);
-    expect(lastFrame()).toContain('[R]');
-    expect(lastFrame()).toContain('[J]');
-    expect(lastFrame()).toContain('[Q]');
+  it('does not advertise R/J/Q while the phase loop is running', () => {
+    const state = makeState({ currentPhase: 1 });
+    state.phases['1'] = 'in_progress';
+
+    const { lastFrame } = render(<ActionMenu state={state} callsite="loop-top" />);
+
+    expect(lastFrame()).toContain('Running');
+    expect(lastFrame()).not.toContain('[R]');
+    expect(lastFrame()).not.toContain('[J]');
+    expect(lastFrame()).not.toContain('[Q]');
   });
 
   it('shows prominent form at terminal-failed callsite', () => {
@@ -24,16 +29,18 @@ describe('ActionMenu', () => {
     expect(lastFrame()).toContain('[Q]');
   });
 
-  it('shows hint form (not prominent) at terminal-complete callsite', () => {
+  it('shows Ctrl+C guidance at terminal-complete callsite', () => {
     const { lastFrame } = render(<ActionMenu state={makeState()} callsite="terminal-complete" />);
-    expect(lastFrame()).toContain('[R]');
+    expect(lastFrame()).toContain('Ctrl+C');
+    expect(lastFrame()).not.toContain('[R]');
   });
 
-  it('shows hint form when a phase has failed but callsite is not terminal-failed', () => {
-    const state = makeState();
+  it('does not show R/J/Q when a phase has failed but the terminal key handler is not active yet', () => {
+    const state = makeState({ currentPhase: 3 });
     state.phases['3'] = 'failed';
     const { lastFrame } = render(<ActionMenu state={state} callsite="gate-approve" />);
-    expect(lastFrame()).toContain('[R]');
+    expect(lastFrame()).toContain('Phase stopped');
+    expect(lastFrame()).not.toContain('[R]');
   });
 
   it('renders without crashing at narrow width', () => {

--- a/tests/phases/interactive-sentinel-poll.test.ts
+++ b/tests/phases/interactive-sentinel-poll.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+vi.mock('chokidar', () => ({
+  default: {
+    watch: vi.fn(() => ({
+      on: vi.fn().mockReturnThis(),
+      close: vi.fn(async () => undefined),
+    })),
+  },
+}));
+
+vi.mock('../../src/process.js', () => ({
+  isPidAlive: vi.fn(() => true),
+}));
+
+import { waitForPhaseCompletion } from '../../src/phases/interactive.js';
+import { createInitialState } from '../../src/state.js';
+
+const tmpDirs: string[] = [];
+
+function makeTmpDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+  tmpDirs.length = 0;
+});
+
+describe('waitForPhaseCompletion — sentinel polling fallback', () => {
+  it('completes from a fresh sentinel while the Claude PID is still alive even if fs watcher events are missed', async () => {
+    const cwd = makeTmpDir('sentinel-poll-cwd-');
+    const runDir = makeTmpDir('sentinel-poll-run-');
+    const state = createInitialState('run', 'task', 'base', false);
+
+    const specPath = path.join(cwd, state.artifacts.spec);
+    const decisionPath = path.join(cwd, state.artifacts.decisionLog);
+    fs.mkdirSync(path.dirname(specPath), { recursive: true });
+    fs.mkdirSync(path.dirname(decisionPath), { recursive: true });
+    fs.writeFileSync(specPath, '# Spec\n\n## Complexity\n\nMedium\n');
+    fs.writeFileSync(decisionPath, '# Decisions\n');
+
+    const attemptId = 'attempt-fresh';
+    const sentinelPath = path.join(runDir, 'phase-1.done');
+    const resultPromise = waitForPhaseCompletion(sentinelPath, attemptId, 4242, 1, state, cwd, runDir);
+
+    let settled = false;
+    resultPromise.then(() => { settled = true; });
+
+    fs.writeFileSync(sentinelPath, `${attemptId}\n`);
+    await vi.advanceTimersByTimeAsync(600);
+    await Promise.resolve();
+
+    expect(settled).toBe(true);
+    await expect(resultPromise).resolves.toEqual({ status: 'completed' });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a sentinel polling backstop so interactive phases complete when `phase-N.done` is fresh even if file watcher events are missed and Claude is still alive.
- Stop showing `[R]/[J]/[Q]` in the Ink action menu while the phase loop is still running; show those controls only in the failed terminal UI.
- Add regression coverage for the watcher-miss + live-PID sentinel completion path and update ActionMenu expectations.

Fixes #76

## Verification
- `pnpm run lint`
- `pnpm run build`
- `pnpm test`

## Notes
- Not manually dogfooded with a long-running Claude/tmux run. The failing condition from #76 is covered by a focused unit test (`tests/phases/interactive-sentinel-poll.test.ts`).