### PR TITLE
fix(phase5): surface Codex uncommitted-changes failure (#84)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ pnpm build          # tsc + scripts/copy-assets.mjs (dist 생성)
 |---|---|
 | `session_start` | `task`, `autoMode`, `baseCommit`, `harnessVersion` |
 | `phase_start` | `phase`, `attemptId`, **`preset: { id, runner, model, effort }`** (PR #11 — phase 6 제외) |
-| `phase_end` | `phase`, `attemptId`, `status`, `durationMs`, **`claudeTokens?: { input, output, cacheRead, cacheCreate, total } \| null`** (PR #16 — interactive 1/3/5 + `preset.runner === 'claude'` 실자 페이즈만; codex/redirect-by-signal 분기는 필드 자체 생략) |
+| `phase_end` | `phase`, `attemptId`, `status`, `durationMs`, **`claudeTokens?: { input, output, cacheRead, cacheCreate, total } \| null`** (PR #16 — interactive 1/3/5 + `preset.runner === 'claude'` 실자 페이즈만; codex/redirect-by-signal 분기는 필드 자체 생략), **`uncommittedRepos?: Array<{ path: string; count: number }>`** (#84 — Phase 5 + codex runner + sentinel fresh + dirty tree에서만 발현; 그 외 분기는 필드 자체 생략) |
 | `gate_verdict` | `phase`, `retryIndex`, `runner`, `verdict`, `durationMs`, `tokensTotal`, `promptBytes`, `codexSessionId`, `resumedFrom`, `resumeFallback`, `preset` |
 | `gate_retry` | `phase`, `retryIndex`, `retryCount`, `retryLimit`, `feedbackPath`, `feedbackBytes`, `feedbackPreview` |
 | `gate_error` | `preset` (PR #11) |

--- a/README.ko.md
+++ b/README.ko.md
@@ -356,6 +356,7 @@ logging이 켜져 있으면 control pane footer에 다음 정보가 표시됩니
 - Harness는 **atomic state write**와 **outer/inner lock handoff**를 사용합니다.
 - interactive phase 완료는 `.harness/<runId>/phase-1.done` 같은 sentinel 파일로 검증합니다.
 - phase 5는 기본적으로 clean tree와 `implRetryBase` 이후 최소 1개 commit이 필요합니다. 단, reopen 경로에서 commit 없는 artifact 수정만 필요한 경우는 예외가 있습니다.
+- Phase 5에 Codex 프리셋을 쓰면 commit 누락 함정(sentinel fresh + uncommitted = silent failed 루프)에 빠질 수 있습니다. 이 경우 하네스가 stderr 경고 블록 + `phase_end.uncommittedRepos` 필드로 안내합니다. 자세한 내용은 `docs/HOW-IT-WORKS.ko.md` 참고 (#84).
 - `skip`과 `jump`는 control-plane 연산이므로 main run lock을 직접 잡지 않습니다.
 - 모델 preset을 다시 고르면 effective runner/model lineage가 바뀐 gate replay sidecar는 무효화될 수 있습니다.
 

--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ When logging is enabled, the control pane footer shows:
 - Harness uses **atomic state writes** and **lock handoff** between the outer starter process and the inner tmux process.
 - Interactive phases are validated with sentinel files such as `.harness/<runId>/phase-1.done`.
 - Phase 5 requires a clean tree and at least one commit after `implRetryBase` unless it is a reopen path that only fixes non-commit artifacts.
+- A Codex preset on Phase 5 can hit a commit-discipline trap (sentinel fresh + uncommitted edits → silent failed loop). The harness now surfaces this with a stderr warn block + `phase_end.uncommittedRepos`. See `docs/HOW-IT-WORKS.md` (#84).
 - `skip` and `jump` are control-plane operations; they do not take the main run lock.
 - Re-selecting presets can invalidate saved gate replay sidecars when the effective runner/model lineage changes.
 

--- a/docs/HOW-IT-WORKS.ko.md
+++ b/docs/HOW-IT-WORKS.ko.md
@@ -111,6 +111,15 @@ light flow 특이사항:
 
 tracked 레포 중 **하나 이상**이 `implRetryBase`를 넘어 진행되면 Phase 5가 성공합니다. 수정되지 않은 레포는 `implHead = null`으로 유지됩니다.
 
+#### Codex 프리셋 + Phase 5 — commit 누락 함정 (issue #84)
+
+Phase 5는 적어도 하나의 tracked 레포의 HEAD가 `implRetryBase`를 넘어 진전했을 때만 완료로 간주합니다. Codex가 구현은 마치고 sentinel은 남겼지만 commit을 빠뜨리는 경우가 있는데, validator 입장에서는 "진전 없음 = failed"로 보입니다. 하네스는 이 케이스(Codex 프리셋 + sentinel fresh + working tree dirty)를 정확히 검출하면 stderr에 `⚠️  Phase 5 failed: Codex completed (sentinel fresh) but left uncommitted changes` 블록을 출력하고, `phase_end` 이벤트에 `uncommittedRepos: [{ path, count }, …]` 필드를 부착해 operator가 다음 중 하나를 선택할 수 있게 안내합니다:
+
+- 변경분을 직접 commit한 뒤 Resume, 또는
+- Phase 5 프리셋을 Claude 계열(예: `claude-sonnet-default`)로 전환 — `superpowers:subagent-driven-development`가 commit 규율을 강제하므로 안전합니다.
+
+Claude 브랜치는 wrapper skill에서 commit을 강제하므로 이 함정에 빠지지 않습니다.
+
 ### Gate diff (Phase 2/4/7)
 
 - **N=1이고 `trackedRepos[0].path === cwd`**: diff 출력이 멀티 워크트리 이전 형식과 바이트 단위로 동일합니다 (레이블 없음).

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -111,6 +111,15 @@ A legacy mirror (`state.baseCommit`, `state.implRetryBase`, `state.implCommit`) 
 
 Phase 5 succeeds when **at least one** tracked repo has advanced past its `implRetryBase`. Repos that were not modified are left with `implHead = null`.
 
+#### Codex preset on Phase 5 — commit-discipline trap (issue #84)
+
+Phase 5 only treats an attempt as completed when at least one tracked repo's HEAD advances past `implRetryBase`. Codex sometimes finishes the work and writes the sentinel but forgets to commit, leaving the validator to read "no advance" and report `failed`. When the harness detects this exact case (Codex preset + sentinel fresh + working tree dirty in any tracked repo), it writes a `⚠️  Phase 5 failed: Codex completed (sentinel fresh) but left uncommitted changes` block to stderr and attaches `uncommittedRepos: [{ path, count }, …]` on the `phase_end` log event so operators can either:
+
+- commit the dirty changes manually and Resume, or
+- switch the Phase 5 preset to a Claude variant (e.g. `claude-sonnet-default`), which has commit-discipline guards via `superpowers:subagent-driven-development`.
+
+The Claude branch does not have this trap — its commit guard is enforced by the wrapper skill, so HEAD always advances on a successful attempt.
+
 ### Gate diff (Phase 2/4/7)
 
 - **N=1 and `trackedRepos[0].path === cwd`**: diff output is byte-identical to the pre-multi-worktree format (no label).

--- a/docs/plans/2026-04-25-codex-phase5-uncommitted-detection.md
+++ b/docs/plans/2026-04-25-codex-phase5-uncommitted-detection.md
@@ -1,0 +1,519 @@
+# Codex Phase 5 Uncommitted-Changes Detection — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect when Codex finishes a Phase 5 attempt with the sentinel fresh but the working tree dirty (uncommitted changes), and surface that state via a stderr warn block plus an `uncommittedRepos?` field on the `phase_end` event.
+
+**Architecture:** A new pure helper `detectUncommittedChanges(repoPaths)` in `src/git.ts` (mirrors the existing `isWorkingTreeClean` / `hasStagedChanges` shape) lives in isolation and is unit-testable. The Codex P5 branch in `src/phases/interactive.ts` calls it post-`waitForPhaseCompletion` and stashes the result on the existing `InteractiveResult` shape. `src/phases/runner.ts` reads that field on the "Normal failure" path and forwards it onto the `phase_end` log event (typed via `src/types.ts`).
+
+**Tech Stack:** TypeScript, vitest, pnpm. No new dependencies.
+
+**Spec:** [`docs/specs/2026-04-25-codex-phase5-uncommitted-detection-design.md`](../specs/2026-04-25-codex-phase5-uncommitted-detection-design.md)
+
+**Issue:** [#84](https://github.com/DongGukMon/harness-cli/issues/84)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/git.ts` | Modify | Add `detectUncommittedChanges` + `UncommittedRepo` interface (alongside existing helpers like `isWorkingTreeClean`). |
+| `src/phases/interactive.ts` | Modify | Extend `InteractiveResult` with `uncommittedRepos?`. Add detection block in Codex P5 branch. Add local `formatUncommittedWarn` helper. |
+| `src/phases/runner.ts` | Modify | On the "Normal failure" path of `handleInteractivePhase`, forward `result.uncommittedRepos` onto the `phase_end` log event. |
+| `src/types.ts` | Modify | Extend `phase_end` log-event variant with `uncommittedRepos?: Array<{ path: string; count: number }>`. |
+| `tests/git.test.ts` | Modify | Add `describe('detectUncommittedChanges')` block with three cases. |
+| `tests/phases/interactive.test.ts` | Modify | Add P5+Codex+dirty / P5+Codex+clean / P5+Claude+dirty cases. |
+| `docs/HOW-IT-WORKS.md` | Modify | Phase 5 success-criteria callout. |
+| `docs/HOW-IT-WORKS.ko.md` | Modify | Mirror of the English callout. |
+| `CLAUDE.md` | Modify | Events table — add `uncommittedRepos?` row to `phase_end`. |
+| `README.md`, `README.ko.md` | Inspect (modify only if existing P5/preset coverage warrants it) | Doc-sync obligation per CLAUDE.md. |
+
+---
+
+## Task 1 — `detectUncommittedChanges` helper
+
+**Files:**
+- Modify: `src/git.ts`
+- Modify: `tests/git.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/git.test.ts`:
+
+```typescript
+import {
+  // ... existing imports
+  detectUncommittedChanges,
+} from '../src/git.js';
+
+describe('detectUncommittedChanges', () => {
+  let repo: { path: string; cleanup: () => void };
+
+  beforeEach(() => {
+    repo = createTestRepo();
+  });
+
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  it('returns [] for a clean repo', () => {
+    expect(detectUncommittedChanges([repo.path])).toEqual([]);
+  });
+
+  it('reports dirty repo with line count', () => {
+    writeFileSync(join(repo.path, 'a.txt'), 'a');
+    writeFileSync(join(repo.path, 'b.txt'), 'b');
+    const result = detectUncommittedChanges([repo.path]);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe(repo.path);
+    expect(result[0].count).toBe(2);
+  });
+
+  it('returns [] for a non-git path without throwing', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'no-git-uncommit-'));
+    try {
+      expect(detectUncommittedChanges([tmpDir])).toEqual([]);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports each dirty repo separately when given multiple paths', () => {
+    const repo2 = createTestRepo();
+    try {
+      writeFileSync(join(repo.path, 'x.txt'), 'x');
+      writeFileSync(join(repo2.path, 'y.txt'), 'y');
+      const result = detectUncommittedChanges([repo.path, repo2.path]);
+      expect(result).toHaveLength(2);
+      expect(result.map(r => r.count)).toEqual([1, 1]);
+    } finally {
+      repo2.cleanup();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm vitest run tests/git.test.ts -t detectUncommittedChanges
+```
+
+Expected: FAIL — `detectUncommittedChanges is not exported from '../src/git.js'`.
+
+- [ ] **Step 3: Implement the helper**
+
+Append to `src/git.ts`:
+
+```typescript
+export interface UncommittedRepo {
+  path: string;
+  count: number;
+}
+
+// Returns an entry for each repoPath whose `git status --porcelain` is non-empty.
+// Non-git paths and exec failures are silently treated as clean (count: 0, omitted).
+export function detectUncommittedChanges(repoPaths: string[]): UncommittedRepo[] {
+  const out: UncommittedRepo[] = [];
+  for (const p of repoPaths) {
+    try {
+      const raw = exec('git status --porcelain', p);
+      if (raw === '') continue;
+      const count = raw.split('\n').filter(line => line.length > 0).length;
+      if (count > 0) {
+        out.push({ path: p, count });
+      }
+    } catch {
+      // Non-git path or git failure → treat as clean.
+    }
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm vitest run tests/git.test.ts -t detectUncommittedChanges
+```
+
+Expected: PASS — all four cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/git.ts tests/git.test.ts
+git commit -m "feat(git): add detectUncommittedChanges helper
+
+Lists repos whose git status --porcelain is non-empty. Used by the
+Phase 5 Codex branch to surface uncommitted-changes failures (#84)."
+```
+
+---
+
+## Task 2 — Wire detection into Codex P5 branch + emit on `phase_end`
+
+This task ties together three files because the change is only useful end-to-end:
+`InteractiveResult` widening, the detection call site, the type extension, and the
+runner-side event emission. Splitting them would leave a half-merged tree that
+typechecks but does nothing observable.
+
+**Files:**
+- Modify: `src/phases/interactive.ts`
+- Modify: `src/phases/runner.ts`
+- Modify: `src/types.ts`
+- Modify: `tests/phases/interactive.test.ts`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Open `tests/phases/interactive.test.ts` and add a new `describe` block at the bottom (study the existing top-of-file mock setup — replicate the exact mock pattern used by other Codex-branch tests there; do NOT invent a new mock pattern):
+
+```typescript
+describe('Codex P5 uncommitted-changes detection (#84)', () => {
+  it('attaches uncommittedRepos and writes stderr warn when working tree is dirty', async () => {
+    // Reuse this file's existing setup pattern: createTestRepo for state.trackedRepos[0],
+    // mock spawnCodexInteractiveInPane to return immediately, and have the sentinel
+    // file written with the matching attemptId (so checkSentinelFreshness === 'fresh').
+    // Then pollute the working tree with one uncommitted change BEFORE calling
+    // runInteractivePhase. validatePhaseArtifacts(5) will return false (no HEAD
+    // advance), so the result.status will be 'failed'.
+
+    // ... existing setup pattern (mirror neighboring tests) ...
+
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const result = await runInteractivePhase(5, state, harnessDir, runDir, cwd, attemptId);
+    expect(result.status).toBe('failed');
+    expect((result as InteractiveResult & { uncommittedRepos?: UncommittedRepo[] }).uncommittedRepos)
+      .toEqual([{ path: trackedRepoPath, count: 1 }]);
+    const writes = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+    expect(writes).toMatch(/Codex completed \(sentinel fresh\) but left uncommitted changes/);
+    stderrSpy.mockRestore();
+  });
+
+  it('does NOT warn when Codex P5 fails with a clean working tree', async () => {
+    // Same setup, sentinel fresh, but the tree stays clean. Result is still
+    // 'failed' (HEAD didn't advance) but no warn / no field.
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const result = await runInteractivePhase(5, state, harnessDir, runDir, cwd, attemptId);
+    expect(result.status).toBe('failed');
+    expect((result as InteractiveResult & { uncommittedRepos?: UncommittedRepo[] }).uncommittedRepos)
+      .toBeUndefined();
+    expect(stderrSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('uncommitted changes')
+    );
+    stderrSpy.mockRestore();
+  });
+
+  it('does NOT warn for Claude P5 even when the tree is dirty', async () => {
+    // Force preset.runner === 'claude' (claude branch never reaches the new code path).
+    // Pollute the working tree. Even with a fresh sentinel + dirty tree, no warn.
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const result = await runInteractivePhase(5, state, harnessDir, runDir, cwd, attemptId);
+    expect((result as InteractiveResult & { uncommittedRepos?: UncommittedRepo[] }).uncommittedRepos)
+      .toBeUndefined();
+    expect(stderrSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('uncommitted changes')
+    );
+    stderrSpy.mockRestore();
+  });
+});
+```
+
+Note: `InteractiveResult` and `UncommittedRepo` need import additions at the top of the test file.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pnpm vitest run tests/phases/interactive.test.ts -t "uncommitted-changes detection"
+```
+
+Expected: FAIL — `result.uncommittedRepos` is undefined and stderr does not match the expected text. (Make sure typescript also fails because `InteractiveResult.uncommittedRepos` does not exist yet — that's the next step.)
+
+- [ ] **Step 3: Extend `InteractiveResult` and add detection in interactive.ts**
+
+In `src/phases/interactive.ts`:
+
+(a) Add the import alongside existing `git.ts` imports:
+
+```typescript
+import { getHead, detectUncommittedChanges, type UncommittedRepo } from '../git.js';
+```
+
+(b) Widen `InteractiveResult`:
+
+```typescript
+export interface InteractiveResult {
+  status: 'completed' | 'failed';
+  uncommittedRepos?: UncommittedRepo[];
+}
+```
+
+(c) Add a private formatter near the top of the file (below `specHasValidComplexity`):
+
+```typescript
+function formatUncommittedWarn(dirty: UncommittedRepo[]): string {
+  const lines = dirty.map(d => `    ${d.path} — ${d.count} files`);
+  return [
+    '',
+    '⚠️  Phase 5 failed: Codex completed (sentinel fresh) but left uncommitted changes:',
+    ...lines,
+    '',
+    '  Resolve by:',
+    '    • Commit the changes manually, then Resume; or',
+    '    • Re-run with a Claude preset for phase 5 (e.g. claude-sonnet-default).',
+    '',
+    '',
+  ].join('\n');
+}
+```
+
+(d) In `runInteractivePhase`, in the Codex `else` branch, **between** the `await waitForPhaseCompletion(...)` line and the existing `try { clearLockChild(...) }` block, insert:
+
+```typescript
+if (
+  phase === 5 &&
+  result.status === 'failed' &&
+  checkSentinelFreshness(sentinelPath, attemptId) === 'fresh'
+) {
+  const dirty = detectUncommittedChanges(updatedState.trackedRepos.map(r => r.path));
+  if (dirty.length > 0) {
+    process.stderr.write(formatUncommittedWarn(dirty));
+    result.uncommittedRepos = dirty;
+  }
+}
+```
+
+(`result` is `const { status }` from `await`, so destructure differently or rebind. Check the surrounding code: at line ~304 the code uses `const result = await waitForPhaseCompletion(...)`. That's already a let-bindable shape since it's an object literal returned from the helper. Type-widen the local declaration to `InteractiveResult` so we can attach the optional field — i.e. `const result: InteractiveResult = await waitForPhaseCompletion(...)`.)
+
+- [ ] **Step 4: Forward the field on `phase_end` in runner.ts**
+
+In `src/phases/runner.ts`, locate the "Normal failure (redirect case already handled above)" `else` block (around line 495). Modify the `phase_end` log event to include the optional field:
+
+```typescript
+const failedTokens = collectClaudeTokens();
+logger.logEvent({
+  event: 'phase_end',
+  phase,
+  attemptId,
+  status: 'failed',
+  durationMs: Date.now() - phaseStartTs,
+  ...(failedTokens !== undefined ? { claudeTokens: failedTokens } : {}),
+  ...(result.uncommittedRepos !== undefined && result.uncommittedRepos.length > 0
+    ? { uncommittedRepos: result.uncommittedRepos }
+    : {}),
+});
+```
+
+Do NOT add the field on the artifact-commit-failure path or the throw path — the spec scopes this strictly to the validator-rejected, sentinel-fresh case which only the "Normal failure" branch matches.
+
+- [ ] **Step 5: Extend the `phase_end` event type in `src/types.ts`**
+
+Locate the `phase_end` variant on the `LogEvent` union (around line 279) and add the optional field:
+
+```typescript
+| (LogEventBase & {
+    event: 'phase_end';
+    phase: number;
+    attemptId?: string | null;
+    status: 'completed' | 'failed';
+    durationMs: number;
+    details?: { reason: string };
+    claudeTokens?: ClaudeTokens | null;
+    codexTokens?: ClaudeTokens | null;
+    uncommittedRepos?: Array<{ path: string; count: number }>;
+  })
+```
+
+- [ ] **Step 6: Run typecheck and tests**
+
+```bash
+pnpm tsc --noEmit
+pnpm vitest run tests/phases/interactive.test.ts -t "uncommitted-changes detection"
+pnpm vitest run tests/phases/runner.test.ts
+```
+
+Expected: typecheck PASS; the three new test cases PASS; existing runner tests still PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/phases/interactive.ts src/phases/runner.ts src/types.ts tests/phases/interactive.test.ts
+git commit -m "feat(phase5): surface Codex uncommitted-changes failure (#84)
+
+When Phase 5 fails with a fresh sentinel under a Codex preset and the
+working tree is dirty, write a stderr warn and attach uncommittedRepos
+to the phase_end log event. Detection-only — no auto-commit fallback."
+```
+
+---
+
+## Task 3 — Documentation sync
+
+**Files:**
+- Modify: `docs/HOW-IT-WORKS.md`
+- Modify: `docs/HOW-IT-WORKS.ko.md`
+- Modify: `CLAUDE.md` (events.jsonl schema table)
+- Inspect: `README.md`, `README.ko.md`
+
+- [ ] **Step 1: Update `docs/HOW-IT-WORKS.md`**
+
+Locate the Phase 5 section (search for "Phase 5" success criteria / "implRetryBase" / "HEAD has advanced"). Add this paragraph immediately after the existing success-criteria description:
+
+```markdown
+**Codex preset on Phase 5 — commit-discipline trap.** Phase 5 only treats an
+attempt as completed when at least one tracked repo's HEAD advances past
+`implRetryBase`. Codex sometimes finishes the work and writes the sentinel but
+forgets to commit — leaving the validator to read "no advance" and report
+`failed`. When the harness detects this exact case (sentinel fresh + working
+tree dirty under a Codex preset), it writes a `⚠️  Phase 5 failed: Codex
+completed … but left uncommitted changes` block to stderr and attaches
+`uncommittedRepos: [{ path, count }, …]` on the `phase_end` log event so
+operators can either (a) commit the changes manually and Resume, or (b)
+switch the Phase 5 preset to a Claude variant (e.g. `claude-sonnet-default`)
+which has commit-discipline guards via `superpowers:subagent-driven-development`.
+The Claude branch does not have this trap.
+```
+
+- [ ] **Step 2: Mirror the change in `docs/HOW-IT-WORKS.ko.md`**
+
+Same paragraph, translated. Locate the equivalent Phase 5 section, add directly after the success-criteria description:
+
+```markdown
+**Codex 프리셋 + Phase 5 — commit 누락 함정.** Phase 5는 적어도 하나의 tracked
+repo의 HEAD가 `implRetryBase`를 넘어 진전했을 때만 완료로 간주한다. Codex가
+구현은 마치고 sentinel은 남겼지만 commit을 빠뜨리는 경우가 있는데, validator
+입장에서는 "진전 없음 = failed"로 보인다. harness는 이 케이스(Codex preset +
+sentinel fresh + working tree dirty)를 정확히 검출하면 stderr에 `⚠️  Phase 5
+failed: Codex completed … but left uncommitted changes` 블록을 출력하고,
+`phase_end` 이벤트에 `uncommittedRepos: [{ path, count }, …]` 필드를 부착해서
+operator가 (a) 직접 commit 후 Resume하거나, (b) Phase 5 프리셋을 Claude 계열
+(예: `claude-sonnet-default`)로 전환할 수 있도록 안내한다. Claude 브랜치는
+`superpowers:subagent-driven-development`가 commit 규율을 강제하므로 이 함정에
+빠지지 않는다.
+```
+
+- [ ] **Step 3: Update `CLAUDE.md` events table**
+
+Locate the events table row for `phase_end` (search for `phase_end` in the table). Append `uncommittedRepos?: Array<{ path: string; count: number }>` to the field list, with a brief gloss matching the existing 3-state pattern, e.g.:
+
+```markdown
+| `phase_end` | `phase`, `attemptId`, `status`, `durationMs`, **`claudeTokens?: { input, output, cacheRead, cacheCreate, total } \| null`** (PR #16 — interactive 1/3/5 + `preset.runner === 'claude'` 실자 페이즈만; codex/redirect-by-signal 분기는 필드 자체 생략), **`uncommittedRepos?: Array<{ path: string; count: number }>`** (#84 — Phase 5 + codex runner + sentinel fresh + dirty tree에서만 발현; 그 외 분기는 필드 자체 생략) |
+```
+
+- [ ] **Step 4: Inspect `README.md` and `README.ko.md`**
+
+Run:
+
+```bash
+grep -n "Phase 5\|phasePresets\|codex-high\|claude-sonnet" README.md README.ko.md | head -30
+```
+
+If existing sections describe Phase 5 preset selection or commit semantics, add a one-liner pointing readers to the HOW-IT-WORKS callout. If neither README touches Phase 5 preset choice, leave them alone — the README should not enumerate every edge case (see CLAUDE.md doc-sync clause: "문서 영향이 없다고 판단한 경우에도 PR/커밋 설명에 ... 문서 변경 불필요라는 취지의 근거를 남긴다").
+
+- [ ] **Step 5: Commit**
+
+If both READMEs needed edits:
+
+```bash
+git add docs/HOW-IT-WORKS.md docs/HOW-IT-WORKS.ko.md CLAUDE.md README.md README.ko.md
+```
+
+If READMEs were unchanged:
+
+```bash
+git add docs/HOW-IT-WORKS.md docs/HOW-IT-WORKS.ko.md CLAUDE.md
+```
+
+Then:
+
+```bash
+git commit -m "docs(phase5): document codex commit-discipline trap (#84)
+
+Update HOW-IT-WORKS.{md,ko.md} and CLAUDE.md events table to describe
+the new uncommitted-changes detection. README scan: <unchanged|note added>."
+```
+
+---
+
+## Task 4 — Final validation
+
+**Files:** none modified; runs full validation suite.
+
+- [ ] **Step 1: Run full typecheck**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: zero errors.
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+pnpm vitest run
+```
+
+Expected: all tests pass. If anything else broke, fix it before proceeding (do NOT commit a workaround).
+
+- [ ] **Step 3: Run full build**
+
+```bash
+pnpm build
+```
+
+Expected: success; `dist/` updated.
+
+- [ ] **Step 4: Smoke-check the new helper from a quick REPL**
+
+```bash
+node -e "
+const { detectUncommittedChanges } = require('./dist/git.js');
+console.log(detectUncommittedChanges([process.cwd()]));
+"
+```
+
+Expected: prints `[]` if the worktree is clean (the plan/spec/code commits should have left it clean), or one entry if anything is uncommitted. Either way, no throw.
+
+- [ ] **Step 5: Push branch and open PR**
+
+```bash
+git push -u origin hung-fix
+gh pr create --title "fix(phase5): surface Codex uncommitted-changes failure" --body "$(cat <<'EOF'
+## Summary
+
+Closes #84.
+
+When `phasePresets["5"]` resolves to a Codex preset and Codex finishes the
+work but forgets to commit, the harness used to silently re-loop on
+`failed` because `validatePhaseArtifacts(5)` only checks HEAD advancement.
+This PR adds detection-only surfacing: a stderr warn block and an
+`uncommittedRepos?` field on the `phase_end` log event, fired only when
+all five trigger conditions hold (P5 + Codex runner + result=failed +
+sentinel fresh + working tree dirty in any tracked repo).
+
+Auto-commit fallback was deliberately rejected — see the spec's "Out of
+scope" section for the full rationale.
+
+- Spec: `docs/specs/2026-04-25-codex-phase5-uncommitted-detection-design.md`
+- Plan: `docs/plans/2026-04-25-codex-phase5-uncommitted-detection.md`
+
+## Test plan
+
+- [x] `pnpm tsc --noEmit`
+- [x] `pnpm vitest run` (full suite)
+- [x] `pnpm build`
+- [x] New unit tests for `detectUncommittedChanges` (4 cases)
+- [x] New integration tests for the detection branch (3 cases: P5+codex+dirty / P5+codex+clean / P5+claude+dirty)
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Trigger conditions (5 clauses) → Task 2, Step 3 (d). UX block → Task 2, Step 3 (c). Telemetry field → Task 2, Steps 4–5. Helper → Task 1. Tests → Task 1 + Task 2 Step 1. Docs → Task 3. Out-of-scope items remain out (no auto-commit, no prompt edits, no preset rejection).
+- **Type consistency:** `UncommittedRepo` interface lives in `src/git.ts`, exported and re-imported in `src/phases/interactive.ts`; the `phase_end` event type uses the inline shape `Array<{ path: string; count: number }>` which is structurally identical (both are `{ path: string; count: number }`).
+- **No placeholders:** every code step has the exact code; commit messages are real; commands have expected output.

--- a/docs/specs/2026-04-25-codex-phase5-uncommitted-detection-design.md
+++ b/docs/specs/2026-04-25-codex-phase5-uncommitted-detection-design.md
@@ -1,0 +1,196 @@
+# Spec — Codex Phase 5 uncommitted-changes detection
+
+**Date**: 2026-04-25
+**Issue**: [#84](https://github.com/DongGukMon/harness-cli/issues/84) — Phase 5 with codex preset loops failed when Codex skips git commit
+**Related code**:
+- `src/phases/interactive.ts` (Codex P5 dispatch + `validatePhaseArtifacts`)
+- `src/phases/runner.ts` (`phase_end` event emission)
+- `src/git.ts` (git helpers)
+
+## Problem
+
+When `phasePresets["5"]` resolves to a Codex preset, Phase 5 silently loops on `failed`
+even when Codex (a) edited many files and (b) wrote a fresh `phase-5.done` sentinel
+matching the current `attemptId`. `validatePhaseArtifacts(5)` only succeeds when HEAD
+has advanced past `implRetryBase`, and `preparePhase` re-snaps `implRetryBase` to the
+current HEAD on every retry. So a Codex impl session that ends with uncommitted edits
+is indistinguishable from a no-op to the validator, and the operator gets no signal
+pointing at the missing commit. The dogfood report (issue #84) burned 4 attempts /
+~20 min before the cause was identified.
+
+The Claude interactive branch does not hit this because `superpowers:subagent-driven-development`
+enforces commits. The Codex branch has no equivalent guard.
+
+## Goal
+
+Make the failure mode visible. When Codex finishes a P5 attempt with the sentinel
+fresh but the working tree dirty, surface a clear message (stderr) and a structured
+event field (`events.jsonl`) so the operator knows exactly what to do — either commit
+manually and resume, or switch the preset for P5 to a Claude variant.
+
+This spec deliberately does **not** auto-recover. Auto-commit fallback is rejected
+(see Out of Scope) because it relies on later phases catching bad code, and false-positive
+commits would silently corrupt the run history.
+
+## Trigger conditions
+
+A new "uncommitted-changes" notice fires only when **all** of the following hold:
+
+1. `phase === 5`
+2. `preset.runner === 'codex'` (Claude branch unaffected)
+3. The phase result is `failed` (validation rejected the attempt)
+4. The sentinel file `phase-5.done` is *fresh* per `checkSentinelFreshness` —
+   i.e., its content equals the current `attemptId`. This proves Codex itself
+   declared completion. A stale/missing sentinel is a different failure mode
+   (Codex crash / no completion claim) and uses the existing failure path.
+5. At least one repo in `state.trackedRepos` has a non-empty `git status --porcelain`
+   output.
+
+When any of (1)–(5) is false, the existing failure path runs unchanged.
+
+## UX — stderr message
+
+On detection, write a single English block to stderr (matching the language of
+existing operator-facing warns and `events.jsonl` field labels):
+
+```
+⚠️  Phase 5 failed: Codex completed (sentinel fresh) but left uncommitted changes:
+    <repo path 1> — N files
+    <repo path 2> — M files
+
+  Resolve by:
+    • Commit the changes manually, then Resume; or
+    • Re-run with a Claude preset for phase 5 (e.g. claude-sonnet-default).
+```
+
+Written once per failed attempt via `process.stderr.write` (not `console.warn`,
+to avoid interleaving with structured logger output). No ANSI coloring. Goes to
+stderr unconditionally so operators see it even when `--enable-logging` is off.
+
+## Telemetry — events.jsonl
+
+Extend the existing `phase_end` event with an optional field (no new event type):
+
+```ts
+phase_end: {
+  // ... existing fields
+  uncommittedRepos?: Array<{ path: string; count: number }>;
+}
+```
+
+Field semantics:
+- Present (non-empty array) only when all 5 trigger conditions hold.
+- Absent in every other case (Claude runs, non-P5 phases, clean working tree, etc.).
+- `path` is the repo root absolute path; `count` is the line count of
+  `git status --porcelain` (one-line-per-change convention).
+
+The optional-field pattern matches the existing `claudeTokens?` 3-state contract
+(present-on-applicable / absent-on-non-applicable / null-on-extraction-failure),
+except here there is no "failure" state — git status is either non-empty or not.
+
+CLAUDE.md's events table is updated to reflect this new field.
+
+## Implementation outline
+
+### New helper: `src/git.ts`
+
+```ts
+export interface UncommittedRepo {
+  path: string;
+  count: number;
+}
+
+export function detectUncommittedChanges(
+  repoPaths: string[],
+): UncommittedRepo[];
+```
+
+- Runs `git -C <path> status --porcelain` for each repo.
+- Counts non-empty lines.
+- Returns only repos with `count > 0`.
+- Swallows per-repo errors (e.g. non-git path) silently; treats them as `count: 0`.
+- Pure synchronous wrapper over `execSync` to match other helpers in `git.ts`.
+
+### Detection site: `src/phases/interactive.ts`
+
+Widen the existing `InteractiveResult` interface to include an optional
+`uncommittedRepos?: UncommittedRepo[]` field, then in the Codex branch of
+`runInteractivePhase`, after `waitForPhaseCompletion` returns and before the
+final `return { ...result, attemptId }`:
+
+```ts
+if (
+  phase === 5 &&
+  result.status === 'failed' &&
+  checkSentinelFreshness(sentinelPath, attemptId) === 'fresh'
+) {
+  const dirty = detectUncommittedChanges(state.trackedRepos.map(r => r.path));
+  if (dirty.length > 0) {
+    process.stderr.write(formatUncommittedWarn(dirty));
+    result.uncommittedRepos = dirty;
+  }
+}
+```
+
+Stash the data on the result object so `runner.ts` can read it without re-running
+git. `formatUncommittedWarn` is a small local helper that produces the block
+shown in "UX — stderr message".
+
+### Event emission: `src/phases/runner.ts`
+
+Where `phase_end` is currently emitted for the P5 interactive path, read
+`result.uncommittedRepos` (if defined) and include it in the event payload.
+
+### Type extension: `src/types.ts`
+
+Add `uncommittedRepos?: Array<{ path: string; count: number }>` to the `phase_end`
+event type. Keep it strictly optional — older log readers must keep working.
+
+## Documentation changes
+
+Per CLAUDE.md doc-sync obligation, the following are updated in the same PR:
+
+- `docs/HOW-IT-WORKS.md` + `.ko.md`: in the Phase 5 success-criteria section, add
+  a callout that Codex on P5 depends on commit discipline, and describe the new
+  notice + recommended remediation (commit + resume, or switch to Claude preset).
+- `README.md` + `.ko.md`: scan for any P5 / preset coverage; add a one-line note
+  if the existing sections cover Codex-on-P5. If they do not, add nothing — this
+  is a niche failure mode and READMEs should not enumerate every edge case.
+- `CLAUDE.md`: update the events.jsonl schema table to list the new
+  `uncommittedRepos?` field on `phase_end`.
+
+## Tests
+
+- New `src/git.test.ts`: unit-test `detectUncommittedChanges` with a tmpdir git
+  repo — clean tree returns `[]`; one-file dirty tree returns one entry with
+  `count: 1`; non-git path returns `[]` without throwing.
+- `src/phases/interactive.test.ts`: extend existing P5 + Codex test path. Three
+  cases:
+  1. Codex P5 + sentinel fresh + dirty tree → `uncommittedRepos` populated on
+     result + stderr warn observed (spy on `process.stderr.write`).
+  2. Codex P5 + sentinel fresh + clean tree → no warn, field absent.
+  3. Claude P5 + dirty tree → no warn, field absent (Claude branch never calls
+     the new code).
+- `pnpm tsc --noEmit` and `pnpm vitest run` must both pass.
+
+## Out of scope (explicitly rejected)
+
+- **Auto-commit fallback** (issue suggestion #2): rejected. Relies on later phases
+  catching bad code; false-positive commits silently corrupt run history. The
+  reporter explicitly stated that even a stderr warn would have saved the run.
+- **Codex prompt enforcement** (issue suggestion #3): rejected. Codex already
+  receives the same commit instructions as Claude and ignores them. Adding more
+  prompt text without a runner-side enforcement layer does not change behavior.
+- **Reject codex-* presets for P5** (issue suggestion #4): rejected. Too aggressive
+  for a niche failure mode; users may legitimately want Codex on P5.
+- **Apply detection to Phase 1/3 / Claude branch**: rejected. Phase 1/3 do not
+  depend on commit advancement, and Claude branch has commit-discipline guards
+  via subagent-driven-development. Detection scope stays surgical to avoid
+  false positives.
+- **Opt-in `--codex-impl-auto-commit` flag**: rejected for now. YAGNI — easy to
+  add later as a separate change if real users ask. This spec only ships
+  detection + surfacing.
+
+## Complexity
+
+Small.

--- a/src/git.ts
+++ b/src/git.ts
@@ -55,6 +55,30 @@ export function isWorkingTreeClean(cwd?: string): boolean {
   }
 }
 
+export interface UncommittedRepo {
+  path: string;
+  count: number;
+}
+
+// Returns an entry for each repoPath whose `git status --porcelain` is non-empty.
+// Non-git paths and exec failures are silently treated as clean (entry omitted).
+export function detectUncommittedChanges(repoPaths: string[]): UncommittedRepo[] {
+  const out: UncommittedRepo[] = [];
+  for (const p of repoPaths) {
+    try {
+      const raw = exec('git status --porcelain', p);
+      if (raw === '') continue;
+      const count = raw.split('\n').filter((line) => line.length > 0).length;
+      if (count > 0) {
+        out.push({ path: p, count });
+      }
+    } catch {
+      // Non-git path or git failure → treat as clean.
+    }
+  }
+  return out;
+}
+
 // Returns true if any files are staged.
 export function hasStagedChanges(cwd?: string): boolean {
   try {

--- a/src/phases/interactive.ts
+++ b/src/phases/interactive.ts
@@ -5,7 +5,7 @@ import chokidar from 'chokidar';
 import type { HarnessState, InteractivePhase, Artifacts } from '../types.js';
 import { getPhaseArtifactFiles, getPresetById } from '../config.js';
 import { writeState, syncLegacyMirror } from '../state.js';
-import { getHead } from '../git.js';
+import { getHead, detectUncommittedChanges, type UncommittedRepo } from '../git.js';
 import { isPidAlive } from '../process.js';
 import { assembleInteractivePrompt } from '../context/assembler.js';
 import { runClaudeInteractive } from '../runners/claude.js';
@@ -38,6 +38,27 @@ function specHasValidComplexity(specBody: string): boolean {
 
 export interface InteractiveResult {
   status: 'completed' | 'failed';
+  /**
+   * Populated by the Codex P5 branch when (a) result.status === 'failed',
+   * (b) the sentinel is fresh (Codex declared completion), and (c) the
+   * working tree is dirty in any tracked repo. See issue #84.
+   */
+  uncommittedRepos?: UncommittedRepo[];
+}
+
+function formatUncommittedWarn(dirty: UncommittedRepo[]): string {
+  const lines = dirty.map((d) => `    ${d.path} — ${d.count} files`);
+  return [
+    '',
+    '⚠️  Phase 5 failed: Codex completed (sentinel fresh) but left uncommitted changes:',
+    ...lines,
+    '',
+    '  Resolve by:',
+    '    • Commit the changes manually, then Resume; or',
+    '    • Re-run with a Claude preset for phase 5 (e.g. claude-sonnet-default).',
+    '',
+    '',
+  ].join('\n');
 }
 
 /**
@@ -301,9 +322,25 @@ export async function runInteractivePhase(
       sentinelPath,
     });
 
-    const result = await waitForPhaseCompletion(
+    const result: InteractiveResult = await waitForPhaseCompletion(
       sentinelPath, attemptId, codexPid, phase, updatedState, cwd, runDir,
     );
+
+    // Issue #84 — when Phase 5 fails under a Codex preset and Codex itself
+    // declared completion (fresh sentinel) but the working tree is dirty in
+    // any tracked repo, surface that exact state so the operator can commit
+    // manually or switch the P5 preset to a Claude variant.
+    if (
+      phase === 5 &&
+      result.status === 'failed' &&
+      checkSentinelFreshness(sentinelPath, attemptId) === 'fresh'
+    ) {
+      const dirty = detectUncommittedChanges(updatedState.trackedRepos.map((r) => r.path));
+      if (dirty.length > 0) {
+        process.stderr.write(formatUncommittedWarn(dirty));
+        result.uncommittedRepos = dirty;
+      }
+    }
 
     try { clearLockChild(harnessDir); } catch { /* best-effort */ }
     updatedState.lastWorkspacePid = null;

--- a/src/phases/runner.ts
+++ b/src/phases/runner.ts
@@ -507,6 +507,10 @@ export async function handleInteractivePhase(
         status: 'failed',
         durationMs: Date.now() - phaseStartTs,
         ...(failedTokens !== undefined ? { claudeTokens: failedTokens } : {}),
+        // Issue #84 — Codex P5 sentinel-fresh + dirty-tree case only.
+        ...(result.uncommittedRepos !== undefined && result.uncommittedRepos.length > 0
+          ? { uncommittedRepos: result.uncommittedRepos }
+          : {}),
       });
     }
   } catch (err) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -276,7 +276,7 @@ export type LogEvent =
   | (LogEventBase & { event: 'escalation'; phase: number; reason: 'gate-retry-limit' | 'gate-error' | 'verify-limit' | 'verify-error'; userChoice?: 'C' | 'S' | 'Q' | 'R' })
   | (LogEventBase & { event: 'force_pass'; phase: number; by: 'auto' | 'user' })
   | (LogEventBase & { event: 'verify_result'; passed: boolean; retryIndex: number; durationMs: number; failedChecks?: string[] })
-  | (LogEventBase & { event: 'phase_end'; phase: number; attemptId?: string | null; status: 'completed' | 'failed'; durationMs: number; details?: { reason: string }; claudeTokens?: ClaudeTokens | null; codexTokens?: ClaudeTokens | null })
+  | (LogEventBase & { event: 'phase_end'; phase: number; attemptId?: string | null; status: 'completed' | 'failed'; durationMs: number; details?: { reason: string }; claudeTokens?: ClaudeTokens | null; codexTokens?: ClaudeTokens | null; uncommittedRepos?: Array<{ path: string; count: number }> })
   | (LogEventBase & { event: 'state_anomaly'; kind: string; details: Record<string, unknown> })
   | (LogEventBase & {
       event: 'ui_render';

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -14,6 +14,7 @@ import {
   getStagedFiles,
   generateRunId,
   isPathGitignored,
+  detectUncommittedChanges,
 } from '../src/git.js';
 
 describe('getGitRoot', () => {
@@ -256,6 +257,53 @@ describe('isPathGitignored', () => {
       expect(isPathGitignored('anything.md', tmpDir)).toBe(false);
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('detectUncommittedChanges', () => {
+  let repo: { path: string; cleanup: () => void };
+
+  beforeEach(() => {
+    repo = createTestRepo();
+  });
+
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  it('returns [] for a clean repo', () => {
+    expect(detectUncommittedChanges([repo.path])).toEqual([]);
+  });
+
+  it('reports dirty repo with line count', () => {
+    writeFileSync(join(repo.path, 'a.txt'), 'a');
+    writeFileSync(join(repo.path, 'b.txt'), 'b');
+    const result = detectUncommittedChanges([repo.path]);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe(repo.path);
+    expect(result[0].count).toBe(2);
+  });
+
+  it('returns [] for a non-git path without throwing', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'no-git-uncommit-'));
+    try {
+      expect(detectUncommittedChanges([tmpDir])).toEqual([]);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports each dirty repo separately when given multiple paths', () => {
+    const repo2 = createTestRepo();
+    try {
+      writeFileSync(join(repo.path, 'x.txt'), 'x');
+      writeFileSync(join(repo2.path, 'y.txt'), 'y');
+      const result = detectUncommittedChanges([repo.path, repo2.path]);
+      expect(result).toHaveLength(2);
+      expect(result.map(r => r.count)).toEqual([1, 1]);
+    } finally {
+      repo2.cleanup();
     }
   });
 });

--- a/tests/phases/interactive.test.ts
+++ b/tests/phases/interactive.test.ts
@@ -939,6 +939,106 @@ describe('runInteractivePhase — codex-interactive branch invokes codex isolati
   });
 });
 
+// ─── runInteractivePhase — Codex P5 uncommitted-changes detection (#84) ─────
+
+describe('runInteractivePhase — Codex P5 uncommitted-changes detection (#84)', () => {
+  it('attaches uncommittedRepos and writes stderr warn when working tree is dirty', async () => {
+    const { runInteractivePhase } = await import('../../src/phases/interactive.js');
+
+    const runDir = makeTmpDir();
+    const harnessDir = makeTmpDir();
+    const repoDir = createTestRepo();
+
+    // Pollute working tree (uncommitted file) BEFORE running phase.
+    fs.writeFileSync(path.join(repoDir, 'dirty.txt'), 'wip\n');
+
+    const head = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+    const state = makeState({
+      tmuxSession: 'test-session',
+      tmuxWorkspacePane: '%1',
+      tmuxControlPane: '%0',
+      phasePresets: { ...createInitialState('r', 't', 'b', false).phasePresets, '5': 'codex-high' },
+      codexNoIsolate: true,
+      baseCommit: head,
+      implRetryBase: head,
+    });
+    state.trackedRepos = [{ path: repoDir, baseCommit: head, implRetryBase: head, implHead: null }];
+
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const result = await runInteractivePhase(5, state, harnessDir, runDir, repoDir, 'attempt-uncommitted');
+      expect(result.status).toBe('failed');
+      expect(result.uncommittedRepos).toEqual([{ path: repoDir, count: 1 }]);
+      const writes = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(writes).toMatch(/Codex completed \(sentinel fresh\) but left uncommitted changes/);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it('does NOT warn when Codex P5 fails with a clean working tree', async () => {
+    const { runInteractivePhase } = await import('../../src/phases/interactive.js');
+
+    const runDir = makeTmpDir();
+    const harnessDir = makeTmpDir();
+    const repoDir = createTestRepo();
+    // No pollution — tree stays clean.
+
+    const head = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+    const state = makeState({
+      tmuxSession: 'test-session',
+      tmuxWorkspacePane: '%1',
+      tmuxControlPane: '%0',
+      phasePresets: { ...createInitialState('r', 't', 'b', false).phasePresets, '5': 'codex-high' },
+      codexNoIsolate: true,
+      baseCommit: head,
+      implRetryBase: head,
+    });
+    state.trackedRepos = [{ path: repoDir, baseCommit: head, implRetryBase: head, implHead: null }];
+
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const result = await runInteractivePhase(5, state, harnessDir, runDir, repoDir, 'attempt-clean');
+      expect(result.status).toBe('failed');
+      expect(result.uncommittedRepos).toBeUndefined();
+      const writes = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(writes).not.toMatch(/uncommitted changes/);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it('does NOT warn for Claude P5 even when the tree is dirty (Claude branch never reaches the new code path)', async () => {
+    const { runInteractivePhase } = await import('../../src/phases/interactive.js');
+
+    const runDir = makeTmpDir();
+    const harnessDir = makeTmpDir();
+    const repoDir = createTestRepo();
+    fs.writeFileSync(path.join(repoDir, 'dirty.txt'), 'wip\n');
+
+    const head = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf-8' }).trim();
+    // Default phase 5 preset is a Claude variant.
+    const state = makeState({
+      tmuxSession: 'test-session',
+      tmuxWorkspacePane: '%1',
+      tmuxControlPane: '%0',
+      baseCommit: head,
+      implRetryBase: head,
+    });
+    state.trackedRepos = [{ path: repoDir, baseCommit: head, implRetryBase: head, implHead: null }];
+
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const result = await runInteractivePhase(5, state, harnessDir, runDir, repoDir, 'attempt-claude');
+      expect(result.uncommittedRepos).toBeUndefined();
+      const writes = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(writes).not.toMatch(/uncommitted changes/);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+});
+
 describe('validatePhaseArtifacts — Phase 5 multi-repo (FR-6, ADR-D4)', () => {
   it('returns true when any repo advanced; sets implHead on advanced repos only', () => {
     const outer = makeTmpDir();


### PR DESCRIPTION
## Summary

Closes #84.

When `phasePresets["5"]` resolves to a Codex preset and Codex finishes the work but forgets to commit, the harness used to silently re-loop on `failed` because `validatePhaseArtifacts(5)` only checks HEAD advancement. This PR adds detection-only surfacing:

- A stderr warn block (`⚠️  Phase 5 failed: Codex completed (sentinel fresh) but left uncommitted changes: …`) listing each dirty repo with its file count, plus two suggested remediations (manual commit + Resume / switch to a Claude preset).
- An optional `uncommittedRepos: Array<{ path, count }>` field on the `phase_end` log event.

The detection fires only when **all** of the following hold: `phase === 5`, `preset.runner === 'codex'`, `result.status === 'failed'`, sentinel is fresh per `checkSentinelFreshness` (Codex itself declared completion), and at least one tracked repo has a non-empty `git status --porcelain`. In every other case the existing failure path runs unchanged.

Auto-commit fallback was deliberately rejected — it depends on later phases catching bad code, and false-positive commits would silently corrupt run history. The reporter's own observation ("Even a single stderr warn + an `events.jsonl` entry would have saved this run") matches the design.

- Spec: `docs/specs/2026-04-25-codex-phase5-uncommitted-detection-design.md`
- Plan: `docs/plans/2026-04-25-codex-phase5-uncommitted-detection.md`

## Test plan

- [x] `pnpm tsc --noEmit` (clean)
- [x] `pnpm vitest run` — 1043 passed, 1 skipped (full suite)
- [x] `pnpm build` (dist regenerated)
- [x] Smoke-check via `node -e "require('./dist/src/git.js').detectUncommittedChanges([process.cwd()])"` returns `[]` on a clean tree
- [x] New unit tests for `detectUncommittedChanges` (4 cases: clean / dirty / non-git / multi-repo)
- [x] New integration tests for the detection branch (3 cases: P5+codex+dirty fires warn+field; P5+codex+clean stays quiet; P5+claude+dirty stays quiet — Claude branch never enters the new code path)