### PR TITLE
feat(runner): restore TUI codex in workspace pane via pre-trusted CODEX_HOME

### DIFF
--- a/docs/HOW-IT-WORKS.ko.md
+++ b/docs/HOW-IT-WORKS.ko.md
@@ -118,7 +118,7 @@ tracked 레포 중 **하나 이상**이 `implRetryBase`를 넘어 진행되면 P
 
 ### Codex (outer-cwd gate)
 
-outer cwd가 git 레포가 아니면 gate가 실행될 수 있도록 Codex 호출에 `--skip-git-repo-check`가 자동으로 추가됩니다.
+outer cwd가 git 레포가 아니어도 codex가 trust 프롬프트나 git-repo 안전 거절 없이 진입할 수 있도록, `ensureCodexIsolation`이 `<runDir>/codex-home/config.toml`에 `[projects."<realpath cwd>"] trust_level = "trusted"` 엔트리를 자동으로 기록합니다. (codex 0.124.0에서 top-level `--skip-git-repo-check` 플래그가 제거됐기 때문에 trust-entry 방식이 정식 대체 경로입니다.)
 
 ---
 
@@ -158,35 +158,37 @@ claude --session-id <attemptId> --model <model> --effort <effort> @<prompt-file>
 
 ### Codex interactive phase
 
-선택된 preset의 runner가 `codex`이면 다음 형태로 실행합니다.
+선택된 preset의 runner가 `codex`이면 harness는 workspace pane에 top-level `codex` TUI를 띄웁니다. Claude와 동일한 UX(입력 라인 + reasoning stream 가시화 + 실시간 개입 가능):
 
 ```bash
-codex exec --model <model> -c model_reasoning_effort="<effort>" --sandbox <level> --full-auto -
+codex --model <model> -c model_reasoning_effort="<effort>" --sandbox <level> --full-auto "$(cat <prompt-file>)"
 ```
+
+프롬프트는 셸 command-substitution(`$(cat ...)`)을 통해 실행 시점에 positional CLI argument로 주입됩니다. tmux send-keys가 운반하는 건 짧은 wrapper뿐이라 프롬프트 크기가 수십 KB가 되어도 문제없습니다. agent 자신이 phase 프롬프트의 지시에 따라 tool use로 `phase-N.done` sentinel을 작성하며, 이는 Claude의 동작 패턴과 일치합니다.
 
 sandbox 레벨:
 - phase 1, 3 → `workspace-write`
 - phase 5 → `danger-full-access`
 
-Codex interactive phase는 sentinel 파일을 쓰지 않고, subprocess 종료 후 harness가 산출물을 직접 검증합니다.
-
 ### Gate phase
 
-gate phase도 preset 기반입니다.
-기본적으로는 예전 companion 경로가 아니라 실제 `codex` CLI를 사용합니다.
+gate phase도 preset 기반입니다. Codex gate는 interactive phase와 **동일한 tmux workspace pane**에서 top-level `codex` TUI로 실행됩니다.
 
 ```bash
-codex exec --model <model> -c model_reasoning_effort="<effort>" -
+codex --model <model> -c model_reasoning_effort="<effort>" -s workspace-write --full-auto "$(cat <prompt-file>)"
 ```
 
-gate phase를 Claude preset으로 강제로 매핑한 경우에만 `claude --print` gate subprocess를 사용합니다.
+reopen 시에는 동일한 플래그로 `codex resume <session_id>`를 사용합니다. gate phase를 Claude preset으로 강제로 매핑한 경우에만 `claude --print` gate subprocess를 사용합니다.
 
-Gate phase(2, 4, 7)는 interactive phase와 **동일한 tmux workspace pane**에서 Codex CLI를 대화형 TUI로 실행합니다. Codex는 `<runDir>/gate-N-verdict.md`에 판정 결과를 기록하고, harness는 `<runDir>/phase-N.done` sentinel 파일로 완료를 감지합니다. gate 실행 중에는 control pane footer에 `attach: tmux attach -t <session>`이 표시되므로 workspace pane으로 이동해 실시간으로 리뷰 진행 상황을 확인할 수 있습니다.
+Codex는 `<runDir>/gate-N-verdict.md`에 판정 결과를 기록하고, harness는 `<runDir>/phase-N.done` sentinel 파일로 완료를 감지합니다. gate 실행 중에는 control pane footer에 `attach: tmux attach -t <session>`이 표시되므로 workspace pane으로 이동해 실시간으로 리뷰 진행 상황을 확인할 수 있습니다.
 
 ### Codex isolation
 
-기본적으로 Codex subprocess는 `<runDir>/codex-home/` 안에서 실행되고, 그 안에는 `auth.json`만 symlink됩니다.
-이렇게 해야 사용자 전역 `CODEX_HOME` 규칙이 런타임에 섞여들지 않습니다.
+기본적으로 Codex subprocess는 `<runDir>/codex-home/` 안에서 실행되며, 다음 두 가지를 harness가 채워 넣습니다:
+- 사용자의 실제 `~/.codex/` (또는 `$CODEX_HOME`)에서 `auth.json` symlink
+- `[projects."<realpath cwd>"] trust_level = "trusted"` 단일 엔트리만 담은 harness 제어용 `config.toml` — codex TUI가 trust 프롬프트나 git-repo 거절 없이 cwd를 받아들이도록 함
+
+이렇게 해야 사용자 전역 `CODEX_HOME` 규약이 런타임에 섞여들지 않고, cwd trust도 사용자 글로벌 config을 변경하지 않은 채 per-run으로만 적용됩니다. `--codex-no-isolate`로 isolation을 끄면 사용자의 `~/.codex/config.toml` 및 trust 캐시가 그대로 사용되며, 이 모드에서는 비-git cwd에 처음 들어갈 때 trust 프롬프트가 뜹니다.
 `--codex-no-isolate`는 이 안전장치를 끕니다.
 
 Claude Code 환경에서 1M context를 사용할 수 없다면, 모델 선택기에서 기존 non-1M Claude preset을 계속 사용하거나 자체 포크의 `src/config.ts` 기본값을 바꾸면 됩니다.

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -118,7 +118,7 @@ Phase 5 succeeds when **at least one** tracked repo has advanced past its `implR
 
 ### Codex (outer-cwd gate)
 
-When the outer cwd is not a git repo, `--skip-git-repo-check` is automatically added to the Codex invocation so the gate can still run.
+When the outer cwd is not a git repo, `ensureCodexIsolation` writes a `[projects."<realpath cwd>"] trust_level = "trusted"` entry into the isolated `<runDir>/codex-home/config.toml` so codex skips the trust prompt and the git-repo safety refusal. (`--skip-git-repo-check` was removed from top-level codex in 0.124.0; the trust-entry is the supported replacement.)
 
 ---
 
@@ -176,36 +176,37 @@ Other behavior:
 
 ### Codex interactive phases
 
-When the selected preset runner is `codex`, harness runs:
+When the selected preset runner is `codex`, harness launches the top-level `codex` TUI in the workspace pane — same UX as Claude (input line + reasoning stream visible, intervention possible):
 
 ```bash
-codex exec --model <model> -c model_reasoning_effort="<effort>" --sandbox <level> --full-auto -
+codex --model <model> -c model_reasoning_effort="<effort>" --sandbox <level> --full-auto "$(cat <prompt-file>)"
 ```
+
+The prompt is injected as a positional CLI argument via shell command substitution at execution time, so tmux send-keys carries only the short wrapper (the prompt itself can exceed tens of KB). The agent itself writes the `phase-N.done` sentinel via tool use per the phase prompt's instructions, matching Claude's pattern.
 
 Sandbox level:
 - phases 1 and 3 → `workspace-write`
 - phase 5 → `danger-full-access`
 
-Codex interactive phases do not use sentinel files; harness validates artifacts after the subprocess exits.
-
 ### Gate phases
 
-Gate phases are preset-driven too.
-By default they run through the real `codex` CLI, not the older companion-path flow:
+Gate phases are preset-driven too. Codex gates run through the top-level `codex` TUI in the **same tmux workspace pane** as interactive phases:
 
 ```bash
-codex exec --model <model> -c model_reasoning_effort="<effort>" -
+codex --model <model> -c model_reasoning_effort="<effort>" -s workspace-write --full-auto "$(cat <prompt-file>)"
 ```
 
-If a gate phase is explicitly mapped to a Claude preset, harness instead runs a `claude --print` gate subprocess.
+For reopens, harness uses `codex resume <session_id>` with the same flags. If a gate phase is explicitly mapped to a Claude preset, harness instead runs a `claude --print` gate subprocess.
 
-Gate phases (2, 4, 7) run Codex CLI as an interactive TUI in the **same tmux workspace pane** used by interactive phases. Codex writes its verdict to `<runDir>/gate-N-verdict.md`, and harness detects completion via a sentinel file `<runDir>/phase-N.done`. While a gate is running, the control-pane footer shows `attach: tmux attach -t <session>` so you can switch to the workspace pane and watch the review in real time.
+Codex writes its verdict to `<runDir>/gate-N-verdict.md`, and harness detects completion via a sentinel file `<runDir>/phase-N.done`. While a gate is running, the control-pane footer shows `attach: tmux attach -t <session>` so you can switch to the workspace pane and watch the review in real time.
 
 ### Codex isolation
 
-By default, Codex subprocesses run inside `<runDir>/codex-home/` with only `auth.json` symlinked in.
-This avoids inheriting unrelated user-level `CODEX_HOME` conventions.
-`--codex-no-isolate` disables that safeguard.
+By default, Codex subprocesses run inside `<runDir>/codex-home/` with:
+- `auth.json` symlinked from the user's real `~/.codex/` (or `$CODEX_HOME`)
+- a harness-controlled `config.toml` containing a single `[projects."<realpath cwd>"] trust_level = "trusted"` entry, so codex TUI accepts the cwd without a trust prompt or git-repo refusal
+
+This avoids inheriting unrelated user-level `CODEX_HOME` conventions and keeps cwd trust per-run rather than mutating the user's global config. `--codex-no-isolate` disables the isolation; in that mode the user's `~/.codex/config.toml` and trust-cache are used directly (so non-git cwds will pop a trust prompt the first time).
 
 If your Claude Code environment does not support 1M context, keep using the legacy non-1M Claude presets from the model picker or change the defaults in `src/config.ts` in your own fork.
 

--- a/src/phases/gate.ts
+++ b/src/phases/gate.ts
@@ -302,7 +302,7 @@ export async function runGatePhaseInteractive(
   // Step 6: Codex isolation setup
   let codexHome: string | null = null;
   if (preset.runner === 'codex' && !state.codexNoIsolate) {
-    try { codexHome = ensureCodexIsolation(runDir); }
+    try { codexHome = ensureCodexIsolation(runDir, cwd); }
     catch (err) {
       if (err instanceof CodexIsolationError) return { type: 'error', error: err.message, runner: 'codex' };
       throw err;

--- a/src/phases/interactive.ts
+++ b/src/phases/interactive.ts
@@ -271,7 +271,7 @@ export async function runInteractivePhase(
     let codexHome: string | null = null;
     if (!updatedState.codexNoIsolate) {
       try {
-        codexHome = ensureCodexIsolation(runDir);
+        codexHome = ensureCodexIsolation(runDir, cwd);
       } catch (err) {
         if (err instanceof CodexIsolationError) {
           const errorPath = path.join(runDir, `codex-${phase}-error.md`);

--- a/src/runners/codex-isolation.ts
+++ b/src/runners/codex-isolation.ts
@@ -18,7 +18,7 @@ function resolveRealCodexHome(): string {
   return process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
 }
 
-export function ensureCodexIsolation(runDir: string): string {
+export function ensureCodexIsolation(runDir: string, cwd: string): string {
   const codexHome = codexHomeFor(runDir);
 
   try {
@@ -45,6 +45,22 @@ export function ensureCodexIsolation(runDir: string): string {
   } catch (err) {
     throw new CodexIsolationError(
       `Failed to symlink codex auth into ${authDst}: ${(err as Error).message}`,
+    );
+  }
+
+  // Pre-trust the cwd so codex TUI doesn't refuse non-git directories or pop a
+  // trust prompt. Codex matches by canonical (realpath) path — on macOS `/tmp`
+  // is a symlink to `/private/tmp`, so the entry must use the resolved path or
+  // it won't match codex's runtime cwd lookup.
+  let trustedPath = cwd;
+  try { trustedPath = fs.realpathSync(cwd); } catch { /* best-effort */ }
+  const tomlPath = path.join(codexHome, 'config.toml');
+  const tomlEntry = `[projects."${trustedPath}"]\ntrust_level = "trusted"\n`;
+  try {
+    fs.writeFileSync(tomlPath, tomlEntry, 'utf-8');
+  } catch (err) {
+    throw new CodexIsolationError(
+      `Failed to write codex trust config at ${tomlPath}: ${(err as Error).message}`,
     );
   }
 

--- a/src/runners/codex.ts
+++ b/src/runners/codex.ts
@@ -323,38 +323,38 @@ export async function spawnCodexInPane(input: SpawnCodexInPaneInput): Promise<Co
   if (fs.existsSync(pidFile)) fs.unlinkSync(pidFile);
 
   const codexBin = resolveCodexBin();
-  const skipGitFlag = !isInGitRepo(cwd) ? '--skip-git-repo-check ' : '';
   const codexHomeEnv = codexHome ? `CODEX_HOME="${codexHome}" ` : '';
 
-  // codex-cli 0.124.0: top-level `codex` refuses stdin redirect ("stdin is not
-  // a terminal") and drops `--skip-git-repo-check`. Both flags/flow were moved
-  // under the `exec` subcommand. The trade-off vs PR #74 is loss of TUI chat
-  // visualization in the workspace pane — exec streams plain progress output
-  // instead. Still visible in the pane, just not interactive.
+  // Spawn the top-level `codex` TUI (not `codex exec`) so the workspace pane
+  // shows the live reasoning + input line — restoring PR #74's intent.
   //
-  // `--full-auto` is required: the gate prompt instructs Codex to write
-  // `gate-N-verdict.md` and `phase-N.done` (see assembler.ts buildGateOutputProtocol),
-  // but `codex exec`'s default sandbox is read-only. `--full-auto` grants
-  // workspace-write implicitly and is accepted by BOTH `codex exec` and
-  // `codex exec resume` (unlike `-s workspace-write`, which `exec resume`
-  // rejects).
+  // codex-cli 0.124.0 made stdin redirect impossible with TUI ("stdin is not a
+  // terminal"), so the prompt is injected via shell command-substitution as a
+  // positional CLI argument instead. tmux send-keys carries only the short
+  // wrapper; `cat` runs at execution time on the pane shell.
+  //
+  // `--skip-git-repo-check` was removed from top-level codex in 0.124.0; we
+  // pre-trust the cwd via codex config (ensureCodexIsolation writes
+  // `[projects."<realpath cwd>"] trust_level = "trusted"` into the isolated
+  // CODEX_HOME), which bypasses both the trust prompt and the git-repo check.
+  //
+  // `-s workspace-write --full-auto` lets codex write gate-N-verdict.md and
+  // phase-N.done as instructed by buildGateOutputProtocol (assembler.ts).
   let codexCmd: string;
   if (mode === 'resume' && sessionId) {
     codexCmd =
-      `${codexBin} exec resume ${sessionId} ` +
-      `${skipGitFlag}` +
+      `${codexBin} resume ${sessionId} ` +
       `--model ${preset.model} ` +
       `-c model_reasoning_effort="${preset.effort}" ` +
-      `--full-auto - ` +
-      `< "${promptFile}"`;
+      `-s workspace-write --full-auto ` +
+      `"$(cat "${promptFile}")"`;
   } else {
     codexCmd =
-      `${codexBin} exec ` +
-      `${skipGitFlag}` +
+      `${codexBin} ` +
       `--model ${preset.model} ` +
       `-c model_reasoning_effort="${preset.effort}" ` +
-      `--full-auto - ` +
-      `< "${promptFile}"`;
+      `-s workspace-write --full-auto ` +
+      `"$(cat "${promptFile}")"`;
   }
 
   const wrappedCmd = `sh -c 'cd "${cwd}" && echo $$ > ${pidFile} && ${codexHomeEnv}exec ${codexCmd}'`;
@@ -382,7 +382,9 @@ export interface SpawnCodexInteractiveInPaneInput {
   promptFile: string;
   cwd: string;
   codexHome: string | null;
+  /** @deprecated Vestigial since the TUI switch — codex now writes the sentinel via tool use per the phase prompt. Kept for caller compatibility; safe to remove once `interactive.ts` stops passing it. */
   attemptId: string;
+  /** @deprecated See `attemptId`. */
   sentinelPath: string;
 }
 
@@ -395,7 +397,12 @@ export interface SpawnCodexInteractiveInPaneInput {
 export async function spawnCodexInteractiveInPane(
   input: SpawnCodexInteractiveInPaneInput,
 ): Promise<CodexSpawnResult> {
-  const { phase, state, preset, harnessDir, runDir, promptFile, cwd, codexHome, attemptId, sentinelPath } = input;
+  const { phase, state, preset, harnessDir, runDir, promptFile, cwd, codexHome } = input;
+  // attemptId / sentinelPath used to drive a shell-level sentinel write when
+  // the runner was `codex exec` (auto-exits). With TUI mode, codex itself
+  // writes the sentinel via tool use per the phase-N prompt — same as Claude
+  // TUI. Kept in the input type for caller compatibility.
+  void input.attemptId; void input.sentinelPath;
 
   const sessionName = state.tmuxSession;
   const workspacePane = state.tmuxWorkspacePane;
@@ -428,17 +435,17 @@ export async function spawnCodexInteractiveInPane(
   const sandbox = phase === 5 ? 'danger-full-access' : 'workspace-write';
   const codexHomeEnv = codexHome ? `CODEX_HOME="${codexHome}" ` : '';
 
-  // No `exec`: sh must survive codex exit to write the sentinel.
+  // Top-level `codex` TUI (matches gate pane spawn pattern). Trust entry in
+  // the isolated CODEX_HOME (ensureCodexIsolation) bypasses git-repo check.
+  // Prompt injected as positional arg via `cat` substitution at exec time.
   const wrappedCmd =
     `sh -c 'cd "${cwd}" && echo $$ > "${pidFile}" && ` +
-    `${codexHomeEnv}${codexBin} exec ` +
+    `${codexHomeEnv}exec ${codexBin} ` +
     `--model ${preset.model} ` +
     `-c model_reasoning_effort="${preset.effort}" ` +
     `--sandbox ${sandbox} ` +
-    `--full-auto - ` +
-    `< "${promptFile}"; ` +
-    `RC=$?; if [ $RC -eq 0 ]; then echo "${attemptId}" > "${sentinelPath}"; fi; ` +
-    `exit $RC'`;
+    `--full-auto ` +
+    `"$(cat "${promptFile}")"'`;
 
   sendKeysToPane(sessionName, workspacePane, wrappedCmd);
 

--- a/tests/phases/gate.test.ts
+++ b/tests/phases/gate.test.ts
@@ -473,7 +473,7 @@ describe('runGatePhase — one-shot sidecar replay', () => {
 
     await runGatePhase(2, state, '/fake-harness', runDir, '/cwd');
 
-    expect(vi.mocked(ensureCodexIsolation)).toHaveBeenCalledWith(runDir);
+    expect(vi.mocked(ensureCodexIsolation)).toHaveBeenCalledWith(runDir, '/cwd');
     const call = vi.mocked(mockSpawn).mock.calls[0];
     expect(call[0].codexHome).toBe(`${runDir}/codex-home`);
   });

--- a/tests/phases/interactive.test.ts
+++ b/tests/phases/interactive.test.ts
@@ -871,7 +871,7 @@ describe('runInteractivePhase — codex-interactive branch invokes codex isolati
 
     await runInteractivePhase(1, state, harnessDir, runDir, repoDir, 'attempt-1');
 
-    expect(vi.mocked(ensureCodexIsolation)).toHaveBeenCalledWith(runDir);
+    expect(vi.mocked(ensureCodexIsolation)).toHaveBeenCalledWith(runDir, repoDir);
     const call = vi.mocked(spawnCodexInteractiveInPane).mock.calls[0];
     expect(call).toBeDefined();
     expect(call[0].codexHome).toBe(`${runDir}/codex-home`);

--- a/tests/runners/codex-isolation.test.ts
+++ b/tests/runners/codex-isolation.test.ts
@@ -42,7 +42,7 @@ describe('codexHomeFor', () => {
 
 describe('ensureCodexIsolation', () => {
   it('creates <runDir>/codex-home/ with auth.json symlink', () => {
-    const returned = ensureCodexIsolation(runDir);
+    const returned = ensureCodexIsolation(runDir, tmpRoot);
     const codexHome = path.join(runDir, 'codex-home');
     expect(returned).toBe(codexHome);
     expect(fs.existsSync(codexHome)).toBe(true);
@@ -55,22 +55,22 @@ describe('ensureCodexIsolation', () => {
   });
 
   it('is idempotent on second call', () => {
-    const first = ensureCodexIsolation(runDir);
+    const first = ensureCodexIsolation(runDir, tmpRoot);
     const authDst = path.join(first, 'auth.json');
     const firstStat = fs.lstatSync(authDst);
     // Re-run: must succeed and refresh the symlink without throwing.
-    const second = ensureCodexIsolation(runDir);
+    const second = ensureCodexIsolation(runDir, tmpRoot);
     expect(second).toBe(first);
     expect(fs.lstatSync(authDst).isSymbolicLink()).toBe(true);
     expect(firstStat.isSymbolicLink()).toBe(true);
   });
 
   it('refreshes symlink when real auth.json rotates (unlink+symlink pattern)', () => {
-    ensureCodexIsolation(runDir);
+    ensureCodexIsolation(runDir, tmpRoot);
     const authDst = path.join(runDir, 'codex-home', 'auth.json');
     // Simulate rotated real auth
     fs.writeFileSync(path.join(fakeRealHome, 'auth.json'), '{"fake":"rotated"}');
-    ensureCodexIsolation(runDir);
+    ensureCodexIsolation(runDir, tmpRoot);
     expect(fs.readFileSync(authDst, 'utf-8')).toBe('{"fake":"rotated"}');
   });
 
@@ -80,7 +80,7 @@ describe('ensureCodexIsolation', () => {
     // will likely not have the fake auth; assert the error message targets
     // the homedir path to prove fallback logic is wired.
     try {
-      ensureCodexIsolation(runDir);
+      ensureCodexIsolation(runDir, tmpRoot);
       // On the off-chance the tester has a real ~/.codex/auth.json, the call
       // succeeds — that's still a valid fallback demonstration: the symlink
       // target must be under os.homedir()/.codex.
@@ -95,9 +95,9 @@ describe('ensureCodexIsolation', () => {
 
   it('throws CodexIsolationError when real auth.json is missing', () => {
     fs.unlinkSync(path.join(fakeRealHome, 'auth.json'));
-    expect(() => ensureCodexIsolation(runDir)).toThrow(CodexIsolationError);
+    expect(() => ensureCodexIsolation(runDir, tmpRoot)).toThrow(CodexIsolationError);
     try {
-      ensureCodexIsolation(runDir);
+      ensureCodexIsolation(runDir, tmpRoot);
     } catch (err) {
       expect((err as Error).message).toMatch(/auth.*not found/i);
       expect((err as Error).message).toMatch(/codex login/i);
@@ -108,16 +108,40 @@ describe('ensureCodexIsolation', () => {
     // Create a FILE at codex-home path so mkdir(recursive:true) errors with EEXIST-not-dir
     const codexHome = path.join(runDir, 'codex-home');
     fs.writeFileSync(codexHome, 'not a dir');
-    expect(() => ensureCodexIsolation(runDir)).toThrow(CodexIsolationError);
+    expect(() => ensureCodexIsolation(runDir, tmpRoot)).toThrow(CodexIsolationError);
     try {
-      ensureCodexIsolation(runDir);
+      ensureCodexIsolation(runDir, tmpRoot);
     } catch (err) {
       expect(err).toBeInstanceOf(CodexIsolationError);
       expect((err as CodexIsolationError).code).toBe('CODEX_ISOLATION_FAILED');
     }
   });
 
-  it('bootstraps ONLY auth.json — absent: AGENTS.md, config.toml, agents/, prompts/, skills/, rules/, memories/, hooks.json', () => {
+  it('writes config.toml with [projects."<canonical-cwd>"] trust_level="trusted"', () => {
+    // cwd must be canonicalized so codex's path-comparison succeeds even when
+    // the caller passes a symlink (e.g. /tmp → /private/tmp on macOS).
+    const codexHome = ensureCodexIsolation(runDir, tmpRoot);
+    const tomlPath = path.join(codexHome, 'config.toml');
+    expect(fs.existsSync(tomlPath)).toBe(true);
+    const canonical = fs.realpathSync(tmpRoot);
+    const content = fs.readFileSync(tomlPath, 'utf-8');
+    expect(content).toContain(`[projects."${canonical}"]`);
+    expect(content).toContain('trust_level = "trusted"');
+  });
+
+  it('uses canonical (realpath) cwd in the trust entry, not the raw input path', () => {
+    // Set up a symlink that points at the actual cwd
+    const symlinkCwd = path.join(tmpRoot, 'cwd-symlink');
+    fs.symlinkSync(tmpRoot, symlinkCwd);
+    const codexHome = ensureCodexIsolation(runDir, symlinkCwd);
+    const content = fs.readFileSync(path.join(codexHome, 'config.toml'), 'utf-8');
+    const realCwd = fs.realpathSync(symlinkCwd);
+    expect(content).toContain(`[projects."${realCwd}"]`);
+    // Negative: must NOT use the symlink path verbatim
+    expect(content).not.toContain(`[projects."${symlinkCwd}"]`);
+  });
+
+  it('bootstraps auth.json + a harness-controlled config.toml; nothing else from the real home leaks', () => {
     // Pre-populate the REAL codex home with everything a user might have
     fs.writeFileSync(path.join(fakeRealHome, 'AGENTS.md'), '# user conventions\n');
     fs.writeFileSync(path.join(fakeRealHome, 'config.toml'), '[profile]\nname="me"\n');
@@ -127,17 +151,23 @@ describe('ensureCodexIsolation', () => {
       fs.writeFileSync(path.join(fakeRealHome, d, 'leak.md'), 'do not leak');
     }
 
-    const codexHome = ensureCodexIsolation(runDir);
+    const codexHome = ensureCodexIsolation(runDir, tmpRoot);
 
+    // Harness manages: auth.json (symlink) + config.toml (trust entry)
     expect(fs.existsSync(path.join(codexHome, 'auth.json'))).toBe(true);
+    expect(fs.existsSync(path.join(codexHome, 'config.toml'))).toBe(true);
+    // The isolated config.toml must be the harness-built trust entry, NOT the
+    // real-home profile config — so user's [profile] settings must not leak.
+    const tomlContent = fs.readFileSync(path.join(codexHome, 'config.toml'), 'utf-8');
+    expect(tomlContent).not.toContain('[profile]');
+    expect(tomlContent).not.toContain('name="me"');
+    // Other user-home files still must NOT leak
     expect(fs.existsSync(path.join(codexHome, 'AGENTS.md'))).toBe(false);
-    expect(fs.existsSync(path.join(codexHome, 'config.toml'))).toBe(false);
     expect(fs.existsSync(path.join(codexHome, 'hooks.json'))).toBe(false);
     for (const d of ['agents', 'prompts', 'skills', 'rules', 'memories']) {
       expect(fs.existsSync(path.join(codexHome, d))).toBe(false);
     }
-
-    const entries = fs.readdirSync(codexHome);
-    expect(entries).toEqual(['auth.json']);
+    const entries = fs.readdirSync(codexHome).sort();
+    expect(entries).toEqual(['auth.json', 'config.toml']);
   });
 });

--- a/tests/runners/codex.test.ts
+++ b/tests/runners/codex.test.ts
@@ -126,7 +126,7 @@ describe('runCodexGate — CODEX_HOME env plumbing (BUG-C isolation)', () => {
 });
 
 describe('spawnCodexInteractiveInPane — pane injection', () => {
-  it('sends a codex exec command to the workspace pane with correct sandbox and CODEX_HOME', async () => {
+  it('sends a top-level `codex` TUI command (not `codex exec`) with prompt arg, sandbox, CODEX_HOME', async () => {
     const fs = await import('fs');
     const os = await import('os');
     const path = await import('path');
@@ -159,10 +159,19 @@ describe('spawnCodexInteractiveInPane — pane injection', () => {
 
     expect(vi.mocked(sendKeysToPane)).toHaveBeenCalled();
     const cmd: string = vi.mocked(sendKeysToPane).mock.calls.at(-1)![2];
+    // Top-level TUI codex — pane stays interactive (input line + reasoning).
+    expect(cmd).toMatch(/\bcodex\s+--model\b/);
+    expect(cmd).not.toMatch(/\bcodex\s+exec\b/);
+    expect(cmd).not.toMatch(/--skip-git-repo-check/);
     expect(cmd).toContain('CODEX_HOME="/iso/interactive"');
     expect(cmd).toContain('--sandbox workspace-write');
     expect(cmd).toContain('--full-auto');
-    expect(cmd).toContain(`echo "atmp-1" > "${sentinelPath}"`);
+    // Prompt as cat-substitution positional arg, not stdin redirect.
+    expect(cmd).toContain(`"$(cat "${promptPath}")"`);
+    expect(cmd).not.toMatch(/<\s+"[^"]*p\.txt"/);
+    // No shell-level sentinel write — codex writes the sentinel via tool use
+    // per phase-N prompt instructions, matching Claude TUI's pattern.
+    expect(cmd).not.toContain('echo "atmp-1"');
 
     fs.rmSync(tmp, { recursive: true, force: true });
   });
@@ -198,6 +207,8 @@ describe('spawnCodexInteractiveInPane — pane injection', () => {
     });
 
     const cmd: string = vi.mocked(sendKeysToPane).mock.calls.at(-1)![2];
+    expect(cmd).toMatch(/\bcodex\s+--model\b/);
+    expect(cmd).not.toMatch(/\bcodex\s+exec\b/);
     expect(cmd).toContain('--sandbox danger-full-access');
     expect(cmd).not.toContain('CODEX_HOME');
 
@@ -385,10 +396,55 @@ function makeMinimalState(): HarnessState {
 }
 
 describe('spawnCodexInPane — fresh', () => {
-  it('sends fresh `codex exec` command to pane and returns pid', async () => {
+  it('sends fresh top-level `codex` TUI command with prompt as cat-substitution arg', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-pane-'));
     const state = makeMinimalState();
+    const promptFile = path.join(tmpDir, 'prompt.md');
     const result = await spawnCodexInPane({
+      phase: 2,
+      state,
+      preset,
+      harnessDir: tmpDir,
+      runDir: tmpDir,
+      promptFile,
+      cwd: tmpDir,
+      codexHome: null,
+      mode: 'fresh',
+    });
+    expect(result.pid).toBe(12345);
+    const sendCalls = vi.mocked(sendKeysToPane).mock.calls;
+    const cmds = sendCalls.map(c => c[2]);
+    const wrappedCmd = cmds.find(c => /\bcodex\b/.test(c) && !c.startsWith('C-'));
+    expect(wrappedCmd).toBeDefined();
+    // Top-level `codex` (TUI), not `codex exec` — TUI gives the user a visible
+    // input line and reasoning stream, restoring PR #74's intent. Trust entry
+    // pre-written by ensureCodexIsolation removes the need for the
+    // exec-only `--skip-git-repo-check` flag in non-git cwds.
+    expect(wrappedCmd).toMatch(/\bcodex\s+--model\b/);
+    expect(wrappedCmd).not.toMatch(/\bcodex\s+exec\b/);
+    expect(wrappedCmd).not.toMatch(/--skip-git-repo-check/);
+    // Sandbox + auto-approval still required so codex can write verdict + sentinel.
+    expect(wrappedCmd).toMatch(/-s\s+workspace-write/);
+    expect(wrappedCmd).toMatch(/--full-auto/);
+    // Prompt is injected via shell command substitution at execution time so
+    // tmux send-keys carries only the short wrapper, not the 40+ KB prompt.
+    expect(wrappedCmd).toContain(`"$(cat "${promptFile}")"`);
+    // No stdin redirect (top-level codex rejects "stdin is not a terminal").
+    expect(wrappedCmd).not.toMatch(/<\s+"[^"]*prompt\.md"/);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});
+
+describe('spawnCodexInPane — fresh in non-git cwd', () => {
+  it('does NOT add --skip-git-repo-check even when cwd is non-git (trust-entry handles it)', async () => {
+    // PR #80/#82/#83 used --skip-git-repo-check conditionally on non-git cwd.
+    // The trust-entry approach (ensureCodexIsolation) makes that flag both
+    // unsupported (top-level codex 0.124.0 dropped it) and unnecessary.
+    const gitMod = await import('../../src/git.js');
+    (gitMod.isInGitRepo as any).mockReturnValueOnce(false);
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-pane-nongit-'));
+    const state = makeMinimalState();
+    await spawnCodexInPane({
       phase: 2,
       state,
       preset,
@@ -399,35 +455,27 @@ describe('spawnCodexInPane — fresh', () => {
       codexHome: null,
       mode: 'fresh',
     });
-    expect(result.pid).toBe(12345);
     const sendCalls = vi.mocked(sendKeysToPane).mock.calls;
     const cmds = sendCalls.map(c => c[2]);
-    const wrappedCmd = cmds.find(c => /\bcodex\s+exec\b/.test(c));
+    const wrappedCmd = cmds.find(c => /\bcodex\s+--model\b/.test(c));
     expect(wrappedCmd).toBeDefined();
-    // codex-cli 0.124.0: top-level `codex` refuses stdin redirect and removed
-    // --skip-git-repo-check; we must use `codex exec` for pane injection now.
-    expect(wrappedCmd).toMatch(/\bcodex\s+exec\b/);
-    expect(wrappedCmd).not.toMatch(/\s-s\s+workspace-write\b/);
-    expect(wrappedCmd).not.toMatch(/\s-a\s+never\b/);
-    // --full-auto required: gate prompt instructs codex to write verdict +
-    // sentinel files; codex exec's default sandbox is read-only.
-    expect(wrappedCmd).toMatch(/--full-auto/);
-    expect(wrappedCmd).toMatch(/- < ".*prompt\.md"/);
+    expect(wrappedCmd).not.toMatch(/--skip-git-repo-check/);
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 });
 
 describe('spawnCodexInPane — resume', () => {
-  it('sends `codex exec resume <sessionId>` command', async () => {
+  it('sends top-level `codex resume <sessionId>` TUI command with prompt arg', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-pane-'));
     const state = makeMinimalState();
+    const promptFile = path.join(tmpDir, 'resume-prompt.md');
     await spawnCodexInPane({
       phase: 2,
       state,
       preset,
       harnessDir: tmpDir,
       runDir: tmpDir,
-      promptFile: path.join(tmpDir, 'resume-prompt.md'),
+      promptFile,
       cwd: tmpDir,
       codexHome: null,
       mode: 'resume',
@@ -437,12 +485,15 @@ describe('spawnCodexInPane — resume', () => {
     const cmds = sendCalls.map(c => c[2]);
     const wrappedCmd = cmds.find(c => c.includes('resume'));
     expect(wrappedCmd).toBeDefined();
-    expect(wrappedCmd).toMatch(/\bcodex\s+exec\s+resume\s+sess-abc-123\b/);
-    // codex exec resume rejects -s / -a, but accepts --full-auto (required to
-    // let codex write the verdict + sentinel files).
-    expect(wrappedCmd).not.toMatch(/\s-s\s+workspace-write\b/);
-    expect(wrappedCmd).not.toMatch(/\s-a\s+never\b/);
+    // Top-level `codex resume <id>`, NOT `codex exec resume`. Top-level resume
+    // accepts -s and --full-auto (unlike exec resume), so fresh and resume
+    // share the same flag set.
+    expect(wrappedCmd).toMatch(/\bcodex\s+resume\s+sess-abc-123\b/);
+    expect(wrappedCmd).not.toMatch(/\bcodex\s+exec\s+resume\b/);
+    expect(wrappedCmd).not.toMatch(/--skip-git-repo-check/);
+    expect(wrappedCmd).toMatch(/-s\s+workspace-write/);
     expect(wrappedCmd).toMatch(/--full-auto/);
+    expect(wrappedCmd).toContain(`"$(cat "${promptFile}")"`);
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary

Replaces the `codex exec` workaround from #82/#83 with the proper fix: pre-trust the cwd in the isolated `CODEX_HOME/config.toml` so the top-level `codex` TUI accepts non-git directories without the (now-removed-from-top-level) `--skip-git-repo-check` flag, and inject the prompt as a positional CLI argument via shell command substitution. Restores PR #74's intent — workspace pane shows live reasoning + input line, user can intervene — while staying compatible with codex-cli 0.124.0's CLI changes.

## Why the previous approach was a workaround, not a fix

`codex` has TWO ways to bypass the git-repo safety refusal:
1. `--skip-git-repo-check` flag — moved to `codex exec` subcommand only in 0.124.0
2. `[projects."<path>"] trust_level = "trusted"` config entry — works on top-level TUI

#82/#83 took path 1, accepting the loss of TUI chat visualization. This PR takes path 2 by writing the trust entry into the per-run isolated `CODEX_HOME/config.toml` during \`ensureCodexIsolation\`, which is the natural place for it (per-run, doesn't mutate user's global config).

Empirically verified before coding: starting top-level \`codex --full-auto \"hello\"\` in a non-git \`/private/tmp/freshdir2\` with isolated \`CODEX_HOME\` containing the trust entry → TUI launches, no trust prompt, codex replies normally.

## Key implementation details

**Canonical-path canonicalization is load-bearing.** Codex matches the project entry by realpath. On macOS \`/tmp\` is a symlink to \`/private/tmp\`, so without \`fs.realpathSync(cwd)\` the entry won't match codex's runtime cwd lookup and the trust prompt fires anyway. The new tests lock this in (\`uses canonical (realpath) cwd in the trust entry, not the raw input path\`).

**Prompt as positional arg, not stdin redirect.** Top-level \`codex\` rejects stdin redirect (\"stdin is not a terminal\") in 0.124.0. Inject via shell substitution: \`codex ... \"\$(cat \"<prompt-file>\")\"\`. \`cat\` runs at execution time on the pane shell, so tmux send-keys carries only the short wrapper. ARG_MAX (1MB on macOS) far exceeds typical 40 KB prompts.

**Resume uses \`codex resume\`, not \`codex exec resume\`.** Top-level \`codex resume <id>\` accepts \`-s\`, \`--full-auto\`, and the positional \`[PROMPT]\` argument; \`codex exec resume\` rejects \`-s\`. Fresh and resume now share the exact same flag set. Live-tested with a fake session id: flag parsing OK, no trust prompt, expected \`No saved session found\` error path.

## Intentional behavior loss

PR #80 added a shell-level safety net for codex interactive: \`RC=\$?; if [ \$RC -eq 0 ]; then echo \"\$attemptId\" > sentinel; fi\` after \`codex exec\` — would write the sentinel even if codex's tool use never did. That was only meaningful with auto-exiting \`codex exec\`. With TUI mode, codex stays alive after the response, so there's no \"after\" hook for the shell. The agent's sentinel write (per phase prompt's instructions) is the only path now — same failure mode Claude TUI has had all along. If the model produces output but never writes the sentinel via tool use (model error, content filter, OOM mid-tool-call), the phase hangs until SIGUSR1 / timeout. Worth knowing for future debugging.

## Out of scope

The \"outer harness process stays alive after gate_error, no further events for 12+ minutes\" recovery bug from session 30ad's supervisor-issue is separate — it re-surfaces any time codex dies unexpectedly. Not addressed here.

## Tests

- \`tests/runners/codex-isolation.test.ts\`: +2 new tests for trust entry shape and realpath canonicalization. The pre-existing \`bootstraps ONLY auth.json\` test was updated to acknowledge config.toml is now intentionally written (still asserts user-home leak prevention: \`[profile]\` from real config doesn't leak).
- \`tests/runners/codex.test.ts\`: pane tests rewritten to assert top-level TUI shape; +1 new \`non-git cwd\` variant locking in no-flag-even-without-git.
- \`tests/phases/{gate,interactive}.test.ts\`: \`ensureCodexIsolation\` call assertion updated to new \`(runDir, cwd)\` signature.
- TDD: every change RED→GREEN; no production code without a failing test first.

## Verification

- \`pnpm tsc --noEmit\` clean
- \`pnpm vitest run\` — **1039 pass / 0 fail / 1 skip** (CLI integration tests in \`lifecycle.test.ts\` need a fresh \`dist/\`, hence \`pnpm build\` before vitest in clean checkouts)
- \`pnpm build\` success
- Live tmux smoke tests (above) confirm flag parsing + trust entry behavior in non-git cwds for both fresh \`codex\` and \`codex resume\`

## Test plan (post-merge)

- [ ] Bump 1.0.5 → 1.0.6, publish
- [ ] On a stuck session like \`30ad\` with the new build: verify phase 2 (gate) actually completes — TUI visible in workspace pane, agent writes verdict + sentinel, harness advances to phase 3
- [ ] Verify same on a phase 1 (interactive) codex run