### PR TITLE
fix(gate): add --full-auto so Codex can write verdict + sentinel files

### DIFF
--- a/src/runners/codex.ts
+++ b/src/runners/codex.ts
@@ -328,11 +328,16 @@ export async function spawnCodexInPane(input: SpawnCodexInPaneInput): Promise<Co
 
   // codex-cli 0.124.0: top-level `codex` refuses stdin redirect ("stdin is not
   // a terminal") and drops `--skip-git-repo-check`. Both flags/flow were moved
-  // under the `exec` subcommand. Mirror runCodexExecRaw's argument structure so
-  // the pane path stays aligned with the headless path on a single source of
-  // truth. The trade-off vs PR #74 is loss of TUI chat visualization in the
-  // workspace pane — exec streams plain progress output instead. Still visible
-  // in the pane, just not interactive.
+  // under the `exec` subcommand. The trade-off vs PR #74 is loss of TUI chat
+  // visualization in the workspace pane — exec streams plain progress output
+  // instead. Still visible in the pane, just not interactive.
+  //
+  // `--full-auto` is required: the gate prompt instructs Codex to write
+  // `gate-N-verdict.md` and `phase-N.done` (see assembler.ts buildGateOutputProtocol),
+  // but `codex exec`'s default sandbox is read-only. `--full-auto` grants
+  // workspace-write implicitly and is accepted by BOTH `codex exec` and
+  // `codex exec resume` (unlike `-s workspace-write`, which `exec resume`
+  // rejects).
   let codexCmd: string;
   if (mode === 'resume' && sessionId) {
     codexCmd =
@@ -340,7 +345,7 @@ export async function spawnCodexInPane(input: SpawnCodexInPaneInput): Promise<Co
       `${skipGitFlag}` +
       `--model ${preset.model} ` +
       `-c model_reasoning_effort="${preset.effort}" ` +
-      `- ` +
+      `--full-auto - ` +
       `< "${promptFile}"`;
   } else {
     codexCmd =
@@ -348,7 +353,7 @@ export async function spawnCodexInPane(input: SpawnCodexInPaneInput): Promise<Co
       `${skipGitFlag}` +
       `--model ${preset.model} ` +
       `-c model_reasoning_effort="${preset.effort}" ` +
-      `- ` +
+      `--full-auto - ` +
       `< "${promptFile}"`;
   }
 

--- a/tests/runners/codex.test.ts
+++ b/tests/runners/codex.test.ts
@@ -409,6 +409,9 @@ describe('spawnCodexInPane — fresh', () => {
     expect(wrappedCmd).toMatch(/\bcodex\s+exec\b/);
     expect(wrappedCmd).not.toMatch(/\s-s\s+workspace-write\b/);
     expect(wrappedCmd).not.toMatch(/\s-a\s+never\b/);
+    // --full-auto required: gate prompt instructs codex to write verdict +
+    // sentinel files; codex exec's default sandbox is read-only.
+    expect(wrappedCmd).toMatch(/--full-auto/);
     expect(wrappedCmd).toMatch(/- < ".*prompt\.md"/);
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
@@ -435,10 +438,11 @@ describe('spawnCodexInPane — resume', () => {
     const wrappedCmd = cmds.find(c => c.includes('resume'));
     expect(wrappedCmd).toBeDefined();
     expect(wrappedCmd).toMatch(/\bcodex\s+exec\s+resume\s+sess-abc-123\b/);
-    // codex exec resume does NOT accept -s / -a / --full-auto.
+    // codex exec resume rejects -s / -a, but accepts --full-auto (required to
+    // let codex write the verdict + sentinel files).
     expect(wrappedCmd).not.toMatch(/\s-s\s+workspace-write\b/);
     expect(wrappedCmd).not.toMatch(/\s-a\s+never\b/);
-    expect(wrappedCmd).not.toMatch(/--full-auto/);
+    expect(wrappedCmd).toMatch(/--full-auto/);
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #82. That PR dropped \`-s workspace-write\` without replacement, leaving \`codex exec\`'s default **read-only** sandbox in effect. Codex could run but couldn't write \`gate-N-verdict.md\` or \`phase-N.done\`, so the gate prompt's Output Protocol (see \`assembler.ts:buildGateOutputProtocol\`) silently failed and \`waitForPhaseCompletion\` hung forever.

## Symptom (observed on v1.0.4)

Run \`2026-04-25-id-nik-id-nik-match-30ad\`. Codex produced a complete verdict in the workspace pane, exited cleanly, and printed:

> I attempted the required file writes, but they were blocked by the read-only sandbox.

The harness TUI then sat on \`Phase 2: Spec Gate — in_progress\` indefinitely (no sentinel → \`waitForPhaseCompletion\` never settles).

## Fix

Add \`--full-auto\` to both fresh and resume pane commands. \`--full-auto\` is accepted by \`codex exec\` **and** \`codex exec resume\` (unlike \`-s workspace-write\`, which \`exec resume\` rejects with \`error: unexpected argument '-s' found\`) and grants the workspace-write sandbox implicitly.

```diff
-codex exec <...> -c ... - < prompt
+codex exec <...> -c ... --full-auto - < prompt

-codex exec resume <sid> <...> -c ... - < prompt
+codex exec resume <sid> <...> -c ... --full-auto - < prompt
```

Fresh and resume now share the same flag set.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm vitest run tests/runners/codex.test.ts\` — 19/19 pass (both pane tests now assert \`--full-auto\`)
- [x] \`pnpm build\` success
- [ ] Dogfood: stuck session 30ad resumes and phase 2 completes (verdict + sentinel written)

## Release

Needs a 1.0.5 bump + republish. 1.0.4 ships the broken intermediate state from #82.