### PR TITLE
chore(release): bump to 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phase-harness",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "AI agent harness orchestrator — multi-phase brainstorm/spec/plan/implement/verify lifecycle with gate reviews",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Bump `phase-harness` from `1.0.2` → `1.0.3` (patch).

## Test plan

- [ ] `phase-harness --version` prints `1.0.3` after publish