### PR TITLE
fix(gate): use `codex exec` for workspace-pane gate invocation

### DIFF
--- a/src/runners/codex.ts
+++ b/src/runners/codex.ts
@@ -454,22 +454,29 @@ export async function spawnCodexInPane(input: SpawnCodexInPaneInput): Promise<Co
   const skipGitFlag = !isInGitRepo(cwd) ? '--skip-git-repo-check ' : '';
   const codexHomeEnv = codexHome ? `CODEX_HOME="${codexHome}" ` : '';
 
+  // codex-cli 0.124.0: top-level `codex` refuses stdin redirect ("stdin is not
+  // a terminal") and drops `--skip-git-repo-check`. Both flags/flow were moved
+  // under the `exec` subcommand. Mirror runCodexExecRaw's argument structure so
+  // the pane path stays aligned with the headless path on a single source of
+  // truth. The trade-off vs PR #74 is loss of TUI chat visualization in the
+  // workspace pane — exec streams plain progress output instead. Still visible
+  // in the pane, just not interactive.
   let codexCmd: string;
   if (mode === 'resume' && sessionId) {
     codexCmd =
-      `${codexBin} resume ${sessionId} ` +
+      `${codexBin} exec resume ${sessionId} ` +
       `${skipGitFlag}` +
       `--model ${preset.model} ` +
       `-c model_reasoning_effort="${preset.effort}" ` +
-      `-s workspace-write -a never --full-auto ` +
+      `- ` +
       `< "${promptFile}"`;
   } else {
     codexCmd =
-      `${codexBin} ` +
+      `${codexBin} exec ` +
       `${skipGitFlag}` +
       `--model ${preset.model} ` +
       `-c model_reasoning_effort="${preset.effort}" ` +
-      `-s workspace-write -a never --full-auto ` +
+      `- ` +
       `< "${promptFile}"`;
   }
 

--- a/tests/runners/codex.test.ts
+++ b/tests/runners/codex.test.ts
@@ -329,7 +329,7 @@ function makeMinimalState(): HarnessState {
 }
 
 describe('spawnCodexInPane — fresh', () => {
-  it('sends fresh codex command to pane and returns pid', async () => {
+  it('sends fresh `codex exec` command to pane and returns pid', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-pane-'));
     const state = makeMinimalState();
     const result = await spawnCodexInPane({
@@ -345,18 +345,21 @@ describe('spawnCodexInPane — fresh', () => {
     });
     expect(result.pid).toBe(12345);
     const sendCalls = vi.mocked(sendKeysToPane).mock.calls;
-    // Last sendKeysToPane call should be the wrappedCmd
     const cmds = sendCalls.map(c => c[2]);
-    const wrappedCmd = cmds.find(c => c.includes('codex') && c.includes('--full-auto'));
+    const wrappedCmd = cmds.find(c => /\bcodex\s+exec\b/.test(c));
     expect(wrappedCmd).toBeDefined();
-    expect(wrappedCmd).not.toMatch(/\bcodex\s+exec\b/); // must NOT use legacy 'codex exec'
-    expect(wrappedCmd).toContain('--full-auto');
+    // codex-cli 0.124.0: top-level `codex` refuses stdin redirect and removed
+    // --skip-git-repo-check; we must use `codex exec` for pane injection now.
+    expect(wrappedCmd).toMatch(/\bcodex\s+exec\b/);
+    expect(wrappedCmd).not.toMatch(/\s-s\s+workspace-write\b/);
+    expect(wrappedCmd).not.toMatch(/\s-a\s+never\b/);
+    expect(wrappedCmd).toMatch(/- < ".*prompt\.md"/);
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 });
 
 describe('spawnCodexInPane — resume', () => {
-  it('sends codex resume command with sessionId', async () => {
+  it('sends `codex exec resume <sessionId>` command', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-pane-'));
     const state = makeMinimalState();
     await spawnCodexInPane({
@@ -375,7 +378,11 @@ describe('spawnCodexInPane — resume', () => {
     const cmds = sendCalls.map(c => c[2]);
     const wrappedCmd = cmds.find(c => c.includes('resume'));
     expect(wrappedCmd).toBeDefined();
-    expect(wrappedCmd).toContain('sess-abc-123');
+    expect(wrappedCmd).toMatch(/\bcodex\s+exec\s+resume\s+sess-abc-123\b/);
+    // codex exec resume does NOT accept -s / -a / --full-auto.
+    expect(wrappedCmd).not.toMatch(/\s-s\s+workspace-write\b/);
+    expect(wrappedCmd).not.toMatch(/\s-a\s+never\b/);
+    expect(wrappedCmd).not.toMatch(/--full-auto/);
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary

- **Bug**: Phase 2 (spec gate) fails in ~1.8–7.5 seconds with `Gate 2 failed (timed out or interrupted)`; `gate-N-raw.txt` is 0 bytes; outer harness then hangs with no new events. Reproduced on sessions `2026-04-25-untitled-598d` and `2026-04-25-id-nik-id-nik-match-30ad`.
- **Root cause**: `codex-cli 0.124.0` made two changes that silently broke `spawnCodexInPane`:
  1. Top-level `codex` refuses redirected stdin → `Error: stdin is not a terminal` (session 598d, git repo cwd)
  2. `--skip-git-repo-check` was moved from top-level `codex` to the `codex exec` subcommand → `error: unexpected argument '--skip-git-repo-check' found` (session 30ad, non-git cwd)
- **Fix**: Switch `spawnCodexInPane` from top-level `codex <flags> < prompt` to `codex exec [resume <sid>] <flags> - < prompt`, matching `runCodexExecRaw` (the headless path that already works).

## Flag changes

| Flag | Fresh (before) | Fresh (after) | Resume (before) | Resume (after) |
|---|---|---|---|---|
| subcommand | `codex` (TUI) | `codex exec` | `codex resume <sid>` | `codex exec resume <sid>` |
| `--skip-git-repo-check` | conditional | conditional | conditional | conditional |
| `-s workspace-write` | yes | **dropped** | yes | **dropped** (rejected by `exec resume`) |
| `-a never` | yes | **dropped** | yes | **dropped** |
| `--full-auto` | yes | **dropped** | yes | **dropped** (matches `runCodexExecRaw`) |
| prompt input | `< prompt` | `- < prompt` | `< prompt` | `- < prompt` |

Empirically verified: `codex exec resume fake-id -s workspace-write ...` fails with `error: unexpected argument '-s' found`, so resume-mode flag drops are non-negotiable.

## Trade-off vs PR #74

PR #74 introduced the workspace-pane gate flow using TUI `codex` for chat visualization. That is unavoidably lost here — `codex-cli 0.124.0` refuses stdin redirect in TUI mode, and prompt injection via stdin is required. `codex exec` still runs visibly in the workspace pane; it just streams plain progress output rather than an interactive TUI.

## Alignment with existing docs

`docs/HOW-IT-WORKS.md:197` already describes the gate invocation as:
```
codex exec --model <model> -c model_reasoning_effort="<effort>" -
```
so this PR brings the code back into alignment with documented behavior. No docs update required.

## Out of scope

The supervisor-issue report on session 30ad observed that after `gate_error`, the outer harness process stayed alive for 12+ minutes with no new events and L2 resume couldn't recover. That recovery bug is separate — it re-surfaces any time codex dies unexpectedly, not just for this specific CLI-regression cause. Tracked separately.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm vitest run tests/runners/codex.test.ts` — 19/19 pass (flipped `spawnCodexInPane — fresh` + `resume` assertions to require `codex exec`)
- [x] `pnpm vitest run` — 1024 pass, 11 fail (all pre-existing `lifecycle.test.ts` failures, unrelated)
- [x] `pnpm build` success
- [ ] Dogfood: resume a stuck session with the new build and confirm gate-2 reaches verdict