### PR TITLE
feat(tui): top-bottom workspace split and Ink control pane polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 node_modules/
 dist/
+build/
 .harness/
 *.tsbuildinfo
+__pycache__/
+.pytest_cache/
+.venv/
 .idea/
 .omx/
 .DS_Store

--- a/README.ko.md
+++ b/README.ko.md
@@ -67,9 +67,9 @@ light flow에서는:
 
 ## tmux 안에서의 실행 구조
 
-Harness는 tmux 안에 **pane 기반 control surface**를 만듭니다:
-- **control pane**: 현재 phase, retry, gate/verify 출력, escalation 메뉴
-- **workspace pane**: 현재 interactive agent 세션
+Harness는 tmux 안에 **상하 분할 pane 기반 control surface**를 만듭니다:
+- **상단 control pane**: 현재 phase, retry, gate/verify 출력, escalation 메뉴
+- **하단 workspace pane**: 현재 interactive agent 세션이며, 터미널 높이 대부분을 사용합니다
 
 Gate phase(2, 4, 7)는 interactive phase와 동일한 workspace pane에서 Codex CLI를 대화형 TUI로 실행합니다. Codex는 판정 결과를 `<runDir>/gate-N-verdict.md`에 기록하고, harness는 `<runDir>/phase-N.done`으로 완료를 감지합니다. gate 실행 중에는 footer에 `attach: tmux attach -t <session>`이 표시되므로 실시간으로 리뷰를 확인할 수 있습니다.
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ In light flow:
 
 ## Runtime layout inside tmux
 
-Harness runs the workflow inside tmux with a split-pane control surface:
-- **control pane**: current phase, retries, gate/verify output, escalation menus
-- **workspace pane**: the active interactive agent session
+Harness runs the workflow inside tmux with a top-bottom split-pane control surface:
+- **top control pane**: current phase, retries, gate/verify output, escalation menus
+- **bottom workspace pane**: the active interactive agent session, with most of the terminal height
 
 Gate phases (2, 4, 7) run Codex CLI as an interactive TUI in the workspace pane (the same pane used by interactive phases). Codex writes its verdict to `<runDir>/gate-N-verdict.md` and harness detects completion via `<runDir>/phase-N.done`. While a gate is running, the footer shows `attach: tmux attach -t <session>` so you can watch the review live.
 

--- a/docs/plans/2026-04-25-untitled-598d.md
+++ b/docs/plans/2026-04-25-untitled-598d.md
@@ -1,0 +1,202 @@
+# Phase-Harness TUI Polish And Top-Bottom Layout - Implementation Plan
+
+> For agentic workers: implement this plan task by task. Keep edits scoped to the listed files and preserve phase lifecycle, runner, state, sentinel, logging, and retry semantics.
+
+**Related:**
+- Spec: `docs/specs/2026-04-25-untitled-598d-design.md`
+- Decisions: `.harness/2026-04-25-untitled-598d/decisions.md`
+
+**Complexity:** Medium. No injected Complexity Directive block was present, and the spec also declares Medium, so this plan uses standard depth with no Small/Large-specific constraints.
+
+**Goal:** Replace the default side-by-side tmux workspace split with a top control pane and bottom workspace pane, then polish the existing Ink control panel so it is easier to scan without changing harness lifecycle behavior.
+
+**Architecture:** Keep `renderControlPanel` as the public facade into `renderInkControlPanel`. `innerCommand` continues to own pane setup and state persistence; only the default workspace pane creation direction/percentage changes. The Ink UI remains the existing component tree, with clearer section order and component-level formatting improvements. Tests cover both pane behavior and rendered control-pane output, including narrow terminal behavior.
+
+**Tech Stack:** TypeScript, Node.js, tmux, Ink/React, ink-testing-library, Vitest.
+
+## Dependency Order
+
+1. Change tmux split behavior first because it defines the runtime layout and has isolated command-level tests.
+2. Polish the Ink shell and components next because they depend on the new compact top-pane assumption.
+3. Update docs after implementation wording is settled.
+4. Run the focused verification set and the README wording grep before handing off.
+
+## File Structure
+
+**Modified files:**
+- `src/commands/inner.ts` - create the default workspace pane below the control pane with a vertical split and a stable 65-75 percent workspace height.
+- `src/ink/App.tsx` - compose the control pane into the required regions with lighter section treatment.
+- `src/ink/theme.ts` - add only minimal labels/glyph helpers if needed for clearer monochrome output.
+- `src/ink/components/Header.tsx` - product name, flow badge, run id, elapsed time.
+- `src/ink/components/PhaseTimeline.tsx` - compact full/light phase progress with narrow labels.
+- `src/ink/components/CurrentPhase.tsx` - current phase status, model/runner/effort, retry count.
+- `src/ink/components/GateVerdict.tsx` - recent gate outcome summary when available.
+- `src/ink/components/ActionMenu.tsx` - in-progress, terminal-complete, and terminal-failed action/status row.
+- `src/ink/components/Footer.tsx` - footer metrics and attach hint that fit narrow terminals.
+- `README.md` - document top control pane and bottom workspace pane, retaining manual attach behavior.
+- `README.ko.md` - same runtime layout update in Korean docs.
+- `tests/commands/inner.test.ts` - assert vertical split creation and persisted workspace pane id.
+- `tests/tmux.test.ts` - keep both `h` and `v` split utility coverage passing.
+- `tests/ink/render.test.ts` - facade/telemetry remains stable; add root layout coverage if needed.
+- `tests/ink/components/*.test.tsx` - cover polished section behavior and at least one narrow-width case.
+
+**Unchanged by design:**
+- `src/state.ts`, state schema, phase ordering, pending action routing, gate/verify retry semantics, runner command injection, sentinel names, non-TTY fallback, and `ui_render` callsite values.
+
+## Task 1: Switch Default Workspace Pane Creation To Top-Bottom
+
+**Files:**
+- Modify: `src/commands/inner.ts`
+- Modify: `tests/commands/inner.test.ts`
+- Verify: `tests/tmux.test.ts`
+
+**Implementation steps:**
+- In `innerCommand`, keep the existing validation sequence:
+  - require `--control-pane`
+  - assign `state.tmuxControlPane`
+  - compute `controlValid`
+  - compute `workspaceValid` as existing, valid, and distinct from the control pane
+- When `controlValid && workspaceValid`, keep the no-op reuse path unchanged.
+- When `controlValid` and the workspace pane is missing, invalid, or equal to the control pane, call `splitPane(state.tmuxSession, controlPaneId, 'v', 70, cwd)` or another stable value in the 65-75 range.
+- Store the returned pane id in `state.tmuxWorkspacePane` and write state as before.
+- Do not change the fatal error text or exit behavior when the control pane is invalid.
+- Do not change `state.tmuxControlPane`, `state.tmuxWorkspacePane`, or runner injection semantics.
+
+**Acceptance criteria:**
+- A new run or resume with no valid distinct workspace pane creates a bottom workspace pane by requesting a vertical tmux split.
+- The workspace split percentage is in the 65-75 range so the workspace receives most terminal height.
+- A valid distinct stored pane pair is reused and does not call `splitPane`.
+- An invalid control pane still prints `Fatal: control pane <id> does not exist.` and exits.
+- State persists the returned workspace pane id.
+
+**Validation:**
+- `./node_modules/.bin/vitest run tests/commands/inner.test.ts tests/tmux.test.ts`
+- Add or update an `innerCommand` test that mocks `paneExists`/`splitPane` and asserts the call includes `'v'`, the chosen percent, and `cwd`.
+- Keep the existing `splitPane` utility tests for both `h` and `v` flags passing.
+
+## Task 2: Restructure The Ink Control Pane Into Clear Regions
+
+**Files:**
+- Modify: `src/ink/App.tsx`
+- Modify: `src/ink/theme.ts` only if small helpers are needed
+- Modify: `tests/ink/render.test.ts`
+- Modify or add focused component tests under `tests/ink/components`
+
+**Implementation steps:**
+- Keep `renderControlPanel` delegating to `renderInkControlPanel`; do not change the public facade.
+- Keep `renderInkControlPanel` telemetry behavior and non-TTY plain stderr fallback unchanged.
+- Recompose `App` so the visible regions appear in this order:
+  1. header
+  2. phase timeline/progress
+  3. current phase summary
+  4. gate verdict or recent outcome summary when available
+  5. action/status row
+  6. footer metrics and attach hint when available
+- Replace the repeated dot-line separator between every component with lighter treatment:
+  - prefer spacing, compact labels, or at most one subtle divider between major groups
+  - avoid the raw-log stacked look from multiple identical divider rows
+- Use existing `COLORS` and `GLYPHS` where possible. If new glyphs are added, pair them with text labels so monochrome terminals remain meaningful.
+- Keep layout stable for top-pane use; avoid extra blank rows that would crowd the workspace.
+
+**Acceptance criteria:**
+- Rendered output follows the required region order.
+- Repeated dot-line separators are removed or reduced to a single subtle divider.
+- `ui_render` events still emit with the same callsite values from `renderInkControlPanel`.
+- Non-TTY rendering still writes a plain `[harness] phase=<n> status=<status>` stderr line and does not mount Ink.
+- No lifecycle/state/runner behavior changes are introduced.
+
+**Validation:**
+- `./node_modules/.bin/vitest run tests/ink/render.test.ts tests/ink/components`
+- Add root or component assertions that the header appears before the timeline, current phase, action row, and footer.
+- Add a regression assertion that the rendered frame is not dominated by repeated separator-only rows.
+
+## Task 3: Polish Header, Timeline, Current Phase, Gate Verdict, And Actions
+
+**Files:**
+- Modify: `src/ink/components/Header.tsx`
+- Modify: `src/ink/components/PhaseTimeline.tsx`
+- Modify: `src/ink/components/CurrentPhase.tsx`
+- Modify: `src/ink/components/GateVerdict.tsx`
+- Modify: `src/ink/components/ActionMenu.tsx`
+- Modify: relevant tests under `tests/ink/components`
+
+**Implementation steps:**
+- Header:
+  - show product name, flow badge, run id, and elapsed time when available
+  - truncate long run ids instead of allowing wide overflow
+- Phase timeline:
+  - preserve full-flow and light-flow phase membership
+  - show meaningful status labels/icons for completed, in-progress, failed/error, skipped, and pending phases
+  - below 60 columns, collapse labels to phase numbers or similarly compact labels
+- Current phase:
+  - show phase number, label, and status
+  - include preset model/runner/effort when applicable
+  - include retry count when applicable, especially for gate phases
+  - make in-progress phases clearly say the harness is waiting for phase completion
+- Gate verdict:
+  - show the most recent gate approval/rejection summary when available
+  - keep the row compact for non-gate states
+- Action/status row:
+  - terminal-complete state clearly says the run is complete and how to exit
+  - terminal-failed state keeps `[R] Resume`, `[J] Jump`, and `[Q] Quit` visible and prominent
+  - in-progress states do not advertise terminal actions prematurely
+
+**Acceptance criteria:**
+- Header tests cover title, flow badge, run id truncation, and elapsed time.
+- Timeline tests cover full and light phase sets plus a narrow-width case below 60 columns.
+- Current phase tests cover status, model/runner/effort, retry count, and waiting-for-completion text.
+- Gate verdict tests cover approved/rejected summaries and hidden/compact behavior when no gate outcome exists.
+- Action tests cover terminal-complete, terminal-failed, in-progress waiting, and failed-but-not-terminal behavior.
+- Long fields do not produce broken output in component tests using narrow column values.
+
+**Validation:**
+- `./node_modules/.bin/vitest run tests/ink/components/Header.test.tsx tests/ink/components/PhaseTimeline.test.tsx tests/ink/components/CurrentPhase.test.tsx tests/ink/components/GateVerdict.test.tsx tests/ink/components/ActionMenu.test.tsx`
+- Manually inspect one rendered component test frame or add an assertion fixture that captures the narrow frame for regressions.
+
+## Task 4: Polish Footer, Update Runtime Layout Docs, And Finalize Verification
+
+**Files:**
+- Modify: `src/ink/components/Footer.tsx`
+- Modify: `tests/ink/components/Footer.test.tsx`
+- Modify: `README.md`
+- Modify: `README.ko.md`
+
+**Implementation steps:**
+- Footer:
+  - preserve existing metrics from `FooterSummary`
+  - preserve the tmux attach hint when `tmuxSession` is available
+  - make narrow output compact so attach hints or metric lines do not break the control pane
+- Documentation:
+  - update the runtime layout section to say the control pane is on top and the workspace pane is below it
+  - mention that the workspace pane receives most of the terminal height
+  - keep the manual `tmux attach -t <session>` behavior documented
+  - remove wording that describes the runtime layout as left-right or side-by-side
+- Final verification:
+  - run lint/typecheck
+  - run focused tmux and Ink test commands
+  - run a README wording grep to prevent old layout wording from surviving
+
+**Acceptance criteria:**
+- Footer tests cover wide metrics, compact metrics, attach hint, and null summary behavior.
+- README and README.ko describe a top control pane and bottom workspace pane.
+- README and README.ko still include the manual tmux attach command.
+- README and README.ko do not describe the runtime layout as left-right or side-by-side.
+- All checklist commands pass before the implementation phase is considered complete.
+
+**Validation:**
+- `./node_modules/.bin/tsc --noEmit`
+- `./node_modules/.bin/vitest run tests/commands/inner.test.ts tests/tmux.test.ts`
+- `./node_modules/.bin/vitest run tests/ink/render.test.ts tests/ink/components`
+- `!/usr/bin/grep -E -n "left[- ]right|side[- ]by[- ]side" README.md README.ko.md`
+
+## Final Checklist For Implementer
+
+- [ ] `innerCommand` uses `splitPane(..., 'v', <65-75>, cwd)` only when a valid distinct workspace pane is not reusable.
+- [ ] Control pane region order matches the spec.
+- [ ] Terminal-complete, terminal-failed, and in-progress messages are explicit.
+- [ ] Narrow-width Ink tests cover labels and long fields.
+- [ ] README and README.ko describe top/bottom layout and retain manual attach instructions.
+- [ ] `./node_modules/.bin/tsc --noEmit` passes.
+- [ ] `./node_modules/.bin/vitest run tests/commands/inner.test.ts tests/tmux.test.ts` passes.
+- [ ] `./node_modules/.bin/vitest run tests/ink/render.test.ts tests/ink/components` passes.
+- [ ] README grep for old side-by-side layout wording passes.

--- a/docs/process/evals/2026-04-25-tui-v2-eval.md
+++ b/docs/process/evals/2026-04-25-tui-v2-eval.md
@@ -1,0 +1,141 @@
+# Auto Verification Report
+- Date: 2026-04-25
+- Related Spec: N/A
+- Related Plan: N/A
+
+## Results
+| Check | Status | Detail |
+|-------|--------|--------|
+| Typecheck and lint | pass |  |
+| Tmux top-bottom pane behavior | pass |  |
+| Ink visual render and narrow-width behavior | pass |  |
+| Documentation omits old side-by-side layout wording | pass |  |
+
+## Summary
+- Total: 4 checks
+- Pass: 4
+- Fail: 0
+
+## Raw Output
+
+### Typecheck and lint
+**Command:** `./node_modules/.bin/tsc --noEmit`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>
+
+### Tmux top-bottom pane behavior
+**Command:** `./node_modules/.bin/vitest run tests/commands/inner.test.ts tests/tmux.test.ts`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+ RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/pretty-tui
+
+ ✓ tests/commands/inner.test.ts (25 tests) 89ms
+ ✓ tests/tmux.test.ts (33 tests) 810ms
+   ✓ pollForPidFile > returns null on timeout when file never appears 402ms
+   ✓ pollForPidFile > returns null when file contains non-numeric content 403ms
+
+ Test Files  2 passed (2)
+      Tests  58 passed (58)
+   Start at  11:38:14
+   Duration  1.21s (transform 123ms, setup 0ms, collect 350ms, tests 899ms, environment 0ms, prepare 93ms)
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>
+
+### Ink visual render and narrow-width behavior
+**Command:** `./node_modules/.bin/vitest run tests/ink/render.test.ts tests/ink/components`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+ RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/pretty-tui
+
+ ✓ tests/ink/components/ActionMenu.test.tsx (5 tests) 12ms
+ ✓ tests/ink/components/Header.test.tsx (7 tests) 14ms
+ ✓ tests/ink/components/GateVerdict.test.tsx (7 tests) 18ms
+ ✓ tests/ink/components/PhaseTimeline.test.tsx (6 tests) 17ms
+ ✓ tests/ink/components/CurrentPhase.test.tsx (10 tests) 22ms
+ ✓ tests/ink/components/Footer.test.tsx (5 tests) 14ms
+ ✓ tests/ink/render.test.ts (11 tests) 46ms
+
+ Test Files  7 passed (7)
+      Tests  51 passed (51)
+   Start at  11:38:16
+   Duration  549ms (transform 240ms, setup 0ms, collect 1.78s, tests 144ms, environment 1ms, prepare 406ms)
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+[harness] phase=1 status=in_progress
+[harness] phase=1 status=in_progress
+[harness] phase=1 status=in_progress
+[harness] phase=1 status=in_progress
+[harness] phase=1 status=in_progress
+[harness] phase=1 status=in_progress
+[harness] phase=1 status=in_progress
+[harness] phase=1 status=in_progress
+[harness] phase=1 status=in_progress
+[harness] phase=1 status=pending
+```
+
+</details>
+
+### Documentation omits old side-by-side layout wording
+**Command:** `! /usr/bin/grep -E -n "left[- ]right|side[- ]by[- ]side" README.md README.ko.md`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>

--- a/docs/specs/2026-04-25-untitled-598d-design.md
+++ b/docs/specs/2026-04-25-untitled-598d-design.md
@@ -1,0 +1,97 @@
+# Phase-Harness TUI Polish And Top-Bottom Layout
+
+## Context & Decisions
+The task asks to make the phase-harness TUI cleaner and more usable, and to replace the current left-right tmux split with a top-bottom split. In this codebase, the user-visible harness TUI is the Ink-based control pane rendered from `src/ink/**`, while the workspace pane runs Claude/Codex interactive sessions. The tmux split is created in `src/commands/inner.ts` through `splitPane(state.tmuxSession, controlPaneId, 'h', 60, cwd)`, so that is the primary layout change.
+
+Decisions:
+- Treat "TUI UI/UX" as the harness control pane only; do not redesign Claude Code or Codex CLI screens running in the workspace pane.
+- Make the control pane the top pane and the workspace the bottom pane. The control pane should stay compact, with the workspace receiving most vertical space.
+- Keep this as a targeted UI polish pass, not a lifecycle/state-machine rewrite. Existing phase orchestration, sentinel behavior, gate routing, logging semantics, and runner behavior must remain unchanged.
+- Prefer incremental improvements to the existing Ink components over replacing Ink or adding a new UI framework.
+- Update user-facing runtime layout docs so the documented tmux layout matches the implementation.
+
+## Complexity
+Medium — touches tmux pane creation, several Ink UI components, docs, and focused tests without introducing a new subsystem.
+
+## Problem
+The current runtime experience is hard to scan because the control panel reads like stacked status lines with repeated separators, and the tmux layout puts the control pane beside the workspace pane. The side-by-side layout competes for terminal width, which is especially painful for agent TUIs that expect a wide workspace. Users need a calmer control surface that communicates run status, current phase, available actions, and attach/help information without stealing horizontal space from the active agent.
+
+## Goals
+- Change the tmux runtime layout from left-right to top-bottom.
+- Improve the control pane so status, progress, current phase details, and actions are visually grouped and easy to scan.
+- Preserve existing keyboard behavior and phase lifecycle behavior.
+- Keep the implementation small enough for one implementation plan and one focused test pass.
+
+## Non-Goals
+- Do not change phase ordering, retry limits, gate verdict parsing, verify behavior, sentinel protocols, or commit behavior.
+- Do not modify Claude/Codex prompts or runner command semantics except where display text must reference the new layout.
+- Do not add a curses-like alternate renderer or replace Ink.
+- Do not add new runtime dependencies unless they are already present in the project.
+
+## Requirements
+
+### Top-Bottom Tmux Layout
+- `innerCommand` must create the workspace pane with a vertical tmux split (`splitPane(..., 'v', percent, cwd)`) when no valid distinct workspace pane already exists.
+- The control pane must remain the original pane and appear above the workspace pane.
+- The workspace pane must be created below the control pane and receive most of the terminal height. Use a stable percentage in the 65-75 range for the new workspace pane so the control pane stays compact but readable.
+- Reuse behavior must stay unchanged: if both stored control and workspace panes are valid and distinct, do not recreate them.
+- Failure behavior must stay unchanged: if the control pane is invalid, print the existing fatal error and exit.
+- Persisted `state.tmuxWorkspacePane` and `state.tmuxControlPane` semantics must not change.
+
+### Control Pane UI Polish
+- Keep `renderControlPanel` as the public facade and continue using `renderInkControlPanel` internally.
+- The control panel should present clear regions in this order:
+  1. Header with product name, flow badge, run id, and elapsed time when available.
+  2. Phase timeline/progress.
+  3. Current phase summary, including status, model/runner when applicable, and retry count when applicable.
+  4. Gate verdict or recent outcome summary when available.
+  5. Action/status row.
+  6. Footer metrics and attach hint when available.
+- Replace repeated dot-line separators with a lighter section treatment. Acceptable approaches include spacing, compact labels, or a single subtle divider between major groups; the result should not look like a stack of raw logs.
+- Use existing `COLORS` and `GLYPHS` conventions or extend them minimally. The UI must stay readable in monochrome terminals by keeping meaningful text labels beside icons.
+- Ensure narrow terminals remain usable. At widths below 60 columns, phase labels may collapse to phase numbers and long fields such as run id, model, or attach hints must truncate or wrap rather than producing broken output.
+- The terminal-complete state must clearly say the run is complete and how to exit.
+- The terminal-failed state must keep the existing `[R] Resume`, `[J] Jump`, `[Q] Quit` actions visible and prominent.
+- In-progress phases must clearly say the harness is waiting for phase completion.
+
+### Documentation
+- Update `README.md` and `README.ko.md` runtime layout text to describe a top control pane and bottom workspace pane.
+- Documentation must still mention the manual tmux attach command behavior.
+
+## Invariants
+- No lifecycle semantics change: phase statuses, pending actions, reopen routing, gate retries, verify retries, terminal states, and sentinel file names stay as they are.
+- No runner behavior change: Claude/Codex commands are still injected into `state.tmuxWorkspacePane`.
+- No state schema migration is required.
+- Non-TTY fallback in `renderInkControlPanel` remains a plain status line on stderr.
+- Existing telemetry event `ui_render` continues to emit with the same callsite values.
+- Top-bottom layout applies only to pane creation; existing valid pane pairs are reused.
+
+## Success Criteria
+- Starting or resuming a run with no valid workspace pane creates a bottom workspace pane with `splitPane(..., 'v', <65-75>, cwd)`.
+- Tests assert `innerCommand` requests a vertical split and stores the returned workspace pane id.
+- Existing tmux utility tests for both `h` and `v` split flags continue to pass.
+- Ink component tests cover the polished header/current phase/action/footer behavior, including at least one narrow-width case.
+- `pnpm run lint` passes.
+- Focused test commands pass for the changed areas:
+  - `pnpm vitest run tests/commands/inner.test.ts tests/tmux.test.ts`
+  - `pnpm vitest run tests/ink/render.test.ts tests/ink/components`
+- Documentation no longer describes the runtime layout as a left-right or side-by-side split.
+
+## Suggested Implementation Surface
+- `src/commands/inner.ts`: switch default workspace pane creation from horizontal to vertical split and choose the final workspace height percentage.
+- `src/ink/App.tsx`: adjust overall grouping and reduce visual noise.
+- `src/ink/theme.ts`: add only small theme/glyph helpers if needed for clearer labels.
+- `src/ink/components/Header.tsx`: improve title, flow badge, elapsed time, and run id presentation.
+- `src/ink/components/PhaseTimeline.tsx`: keep full/light flow correctness while improving scannability.
+- `src/ink/components/CurrentPhase.tsx`: make current phase status/model/retry information more structured.
+- `src/ink/components/GateVerdict.tsx`: keep verdict visibility without overwhelming non-gate states.
+- `src/ink/components/ActionMenu.tsx`: preserve terminal action keys and improve state text.
+- `src/ink/components/Footer.tsx`: preserve metrics and attach hint while avoiding overflow on narrow terminals.
+- `README.md` and `README.ko.md`: update runtime layout wording.
+- Tests under `tests/commands`, `tests/tmux.test.ts`, and `tests/ink/**`: update expectations and add narrow/status coverage.
+
+## Validation Plan
+- Run `pnpm run lint`.
+- Run `pnpm vitest run tests/commands/inner.test.ts tests/tmux.test.ts`.
+- Run `pnpm vitest run tests/ink/render.test.ts tests/ink/components`.
+- If the implementation changes shared rendering or tmux helpers beyond the files above, broaden to `pnpm vitest run`.

--- a/src/commands/inner.ts
+++ b/src/commands/inner.ts
@@ -64,7 +64,7 @@ export async function innerCommand(runId: string, options: InnerOptions = {}): P
   if (controlValid && workspaceValid) {
     // Both panes valid and distinct — reuse
   } else if (controlValid) {
-    const workspacePaneId = splitPane(state.tmuxSession, controlPaneId, 'h', 60, cwd);
+    const workspacePaneId = splitPane(state.tmuxSession, controlPaneId, 'v', 70, cwd);
     state.tmuxWorkspacePane = workspacePaneId;
   } else {
     process.stderr.write(`Fatal: control pane ${controlPaneId} does not exist.\n`);

--- a/src/ink/App.tsx
+++ b/src/ink/App.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Box, Text } from 'ink';
 import { subscribe, getSnapshot } from './store.js';
 import type { StoreSnapshot } from './store.js';
-import { useTerminalSize, GLYPHS } from './theme.js';
+import { useTerminalSize } from './theme.js';
 import { Header } from './components/Header.js';
 import { PhaseTimeline } from './components/PhaseTimeline.js';
 import { CurrentPhase } from './components/CurrentPhase.js';
@@ -24,22 +24,22 @@ export function App(): React.ReactElement {
   }
 
   const { state, callsite, footerSummary } = snap;
-  const separator = GLYPHS.bullet.repeat(Math.max(16, Math.min(64, columns - 2)));
-
   return (
     <Box flexDirection="column">
-      <Header state={state} elapsedMs={footerSummary?.phaseRunningElapsedMs ?? null} />
-      <Text dimColor>{separator}</Text>
+      <Header state={state} elapsedMs={footerSummary?.phaseRunningElapsedMs ?? null} columns={columns} />
+      <Box marginTop={1}>
+        <Text dimColor>Progress</Text>
+      </Box>
       <PhaseTimeline state={state} columns={columns} />
-      <Text dimColor>{separator}</Text>
-      <CurrentPhase state={state} />
+      <Box marginTop={1}>
+        <CurrentPhase state={state} columns={columns} />
+      </Box>
       <GateVerdict state={state} />
       <ActionMenu state={state} callsite={callsite} />
       {footerSummary !== null && (
-        <>
-          <Text dimColor>{separator}</Text>
+        <Box marginTop={1}>
           <Footer summary={footerSummary} columns={columns} />
-        </>
+        </Box>
       )}
     </Box>
   );

--- a/src/ink/components/ActionMenu.tsx
+++ b/src/ink/components/ActionMenu.tsx
@@ -14,7 +14,8 @@ export function ActionMenu({ state, callsite }: Props): React.ReactElement {
     if (callsite === 'terminal-complete' || state.status === 'completed') {
       return (
         <Box>
-          <Text dimColor>  Run complete — press Ctrl+C to exit</Text>
+          <Text dimColor>Status </Text>
+          <Text>Run complete. Press Ctrl+C to exit.</Text>
         </Box>
       );
     }
@@ -23,7 +24,8 @@ export function ActionMenu({ state, callsite }: Props): React.ReactElement {
     if (phaseStatus === 'in_progress') {
       return (
         <Box>
-          <Text dimColor>  Running — waiting for phase completion</Text>
+          <Text dimColor>Status </Text>
+          <Text>Waiting for phase completion.</Text>
         </Box>
       );
     }
@@ -31,20 +33,22 @@ export function ActionMenu({ state, callsite }: Props): React.ReactElement {
     if (phaseStatus === 'failed' || phaseStatus === 'error') {
       return (
         <Box>
-          <Text dimColor>  Phase stopped — terminal actions will appear below</Text>
+          <Text dimColor>Status </Text>
+          <Text>Phase stopped. Terminal actions will appear below.</Text>
         </Box>
       );
     }
 
     return (
       <Box>
-        <Text dimColor>  Starting phase…</Text>
+        <Text dimColor>Status </Text>
+        <Text>Starting phase…</Text>
       </Box>
     );
   }
   return (
     <Box>
-      <Text>  </Text>
+      <Text dimColor>Actions </Text>
       <Text bold color={COLORS.ok}>[R]</Text>
       <Text> Resume  </Text>
       <Text bold color={COLORS.accent}>[J]</Text>

--- a/src/ink/components/CurrentPhase.tsx
+++ b/src/ink/components/CurrentPhase.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import { Box, Text } from 'ink';
 import type { HarnessState } from '../../types.js';
-import { COLORS } from '../theme.js';
+import { COLORS, truncateEnd } from '../theme.js';
 import { getPresetById } from '../../config.js';
 import { phaseLabel } from '../phase-labels.js';
 
 interface Props {
   state: HarnessState;
+  columns?: number;
 }
 
-export function CurrentPhase({ state }: Props): React.ReactElement {
+export function CurrentPhase({ state, columns = 80 }: Props): React.ReactElement {
   const p = state.currentPhase;
   const label = phaseLabel(String(p), state.flow);
   const status = state.phases[String(p)] ?? 'pending';
@@ -22,18 +23,28 @@ export function CurrentPhase({ state }: Props): React.ReactElement {
   const preset = presetId ? getPresetById(presetId) : null;
 
   const retries = state.gateRetries[String(p)] ?? 0;
+  const presetText = preset ? `${preset.model} (${preset.runner}/${preset.effort})` : null;
+  const modelBudget = Math.max(18, columns - 8);
+  const phaseText = columns < 60 ? `P${p}` : `Phase ${p}`;
+  const retryText = retries > 0 ? ` (retry ${retries})` : '';
+  const summaryFixedWidth = 'Current '.length + phaseText.length + ': '.length + ' - '.length + status.length + retryText.length;
+  const summaryLabel = truncateEnd(label, Math.max(4, columns - summaryFixedWidth));
+  const waitingText = truncateEnd('Waiting for phase completion.', Math.max(20, columns));
 
   return (
     <Box flexDirection="column">
       <Box>
-        <Text>  Phase </Text>
-        <Text bold>{p}</Text>
-        <Text>: {label} — </Text>
+        <Text dimColor>Current </Text>
+        <Text bold>{phaseText}</Text>
+        <Text>: {summaryLabel} - </Text>
         <Text color={statusColor}>{status}</Text>
-        {retries > 0 && <Text dimColor> (retry {retries})</Text>}
+        {retries > 0 && <Text dimColor>{retryText}</Text>}
       </Box>
-      {preset && (
-        <Text dimColor>  {preset.model} ({preset.runner}/{preset.effort})</Text>
+      {presetText && (
+        <Text dimColor>Model {truncateEnd(presetText, modelBudget)}</Text>
+      )}
+      {status === 'in_progress' && (
+        <Text dimColor>{waitingText}</Text>
       )}
     </Box>
   );

--- a/src/ink/components/Footer.tsx
+++ b/src/ink/components/Footer.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Box, Text } from 'ink';
 import type { FooterSummary } from '../../metrics/footer-aggregator.js';
 import { formatFooter } from '../../metrics/footer-aggregator.js';
+import { truncateEnd } from '../theme.js';
 
 interface Props {
   summary: FooterSummary | null;
@@ -12,11 +13,12 @@ export function Footer({ summary, columns }: Props): React.ReactElement | null {
   if (summary === null) return null;
   const line = formatFooter(summary, columns);
   if (!line && !summary.tmuxSession) return null;
+  const attach = summary.tmuxSession ? `attach: tmux attach -t ${summary.tmuxSession}` : null;
   return (
     <Box flexDirection="column">
       {line && <Text dimColor>{line}</Text>}
-      {summary.tmuxSession && (
-        <Text dimColor>{`attach: tmux attach -t ${summary.tmuxSession}`}</Text>
+      {attach && (
+        <Text dimColor>{truncateEnd(attach, Math.max(20, columns))}</Text>
       )}
     </Box>
   );

--- a/src/ink/components/GateVerdict.tsx
+++ b/src/ink/components/GateVerdict.tsx
@@ -28,7 +28,8 @@ export function GateVerdict({ state }: Props): React.ReactElement | null {
 
   return (
     <Box>
-      <Text>  Gate P{lastPhase}: </Text>
+      <Text dimColor>Outcome </Text>
+      <Text>Gate P{lastPhase}: </Text>
       <Text color={color}>{verdict}</Text>
       {runner && <Text dimColor> [{runner}]</Text>}
       {retries > 0 && <Text dimColor> (retry {retries})</Text>}

--- a/src/ink/components/Header.tsx
+++ b/src/ink/components/Header.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Box, Text } from 'ink';
 import type { HarnessState } from '../../types.js';
-import { COLORS, GLYPHS } from '../theme.js';
+import { COLORS, GLYPHS, truncateEnd } from '../theme.js';
 
 interface Props {
   state: HarnessState;
   elapsedMs?: number | null;
+  columns?: number;
 }
 
 function fmtMs(ms: number): string {
@@ -13,9 +14,10 @@ function fmtMs(ms: number): string {
   return `${Math.floor(s / 60)}m${String(s % 60).padStart(2, '0')}s`;
 }
 
-export function Header({ state, elapsedMs }: Props): React.ReactElement {
+export function Header({ state, elapsedMs, columns = 80 }: Props): React.ReactElement {
   const id = state.runId;
-  const runIdShort = id.length > 32 ? id.slice(0, 32) + '…' : id;
+  const runLabelBudget = Math.max(12, Math.min(36, columns - 12));
+  const runIdShort = truncateEnd(id, runLabelBudget);
   const badge = state.flow === 'light' ? '[light]' : '[full]';
   return (
     <Box flexDirection="column">
@@ -25,7 +27,7 @@ export function Header({ state, elapsedMs }: Props): React.ReactElement {
         <Text color={COLORS.accent}>{badge}</Text>
         {elapsedMs != null && <Text dimColor> · {fmtMs(elapsedMs)}</Text>}
       </Box>
-      <Text dimColor>  Run: {runIdShort}</Text>
+      <Text dimColor>Run {runIdShort}</Text>
     </Box>
   );
 }

--- a/src/ink/components/PhaseTimeline.tsx
+++ b/src/ink/components/PhaseTimeline.tsx
@@ -41,7 +41,7 @@ export function PhaseTimeline({ state, columns = 80 }: Props): React.ReactElemen
         const icon = statusIcon(status);
         const color = statusColor(status);
         const isCurrent = String(state.currentPhase) === slot.key;
-        const label = narrow ? slot.key : slot.label;
+        const label = narrow ? `P${slot.key}` : slot.label;
 
         return (
           <Box key={slot.key} marginRight={1}>

--- a/src/ink/theme.ts
+++ b/src/ink/theme.ts
@@ -18,6 +18,13 @@ export const GLYPHS = {
   bullet: '·',
 } as const;
 
+export function truncateEnd(value: string, maxColumns: number): string {
+  if (maxColumns <= 0) return '';
+  if (value.length <= maxColumns) return value;
+  if (maxColumns === 1) return '…';
+  return `${value.slice(0, maxColumns - 1)}…`;
+}
+
 export function useTerminalSize(): { columns: number; rows: number } {
   const { stdout } = useStdout();
   return {

--- a/tests/commands/inner.test.ts
+++ b/tests/commands/inner.test.ts
@@ -281,6 +281,106 @@ describe('inner.ts: tmux cleanup on completion', () => {
   });
 });
 
+describe('inner.ts: tmux top-bottom workspace pane setup', () => {
+  let tmpDir: string;
+
+  function makePaneState(overrides: Partial<HarnessState> = {}): HarnessState {
+    return {
+      runId: 'pane-run',
+      flow: 'full',
+      carryoverFeedback: null,
+      currentPhase: 7,
+      status: 'completed',
+      autoMode: false,
+      task: 'test task',
+      baseCommit: 'abc123',
+      implRetryBase: 'abc123',
+      trackedRepos: [{ path: tmpDir, baseCommit: 'abc123', implRetryBase: 'abc123', implHead: null }],
+      codexPath: null,
+      codexNoIsolate: false,
+      externalCommitsDetected: false,
+      artifacts: { spec: 's', plan: 'p', decisionLog: 'd', checklist: 'c', evalReport: 'e' },
+      phases: { '1': 'completed', '2': 'completed', '3': 'completed', '4': 'completed', '5': 'completed', '6': 'completed', '7': 'completed' },
+      gateRetries: { '2': 0, '4': 0, '7': 0 },
+      verifyRetries: 0,
+      pauseReason: null,
+      specCommit: null,
+      planCommit: null,
+      implCommit: null,
+      evalCommit: null,
+      verifiedAtHead: null,
+      pausedAtHead: null,
+      pendingAction: null,
+      phaseOpenedAt: { '1': null, '3': null, '5': null },
+      phaseAttemptId: { '1': null, '3': null, '5': null },
+      phasePresets: {},
+      phaseReopenFlags: { '1': false, '3': false, '5': false },
+      phaseReopenSource: { '1': null, '3': null, '5': null },
+      phaseCodexSessions: { '2': null, '4': null, '7': null },
+      phaseClaudeSessions: { '1': null, '3': null, '5': null },
+      lastWorkspacePid: null,
+      lastWorkspacePidStartTime: null,
+      tmuxSession: 'test-sess',
+      tmuxMode: 'dedicated',
+      tmuxWindows: [],
+      tmuxControlWindow: '',
+      tmuxWorkspacePane: '',
+      tmuxControlPane: '',
+      loggingEnabled: false,
+      dirtyBaseline: [],
+      ...overrides,
+    };
+  }
+
+  function writeRun(state: HarnessState): string {
+    const runDir = path.join(tmpDir, state.runId);
+    fs.mkdirSync(runDir, { recursive: true });
+    fs.writeFileSync(path.join(runDir, 'task.md'), state.task);
+    fs.writeFileSync(path.join(runDir, 'state.json'), JSON.stringify(state));
+    return runDir;
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'inner-pane-'));
+    vi.mocked(findHarnessRoot).mockReturnValue(tmpDir);
+    vi.mocked(splitPane).mockReset();
+    vi.mocked(splitPane).mockReturnValue('%9');
+    vi.mocked(paneExists).mockReset();
+    vi.mocked(runPhaseLoop).mockReset();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates a bottom workspace pane with a vertical split and persists the pane id', async () => {
+    const state = makePaneState({
+      runId: 'pane-run',
+    });
+    const runDir = writeRun(state);
+    vi.mocked(paneExists).mockReturnValue(true);
+
+    await innerCommand(state.runId, { root: tmpDir, controlPane: '%0' });
+
+    expect(splitPane).toHaveBeenCalledWith('test-sess', '%0', 'v', 70, tmpDir);
+    const persisted = JSON.parse(fs.readFileSync(path.join(runDir, 'state.json'), 'utf-8'));
+    expect(persisted.tmuxWorkspacePane).toBe('%9');
+  });
+
+  it('reuses a valid distinct stored workspace pane without creating a split', async () => {
+    const state = makePaneState({
+      runId: 'reuse-run',
+      tmuxWorkspacePane: '%8',
+    });
+    writeRun(state);
+    vi.mocked(paneExists).mockReturnValue(true);
+
+    await innerCommand(state.runId, { root: tmpDir, controlPane: '%0' });
+
+    expect(splitPane).not.toHaveBeenCalled();
+  });
+});
+
 describe('bootstrapSessionLogger', () => {
   function tempHarnessDir(): string {
     return fs.mkdtempSync(path.join(os.tmpdir(), 'bootstrap-'));

--- a/tests/ink/components/ActionMenu.test.tsx
+++ b/tests/ink/components/ActionMenu.test.tsx
@@ -16,7 +16,7 @@ describe('ActionMenu', () => {
 
     const { lastFrame } = render(<ActionMenu state={state} callsite="loop-top" />);
 
-    expect(lastFrame()).toContain('Running');
+    expect(lastFrame()).toContain('Waiting for phase completion.');
     expect(lastFrame()).not.toContain('[R]');
     expect(lastFrame()).not.toContain('[J]');
     expect(lastFrame()).not.toContain('[Q]');
@@ -39,7 +39,7 @@ describe('ActionMenu', () => {
     const state = makeState({ currentPhase: 3 });
     state.phases['3'] = 'failed';
     const { lastFrame } = render(<ActionMenu state={state} callsite="gate-approve" />);
-    expect(lastFrame()).toContain('Phase stopped');
+    expect(lastFrame()).toContain('Phase stopped.');
     expect(lastFrame()).not.toContain('[R]');
   });
 

--- a/tests/ink/components/CurrentPhase.test.tsx
+++ b/tests/ink/components/CurrentPhase.test.tsx
@@ -10,6 +10,12 @@ function makeState(overrides: Partial<HarnessState> = {}): HarnessState {
   return { ...base, ...overrides };
 }
 
+function expectLinesWithin(frame: string | undefined, columns: number): void {
+  for (const line of (frame ?? '').split('\n')) {
+    expect(line.length).toBeLessThanOrEqual(columns);
+  }
+}
+
 describe('CurrentPhase', () => {
   it('shows phase number and label (full flow)', () => {
     const state = makeState({ currentPhase: 3, flow: 'full' });
@@ -31,6 +37,7 @@ describe('CurrentPhase', () => {
     state.phases['5'] = 'in_progress';
     const { lastFrame } = render(<CurrentPhase state={state} />);
     expect(lastFrame()).toContain('in_progress');
+    expect(lastFrame()).toContain('Waiting for phase completion.');
   });
 
   it('shows completed status', () => {
@@ -73,7 +80,22 @@ describe('CurrentPhase', () => {
     expect(frame).toContain('high');
   });
 
-  it('renders without crashing at narrow width', () => {
-    expect(() => render(<CurrentPhase state={makeState({ currentPhase: 1 })} />)).not.toThrow();
+  it('truncates long preset details at narrow width', () => {
+    const state = makeState({ currentPhase: 3, phasePresets: { '3': 'sonnet-high' } });
+    const { lastFrame } = render(<CurrentPhase state={state} columns={30} />);
+    const frame = lastFrame();
+    expect(frame).toContain('claude-sonnet-4-6');
+    expect(frame).toContain('…');
+    expectLinesWithin(frame, 30);
+  });
+
+  it('compacts the current phase summary at narrow width', () => {
+    const state = makeState({ currentPhase: 5 });
+    state.phases['5'] = 'in_progress';
+    const { lastFrame } = render(<CurrentPhase state={state} columns={30} />);
+    const frame = lastFrame();
+    expect(frame).toContain('Current P5');
+    expect(frame).not.toContain('Current Phase');
+    expectLinesWithin(frame, 30);
   });
 });

--- a/tests/ink/components/Footer.test.tsx
+++ b/tests/ink/components/Footer.test.tsx
@@ -17,6 +17,12 @@ function makeSummary(overrides: Partial<FooterSummary> = {}): FooterSummary {
   };
 }
 
+function expectLinesWithin(frame: string | undefined, columns: number): void {
+  for (const line of (frame ?? '').split('\n')) {
+    expect(line.length).toBeLessThanOrEqual(columns);
+  }
+}
+
 describe('Footer', () => {
   it('renders nothing when summary is null', () => {
     const { lastFrame } = render(<Footer summary={null} columns={80} />);
@@ -43,5 +49,15 @@ describe('Footer', () => {
       <Footer summary={makeSummary({ tmuxSession: 'grove-abc123' })} columns={80} />
     );
     expect(lastFrame()).toContain('attach: tmux attach -t grove-abc123');
+  });
+
+  it('truncates long attach hints at narrow width', () => {
+    const { lastFrame } = render(
+      <Footer summary={makeSummary({ tmuxSession: 'grove-this-session-name-is-too-long' })} columns={32} />
+    );
+    const frame = lastFrame();
+    expect(frame).toContain('attach: tmux attach -t grove-th…');
+    expect(frame).not.toContain('too-long');
+    expectLinesWithin(frame, 32);
   });
 });

--- a/tests/ink/components/GateVerdict.test.tsx
+++ b/tests/ink/components/GateVerdict.test.tsx
@@ -20,6 +20,7 @@ describe('GateVerdict', () => {
     state.phases['2'] = 'completed';
     const { lastFrame } = render(<GateVerdict state={state} />);
     expect(lastFrame()).toContain('APPROVED');
+    expect(lastFrame()).toContain('Outcome');
     expect(lastFrame()).toContain('P2');
   });
 

--- a/tests/ink/components/Header.test.tsx
+++ b/tests/ink/components/Header.test.tsx
@@ -9,6 +9,12 @@ function makeState(overrides: Partial<HarnessState> = {}): HarnessState {
   return { ...createInitialState('run-2026-04-23-test', 'task', 'abc123', false), ...overrides };
 }
 
+function expectLinesWithin(frame: string | undefined, columns: number): void {
+  for (const line of (frame ?? '').split('\n')) {
+    expect(line.length).toBeLessThanOrEqual(columns);
+  }
+}
+
 describe('Header', () => {
   it('shows "Harness Control Panel" title', () => {
     const { lastFrame } = render(<Header state={makeState()} />);
@@ -42,7 +48,12 @@ describe('Header', () => {
     expect(lastFrame()).not.toMatch(/\d+m\d+s/);
   });
 
-  it('renders without crashing at narrow width', () => {
-    expect(() => render(<Header state={makeState()} />)).not.toThrow();
+  it('truncates long run IDs at narrow width', () => {
+    const state = makeState({ runId: '2026-04-23-this-run-id-is-far-too-long-for-a-top-pane' });
+    const { lastFrame } = render(<Header state={state} columns={36} />);
+    const frame = lastFrame();
+    expect(frame).toContain('2026-04-23-this-run-id-…');
+    expect(frame).not.toContain('far-too-long');
+    expectLinesWithin(frame, 36);
   });
 });

--- a/tests/ink/components/PhaseTimeline.test.tsx
+++ b/tests/ink/components/PhaseTimeline.test.tsx
@@ -67,8 +67,13 @@ describe('PhaseTimeline — light flow', () => {
 });
 
 describe('PhaseTimeline — narrow width', () => {
-  it('renders without crashing at columns=40', () => {
+  it('collapses labels to phase numbers at columns=40', () => {
     const state = makeState({ flow: 'full', currentPhase: 1 });
-    expect(() => render(<PhaseTimeline state={state} columns={40} />)).not.toThrow();
+    const { lastFrame } = render(<PhaseTimeline state={state} columns={40} />);
+    const frame = lastFrame();
+    expect(frame).toContain('P1');
+    expect(frame).toContain('P7');
+    expect(frame).not.toContain('Spec 작성');
+    expect(frame).not.toContain('Eval Gate');
   });
 });

--- a/tests/ink/render.test.ts
+++ b/tests/ink/render.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render } from 'ink-testing-library';
 import type { HarnessState, SessionLogger, RenderCallsite } from '../../src/types.js';
 import { createInitialState } from '../../src/state.js';
+import { App } from '../../src/ink/App.js';
+import { dispatch, dispatchFooter } from '../../src/ink/store.js';
 
 function makeState(): HarnessState {
   return createInitialState('run', 'task', 'base', false);
@@ -49,5 +53,43 @@ describe('render facade — ui_render emission', () => {
     const logger = makeLogger();
     renderInkControlPanel(makeState(), logger);
     expect(logger.logEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('App layout', () => {
+  it('renders header, progress, current phase, outcome, action row, and footer in order', () => {
+    const state = makeState();
+    state.currentPhase = 5;
+    state.phases['2'] = 'completed';
+    state.phases['5'] = 'in_progress';
+
+    dispatch({ state, callsite: 'loop-top' });
+    dispatchFooter({
+      currentPhase: 5,
+      attempt: 1,
+      phaseRunningElapsedMs: 12_000,
+      sessionElapsedMs: 60_000,
+      claudeTokens: 100,
+      gateTokens: 25,
+      totalTokens: 125,
+      tmuxSession: 'harness-run',
+    });
+
+    const { lastFrame } = render(React.createElement(App));
+    const frame = lastFrame() ?? '';
+    const header = frame.indexOf('Harness Control Panel');
+    const progress = frame.indexOf('Progress');
+    const current = frame.indexOf('Current');
+    const outcome = frame.indexOf('Outcome');
+    const status = frame.indexOf('Status');
+    const footer = frame.indexOf('attach: tmux attach -t harness-run');
+
+    expect(header).toBeGreaterThanOrEqual(0);
+    expect(progress).toBeGreaterThan(header);
+    expect(current).toBeGreaterThan(progress);
+    expect(outcome).toBeGreaterThan(current);
+    expect(status).toBeGreaterThan(outcome);
+    expect(footer).toBeGreaterThan(status);
+    expect(frame).not.toMatch(/····/);
   });
 });


### PR DESCRIPTION
## Summary
- Switch the default tmux workspace creation to a vertical (top-bottom) split with a 70% workspace height, while keeping the reuse path and fatal control-pane validation untouched (`src/commands/inner.ts`).
- Recompose the Ink control pane into ordered regions (header → timeline → current phase → gate verdict → action row → footer) and replace repeated dot-line dividers with lighter spacing (`src/ink/App.tsx`, `src/ink/theme.ts`).
- Polish each region: header truncates long run ids and shows elapsed time; timeline collapses labels under 60 cols; current phase exposes preset/runner/effort + retry count + waiting-for-completion line; gate verdict stays compact when no recent outcome; action row keeps `[R]/[J]/[Q]` prominent only in terminal-failed.
- Update `README.md` / `README.ko.md` runtime layout sections to reflect the top-bottom layout while preserving the manual `tmux attach` instructions.
- Pre-impl scaffolding commit adds language-standard `.gitignore` entries (`build/`, `__pycache__/`, `.pytest_cache/`, `.venv/`).

Run was driven through `phase-harness` (full 7-phase flow). Phase 6 verify passed deterministic checks, Phase 7 Codex eval returned APPROVE (only a P2 about `pnpm run lint` vs `tsc --noEmit`, which is a pre-existing alias per CLAUDE.md).

## Related artifacts
- Spec: `docs/specs/2026-04-25-untitled-598d-design.md`
- Plan: `docs/plans/2026-04-25-untitled-598d.md`
- Eval report: `docs/process/evals/2026-04-25-tui-v2-eval.md`

## Test plan
- [x] `pnpm tsc --noEmit`
- [x] `pnpm vitest run` (all suites green after `pnpm build`)
- [x] `pnpm vitest run tests/commands/inner.test.ts tests/tmux.test.ts`
- [x] `pnpm vitest run tests/ink/render.test.ts tests/ink/components`
- [x] README grep for old left-right wording (`grep -E 'left[- ]right|side[- ]by[- ]side' README.md README.ko.md` returns no matches)
- [x] Manually verified the new vertical split lands the workspace pane below the control pane in tmux