### PR TITLE
feat(runner): run Codex interactive phases in workspace pane

### DIFF
--- a/src/phases/interactive.ts
+++ b/src/phases/interactive.ts
@@ -9,6 +9,7 @@ import { getHead } from '../git.js';
 import { isPidAlive } from '../process.js';
 import { assembleInteractivePrompt } from '../context/assembler.js';
 import { runClaudeInteractive } from '../runners/claude.js';
+import { clearLockChild } from '../lock.js';
 import { isValidChecklistSchema } from './checklist.js';
 import { resolveArtifact } from '../artifact.js';
 
@@ -261,7 +262,7 @@ export async function runInteractivePhase(
     );
     return { ...result, attemptId };
   } else {
-    const { runCodexInteractive } = await import('../runners/codex.js');
+    const { spawnCodexInteractiveInPane } = await import('../runners/codex.js');
     const { ensureCodexIsolation, CodexIsolationError } =
       await import('../runners/codex-isolation.js');
 
@@ -286,15 +287,30 @@ export async function runInteractivePhase(
       }
     }
 
-    const result = await runCodexInteractive(
-      phase, updatedState, preset, harnessDir, runDir, promptFile, cwd, codexHome,
+    const sentinelPath = path.join(runDir, `phase-${phase}.done`);
+    const { pid: codexPid } = await spawnCodexInteractiveInPane({
+      phase,
+      state: updatedState,
+      preset,
+      harnessDir,
+      runDir,
+      promptFile,
+      cwd,
+      codexHome,
+      attemptId,
+      sentinelPath,
+    });
+
+    const result = await waitForPhaseCompletion(
+      sentinelPath, attemptId, codexPid, phase, updatedState, cwd, runDir,
     );
-    if (result.status === 'failed') {
-      return { status: 'failed', attemptId };
-    }
-    // Validate artifacts after Codex completes
-    const valid = validatePhaseArtifacts(phase, updatedState, cwd, runDir);
-    return { status: valid ? 'completed' : 'failed', attemptId };
+
+    try { clearLockChild(harnessDir); } catch { /* best-effort */ }
+    updatedState.lastWorkspacePid = null;
+    updatedState.lastWorkspacePidStartTime = null;
+    writeState(runDir, updatedState);
+
+    return { ...result, attemptId };
   }
 }
 

--- a/src/runners/codex.ts
+++ b/src/runners/codex.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import type { HarnessState, GatePhaseResult } from '../types.js';
 import type { ModelPreset } from '../config.js';
-import { INTERACTIVE_TIMEOUT_MS, GATE_TIMEOUT_MS, SIGTERM_WAIT_MS, MAX_PROMPT_SIZE_KB } from '../config.js';
+import { GATE_TIMEOUT_MS, SIGTERM_WAIT_MS } from '../config.js';
 import { updateLockChild, clearLockChild } from '../lock.js';
 import { getProcessStartTime, killProcessGroup, isPidAlive } from '../process.js';
 import { sendKeysToPane, pollForPidFile } from '../tmux.js';
@@ -17,134 +17,6 @@ function resolveCodexBin(): string {
   } catch {
     throw new Error('Codex CLI not found in PATH.');
   }
-}
-
-export interface CodexInteractiveResult {
-  status: 'completed' | 'failed';
-  exitCode: number;
-}
-
-export async function runCodexInteractive(
-  phase: 1 | 3 | 5,
-  state: HarnessState,
-  preset: ModelPreset,
-  harnessDir: string,
-  runDir: string,
-  promptFile: string,
-  cwd: string,
-  codexHome: string | null = null,
-): Promise<CodexInteractiveResult> {
-  // Prompt size check
-  let promptSize: number;
-  try {
-    promptSize = fs.statSync(promptFile).size;
-  } catch {
-    return { status: 'failed', exitCode: -4 };
-  }
-  if (promptSize > MAX_PROMPT_SIZE_KB * 1024) {
-    const errorPath = path.join(runDir, `codex-${phase}-error.md`);
-    try {
-      fs.writeFileSync(
-        errorPath,
-        `# Codex Phase ${phase} Error\n\nPrompt exceeds ${MAX_PROMPT_SIZE_KB}KB limit (${Math.round(promptSize / 1024)}KB).\n`,
-      );
-    } catch { /* best-effort */ }
-    return { status: 'failed', exitCode: -1 };
-  }
-
-  const codexBin = resolveCodexBin();
-  const sandbox = phase === 5 ? 'danger-full-access' : 'workspace-write';
-
-  const child = spawn(codexBin, [
-    'exec',
-    '--model', preset.model,
-    '-c', `model_reasoning_effort="${preset.effort}"`,
-    '--sandbox', sandbox,
-    '--full-auto',
-    '-',
-  ], {
-    stdio: ['pipe', 'pipe', 'pipe'],
-    detached: true,
-    cwd,
-    env: codexHome === null
-      ? process.env
-      : { ...process.env, CODEX_HOME: codexHome },
-  });
-
-  const childPid = child.pid!;
-  const startTime = getProcessStartTime(childPid);
-  updateLockChild(harnessDir, childPid, phase, startTime);
-
-  // Pipe prompt content to stdin
-  const promptContent = fs.readFileSync(promptFile, 'utf-8');
-  child.stdin.write(promptContent);
-  child.stdin.end();
-
-  // Stream stderr/stdout [codex] progress lines to control panel
-  const stderrChunks: Buffer[] = [];
-  child.stderr.on('data', (chunk: Buffer) => {
-    stderrChunks.push(chunk);
-    const text = chunk.toString();
-    for (const line of text.split('\n')) {
-      if (line.trim()) process.stderr.write(`  [codex] ${line}\n`);
-    }
-  });
-  child.stdout.on('data', (chunk: Buffer) => {
-    const text = chunk.toString();
-    for (const line of text.split('\n')) {
-      if (line.includes('[codex]')) process.stderr.write(`  ${line}\n`);
-    }
-  });
-
-  const result = await new Promise<CodexInteractiveResult>((resolve) => {
-    let settled = false;
-    const timeout = setTimeout(async () => {
-      if (settled) return;
-      settled = true;
-      await killProcessGroup(childPid, SIGTERM_WAIT_MS);
-      resolve({ status: 'failed', exitCode: -2 });
-    }, INTERACTIVE_TIMEOUT_MS);
-
-    child.on('close', (code: number | null) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeout);
-      resolve({
-        status: (code ?? 1) === 0 ? 'completed' : 'failed',
-        exitCode: code ?? 1,
-      });
-    });
-
-    child.on('error', (_err: Error) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeout);
-      resolve({ status: 'failed', exitCode: -3 });
-    });
-  });
-
-  // Cleanup
-  await killProcessGroup(childPid, SIGTERM_WAIT_MS);
-  try { clearLockChild(harnessDir); } catch { /* best-effort */ }
-
-  // Clear workspace PID (Codex subprocess confirmed dead)
-  state.lastWorkspacePid = null;
-  state.lastWorkspacePidStartTime = null;
-  writeState(runDir, state);
-
-  // Error sidecar for non-zero positive exit codes
-  if (result.status === 'failed' && result.exitCode > 0) {
-    const errorPath = path.join(runDir, `codex-${phase}-error.md`);
-    const stderr = Buffer.concat(stderrChunks).toString('utf-8');
-    try {
-      fs.writeFileSync(
-        errorPath,
-        `# Codex Phase ${phase} Error\n\nExit code: ${result.exitCode}\n\n## stderr\n\n\`\`\`\n${stderr}\n\`\`\`\n`,
-      );
-    } catch { /* best-effort */ }
-  }
-
-  return result;
 }
 
 // ─── Error taxonomy for gate runs (spec §4.5) ────────────────────────────────
@@ -474,6 +346,88 @@ export async function spawnCodexInPane(input: SpawnCodexInPaneInput): Promise<Co
   }
 
   const wrappedCmd = `sh -c 'cd "${cwd}" && echo $$ > ${pidFile} && ${codexHomeEnv}exec ${codexCmd}'`;
+  sendKeysToPane(sessionName, workspacePane, wrappedCmd);
+
+  const codexPid = await pollForPidFile(pidFile, 5000);
+
+  if (codexPid !== null) {
+    const startTime = getProcessStartTime(codexPid);
+    updateLockChild(harnessDir, codexPid, phase, startTime);
+    state.lastWorkspacePid = codexPid;
+    state.lastWorkspacePidStartTime = startTime;
+    writeState(runDir, state);
+  }
+
+  return { pid: codexPid };
+}
+
+export interface SpawnCodexInteractiveInPaneInput {
+  phase: 1 | 3 | 5;
+  state: HarnessState;
+  preset: ModelPreset;
+  harnessDir: string;
+  runDir: string;
+  promptFile: string;
+  cwd: string;
+  codexHome: string | null;
+  attemptId: string;
+  sentinelPath: string;
+}
+
+/**
+ * Inject a `codex exec --full-auto` command into the tmux workspace pane for
+ * interactive phases (1/3/5). Unlike spawnCodexInPane (gates), the shell wrapper
+ * does NOT use `exec`, so sh survives codex exit and can write the sentinel.
+ * Sentinel content = attemptId, enabling checkSentinelFreshness to verify it.
+ */
+export async function spawnCodexInteractiveInPane(
+  input: SpawnCodexInteractiveInPaneInput,
+): Promise<CodexSpawnResult> {
+  const { phase, state, preset, harnessDir, runDir, promptFile, cwd, codexHome, attemptId, sentinelPath } = input;
+
+  const sessionName = state.tmuxSession;
+  const workspacePane = state.tmuxWorkspacePane;
+
+  if (state.lastWorkspacePid !== null && isPidAlive(state.lastWorkspacePid)) {
+    const savedStart = state.lastWorkspacePidStartTime;
+    const actualStart = getProcessStartTime(state.lastWorkspacePid);
+    if (savedStart !== null && actualStart !== null && Math.abs(actualStart - savedStart) <= 2) {
+      sendKeysToPane(sessionName, workspacePane, 'C-c');
+      const deadline = Date.now() + 5000;
+      while (isPidAlive(state.lastWorkspacePid) && Date.now() < deadline) {
+        await new Promise<void>((r) => setTimeout(r, 200));
+      }
+      if (isPidAlive(state.lastWorkspacePid)) {
+        await killProcessGroup(state.lastWorkspacePid, SIGTERM_WAIT_MS);
+      }
+    }
+    state.lastWorkspacePid = null;
+    state.lastWorkspacePidStartTime = null;
+    writeState(runDir, state);
+  }
+
+  sendKeysToPane(sessionName, workspacePane, 'C-c');
+  await new Promise<void>((r) => setTimeout(r, 500));
+
+  const pidFile = path.join(runDir, `codex-interactive-${phase}.pid`);
+  if (fs.existsSync(pidFile)) fs.unlinkSync(pidFile);
+
+  const codexBin = resolveCodexBin();
+  const sandbox = phase === 5 ? 'danger-full-access' : 'workspace-write';
+  const codexHomeEnv = codexHome ? `CODEX_HOME="${codexHome}" ` : '';
+
+  // No `exec`: sh must survive codex exit to write the sentinel.
+  const wrappedCmd =
+    `sh -c 'cd "${cwd}" && echo $$ > "${pidFile}" && ` +
+    `${codexHomeEnv}${codexBin} exec ` +
+    `--model ${preset.model} ` +
+    `-c model_reasoning_effort="${preset.effort}" ` +
+    `--sandbox ${sandbox} ` +
+    `--full-auto - ` +
+    `< "${promptFile}"; ` +
+    `RC=$?; if [ $RC -eq 0 ]; then echo "${attemptId}" > "${sentinelPath}"; fi; ` +
+    `exit $RC'`;
+
   sendKeysToPane(sessionName, workspacePane, wrappedCmd);
 
   const codexPid = await pollForPidFile(pidFile, 5000);

--- a/tests/phases/interactive.test.ts
+++ b/tests/phases/interactive.test.ts
@@ -13,8 +13,18 @@ import type { HarnessState } from '../../src/types.js';
 
 // ─── Module mocks for runInteractivePhase ordering test ─────────────────────
 
+vi.mock('chokidar', () => ({
+  default: {
+    watch: vi.fn(() => ({ on: vi.fn().mockReturnThis(), close: vi.fn(async () => undefined) })),
+  },
+}));
+
 vi.mock('../../src/runners/codex.js', () => ({
-  runCodexInteractive: vi.fn(async () => ({ status: 'completed', exitCode: 0 })),
+  spawnCodexInteractiveInPane: vi.fn(async (input: { sentinelPath: string; attemptId: string }) => {
+    // Write sentinel so waitForPhaseCompletion resolves immediately on initial check
+    fs.writeFileSync(input.sentinelPath, `${input.attemptId}\n`);
+    return { pid: 12345 };
+  }),
 }));
 vi.mock('../../src/runners/codex-isolation.js', async () => {
   const actual = await vi.importActual<typeof import('../../src/runners/codex-isolation.js')>(
@@ -839,9 +849,9 @@ describe('validatePhaseArtifacts — light + phase 1 extras (ADR-13)', () => {
 // ─── runInteractivePhase — codex branch + CODEX_HOME isolation (Issue #13) ───
 
 describe('runInteractivePhase — codex-interactive branch invokes codex isolation', () => {
-  it('calls ensureCodexIsolation(runDir) and threads codexHomeFor(runDir) into runCodexInteractive (positive path)', async () => {
+  it('calls ensureCodexIsolation(runDir) and threads codexHome into spawnCodexInteractiveInPane (positive path)', async () => {
     const { runInteractivePhase } = await import('../../src/phases/interactive.js');
-    const { runCodexInteractive } = await import('../../src/runners/codex.js');
+    const { spawnCodexInteractiveInPane } = await import('../../src/runners/codex.js');
     const { ensureCodexIsolation } = await import('../../src/runners/codex-isolation.js');
 
     const runDir = makeTmpDir();
@@ -857,20 +867,19 @@ describe('runInteractivePhase — codex-interactive branch invokes codex isolati
     });
 
     vi.mocked(ensureCodexIsolation).mockClear();
-    vi.mocked(runCodexInteractive).mockClear();
+    vi.mocked(spawnCodexInteractiveInPane).mockClear();
 
     await runInteractivePhase(1, state, harnessDir, runDir, repoDir, 'attempt-1');
 
     expect(vi.mocked(ensureCodexIsolation)).toHaveBeenCalledWith(runDir);
-    // runCodexInteractive signature: phase, state, preset, harnessDir, runDir, promptFile, cwd, codexHome
-    const call = vi.mocked(runCodexInteractive).mock.calls[0];
+    const call = vi.mocked(spawnCodexInteractiveInPane).mock.calls[0];
     expect(call).toBeDefined();
-    expect(call[7]).toBe(`${runDir}/codex-home`);
+    expect(call[0].codexHome).toBe(`${runDir}/codex-home`);
   });
 
-  it('codexNoIsolate=true: ensureCodexIsolation NOT called; runCodexInteractive receives codexHome=null', async () => {
+  it('codexNoIsolate=true: ensureCodexIsolation NOT called; spawnCodexInteractiveInPane receives codexHome=null', async () => {
     const { runInteractivePhase } = await import('../../src/phases/interactive.js');
-    const { runCodexInteractive } = await import('../../src/runners/codex.js');
+    const { spawnCodexInteractiveInPane } = await import('../../src/runners/codex.js');
     const { ensureCodexIsolation } = await import('../../src/runners/codex-isolation.js');
 
     const runDir = makeTmpDir();
@@ -886,18 +895,18 @@ describe('runInteractivePhase — codex-interactive branch invokes codex isolati
     });
 
     vi.mocked(ensureCodexIsolation).mockClear();
-    vi.mocked(runCodexInteractive).mockClear();
+    vi.mocked(spawnCodexInteractiveInPane).mockClear();
 
     await runInteractivePhase(1, state, harnessDir, runDir, repoDir, 'attempt-2');
 
     expect(vi.mocked(ensureCodexIsolation)).not.toHaveBeenCalled();
-    const call = vi.mocked(runCodexInteractive).mock.calls[0];
-    expect(call[7]).toBeNull();
+    const call = vi.mocked(spawnCodexInteractiveInPane).mock.calls[0];
+    expect(call[0].codexHome).toBeNull();
   });
 
   it('CodexIsolationError → phase fails with isolation error sidecar (no runner call)', async () => {
     const { runInteractivePhase } = await import('../../src/phases/interactive.js');
-    const { runCodexInteractive } = await import('../../src/runners/codex.js');
+    const { spawnCodexInteractiveInPane } = await import('../../src/runners/codex.js');
     const isolationMod = await import('../../src/runners/codex-isolation.js');
     const { CodexIsolationError } = isolationMod;
 
@@ -913,7 +922,7 @@ describe('runInteractivePhase — codex-interactive branch invokes codex isolati
       codexNoIsolate: false,
     });
 
-    vi.mocked(runCodexInteractive).mockClear();
+    vi.mocked(spawnCodexInteractiveInPane).mockClear();
     vi.mocked(isolationMod.ensureCodexIsolation).mockImplementationOnce(() => {
       throw new CodexIsolationError('fake: auth.json missing');
     });
@@ -922,7 +931,7 @@ describe('runInteractivePhase — codex-interactive branch invokes codex isolati
 
     expect(result.status).toBe('failed');
     // Runner NEVER called once bootstrap fails.
-    expect(vi.mocked(runCodexInteractive)).not.toHaveBeenCalled();
+    expect(vi.mocked(spawnCodexInteractiveInPane)).not.toHaveBeenCalled();
     // Isolation failure captured as a sidecar for post-mortem debugging.
     const errorSidecar = path.join(runDir, 'codex-1-error.md');
     expect(fs.existsSync(errorSidecar)).toBe(true);

--- a/tests/runners/codex.test.ts
+++ b/tests/runners/codex.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'events';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { runCodexGate, runCodexInteractive, stderrTail, spawnCodexInPane } from '../../src/runners/codex.js';
+import { runCodexGate, spawnCodexInteractiveInPane, stderrTail, spawnCodexInPane } from '../../src/runners/codex.js';
 import { sendKeysToPane } from '../../src/tmux.js';
 import { type ModelPreset } from '../../src/config.js';
 import type { HarnessState } from '../../src/types.js';
@@ -68,9 +68,9 @@ const SUCCESS_STDOUT =
 afterEach(() => { vi.clearAllMocks(); });
 
 describe('Codex Runner — module exports', () => {
-  it('module exports runCodexInteractive and runCodexGate', async () => {
+  it('module exports spawnCodexInteractiveInPane and runCodexGate', async () => {
     const mod = await import('../../src/runners/codex.js');
-    expect(typeof mod.runCodexInteractive).toBe('function');
+    expect(typeof mod.spawnCodexInteractiveInPane).toBe('function');
     expect(typeof mod.runCodexGate).toBe('function');
   });
 });
@@ -125,25 +125,81 @@ describe('runCodexGate — CODEX_HOME env plumbing (BUG-C isolation)', () => {
   });
 });
 
-describe('runCodexInteractive — CODEX_HOME env plumbing', () => {
-  it('spawn env.CODEX_HOME matches provided path', async () => {
-    const cp = await import('child_process');
-    (cp.spawn as any).mockImplementationOnce(() => makeMockChild({ stdout: 'ok\n' }));
-
-    const state = { lastWorkspacePid: null, lastWorkspacePidStartTime: null } as unknown as HarnessState;
-
+describe('spawnCodexInteractiveInPane — pane injection', () => {
+  it('sends a codex exec command to the workspace pane with correct sandbox and CODEX_HOME', async () => {
     const fs = await import('fs');
     const os = await import('os');
     const path = await import('path');
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-iso-ci-'));
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-pane-ci-'));
+    const promptPath = path.join(tmp, 'p.txt');
+    fs.writeFileSync(promptPath, 'hi');
+    const runDir = path.join(tmp, 'run');
+    fs.mkdirSync(runDir);
+    const sentinelPath = path.join(runDir, 'phase-1.done');
+
+    const state: HarnessState = {
+      lastWorkspacePid: null,
+      lastWorkspacePidStartTime: null,
+      tmuxSession: 'sess',
+      tmuxWorkspacePane: '%1',
+    } as unknown as HarnessState;
+
+    await spawnCodexInteractiveInPane({
+      phase: 1,
+      state,
+      preset,
+      harnessDir: '/tmp/h',
+      runDir,
+      promptFile: promptPath,
+      cwd: '/tmp/c',
+      codexHome: '/iso/interactive',
+      attemptId: 'atmp-1',
+      sentinelPath,
+    });
+
+    expect(vi.mocked(sendKeysToPane)).toHaveBeenCalled();
+    const cmd: string = vi.mocked(sendKeysToPane).mock.calls.at(-1)![2];
+    expect(cmd).toContain('CODEX_HOME="/iso/interactive"');
+    expect(cmd).toContain('--sandbox workspace-write');
+    expect(cmd).toContain('--full-auto');
+    expect(cmd).toContain(`echo "atmp-1" > "${sentinelPath}"`);
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('uses danger-full-access sandbox for phase 5', async () => {
+    const fs = await import('fs');
+    const os = await import('os');
+    const path = await import('path');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-pane-p5-'));
     const promptPath = path.join(tmp, 'p.txt');
     fs.writeFileSync(promptPath, 'hi');
     const runDir = path.join(tmp, 'run');
     fs.mkdirSync(runDir);
 
-    await runCodexInteractive(1, state, preset, '/tmp/h', runDir, promptPath, '/tmp/c', '/iso/interactive');
-    const spawnOpts = (cp.spawn as any).mock.calls[0][2];
-    expect(spawnOpts.env.CODEX_HOME).toBe('/iso/interactive');
+    const state: HarnessState = {
+      lastWorkspacePid: null,
+      lastWorkspacePidStartTime: null,
+      tmuxSession: 'sess',
+      tmuxWorkspacePane: '%1',
+    } as unknown as HarnessState;
+
+    await spawnCodexInteractiveInPane({
+      phase: 5,
+      state,
+      preset,
+      harnessDir: '/tmp/h',
+      runDir,
+      promptFile: promptPath,
+      cwd: '/tmp/c',
+      codexHome: null,
+      attemptId: 'atmp-5',
+      sentinelPath: path.join(runDir, 'phase-5.done'),
+    });
+
+    const cmd: string = vi.mocked(sendKeysToPane).mock.calls.at(-1)![2];
+    expect(cmd).toContain('--sandbox danger-full-access');
+    expect(cmd).not.toContain('CODEX_HOME');
 
     fs.rmSync(tmp, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary

- **Bug**: When phase 1/3/5 used Codex as runner, it spawned via `runCodexInteractive` with `stdio:['pipe','pipe','pipe']` — completely headless, never appearing in the TUI workspace pane
- **Fix**: Replaced with `spawnCodexInteractiveInPane` that injects the command into the tmux workspace pane via `sendKeysToPane`, mirroring the gate approach (`spawnCodexInPane`)
- **Root cause session**: `2026-04-25-untitled-598d`

## Key design decisions

**No `exec` in shell wrapper** — unlike the gate pane spawn, the wrapper does NOT use `exec` before `codex`. This keeps sh alive after Codex exits so it can write the sentinel file (`phase-N.done` with attemptId) that `waitForPhaseCompletion` polls for.

**Lock cleanup at call site** — `clearLockChild` is called in `interactive.ts` after `waitForPhaseCompletion` returns (rather than inside the runner), consistent with the fact that the runner returns before Codex finishes.

**Sandbox**: `workspace-write` for phases 1/3, `danger-full-access` for phase 5 — same policy as was in `runCodexInteractive`.

**`MAX_PROMPT_SIZE_KB` drop**: The old headless runner pre-checked prompt size before spawning. The new pane approach doesn't, consistent with `spawnCodexInPane` (gates) which also lacks this check. Pane output is visible, so oversized prompts surface naturally as Codex feedback.

## Codex review items addressed

- Added `clearLockChild` after `waitForPhaseCompletion` (stale lock regression fixed)
- Removed unused `MAX_PROMPT_SIZE_KB` import from `codex.ts`
- Confirmed `waitForPhaseCompletion` arguments are in correct order

## Test results

```
pnpm tsc --noEmit   ✅ clean
pnpm vitest run     ✅ 1025 pass, 11 fail (pre-existing lifecycle.test.ts failures)
pnpm build          ✅ success
```

## README/HOW-IT-WORKS

No documentation update needed — the only "subprocess" mention for Codex is in the `--codex-no-isolate` flag description, which remains accurate.