### PR TITLE
feat(runner): bypass codex approvals + sandbox via yolo flag

### DIFF
--- a/docs/HOW-IT-WORKS.ko.md
+++ b/docs/HOW-IT-WORKS.ko.md
@@ -170,21 +170,19 @@ claude --session-id <attemptId> --model <model> --effort <effort> @<prompt-file>
 선택된 preset의 runner가 `codex`이면 harness는 workspace pane에 top-level `codex` TUI를 띄웁니다. Claude와 동일한 UX(입력 라인 + reasoning stream 가시화 + 실시간 개입 가능):
 
 ```bash
-codex --model <model> -c model_reasoning_effort="<effort>" --sandbox <level> --full-auto "$(cat <prompt-file>)"
+codex --model <model> -c model_reasoning_effort="<effort>" --dangerously-bypass-approvals-and-sandbox "$(cat <prompt-file>)"
 ```
 
 프롬프트는 셸 command-substitution(`$(cat ...)`)을 통해 실행 시점에 positional CLI argument로 주입됩니다. tmux send-keys가 운반하는 건 짧은 wrapper뿐이라 프롬프트 크기가 수십 KB가 되어도 문제없습니다. agent 자신이 phase 프롬프트의 지시에 따라 tool use로 `phase-N.done` sentinel을 작성하며, 이는 Claude의 동작 패턴과 일치합니다.
 
-sandbox 레벨:
-- phase 1, 3 → `workspace-write`
-- phase 5 → `danger-full-access`
+승인/샌드박스: 모든 Codex interactive phase(1/3/5)에 `--dangerously-bypass-approvals-and-sandbox`(yolo)를 적용합니다. 신뢰 경계는 harness 호출 시점이며, codex는 샌드박스/승인 프롬프트 없이 실행되므로 워크트리 간 쓰기·git 조작이 자율 루프를 yes/no 프롬프트로 막지 않습니다.
 
 ### Gate phase
 
 gate phase도 preset 기반입니다. Codex gate는 interactive phase와 **동일한 tmux workspace pane**에서 top-level `codex` TUI로 실행됩니다.
 
 ```bash
-codex --model <model> -c model_reasoning_effort="<effort>" -s workspace-write --full-auto "$(cat <prompt-file>)"
+codex --model <model> -c model_reasoning_effort="<effort>" --dangerously-bypass-approvals-and-sandbox "$(cat <prompt-file>)"
 ```
 
 reopen 시에는 동일한 플래그로 `codex resume <session_id>`를 사용합니다. gate phase를 Claude preset으로 강제로 매핑한 경우에만 `claude --print` gate subprocess를 사용합니다.

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -188,21 +188,19 @@ Other behavior:
 When the selected preset runner is `codex`, harness launches the top-level `codex` TUI in the workspace pane — same UX as Claude (input line + reasoning stream visible, intervention possible):
 
 ```bash
-codex --model <model> -c model_reasoning_effort="<effort>" --sandbox <level> --full-auto "$(cat <prompt-file>)"
+codex --model <model> -c model_reasoning_effort="<effort>" --dangerously-bypass-approvals-and-sandbox "$(cat <prompt-file>)"
 ```
 
 The prompt is injected as a positional CLI argument via shell command substitution at execution time, so tmux send-keys carries only the short wrapper (the prompt itself can exceed tens of KB). The agent itself writes the `phase-N.done` sentinel via tool use per the phase prompt's instructions, matching Claude's pattern.
 
-Sandbox level:
-- phases 1 and 3 → `workspace-write`
-- phase 5 → `danger-full-access`
+Approvals/sandbox: `--dangerously-bypass-approvals-and-sandbox` (yolo) is used for all Codex interactive phases (1/3/5). The harness invocation is the trust boundary; codex runs without sandbox or approval prompts so cross-worktree writes and git operations don't block the autonomous loop on a yes/no inside the workspace pane.
 
 ### Gate phases
 
 Gate phases are preset-driven too. Codex gates run through the top-level `codex` TUI in the **same tmux workspace pane** as interactive phases:
 
 ```bash
-codex --model <model> -c model_reasoning_effort="<effort>" -s workspace-write --full-auto "$(cat <prompt-file>)"
+codex --model <model> -c model_reasoning_effort="<effort>" --dangerously-bypass-approvals-and-sandbox "$(cat <prompt-file>)"
 ```
 
 For reopens, harness uses `codex resume <session_id>` with the same flags. If a gate phase is explicitly mapped to a Claude preset, harness instead runs a `claude --print` gate subprocess.

--- a/src/runners/codex.ts
+++ b/src/runners/codex.ts
@@ -338,22 +338,27 @@ export async function spawnCodexInPane(input: SpawnCodexInPaneInput): Promise<Co
   // `[projects."<realpath cwd>"] trust_level = "trusted"` into the isolated
   // CODEX_HOME), which bypasses both the trust prompt and the git-repo check.
   //
-  // `-s workspace-write --full-auto` lets codex write gate-N-verdict.md and
-  // phase-N.done as instructed by buildGateOutputProtocol (assembler.ts).
+  // `--dangerously-bypass-approvals-and-sandbox` (yolo) disables both the
+  // sandbox and approval prompts, matching harness's autonomous-mode intent —
+  // gates often need to write artifacts (verdict, sentinel, plan files) into
+  // paths whose git metadata sits outside the sandbox writable roots (e.g.
+  // sibling worktrees), and any approval prompt blocks the codex TUI inside
+  // the workspace pane until the human responds. The harness wrapper trusts
+  // the caller's cwd; security boundary is the harness invocation, not codex.
   let codexCmd: string;
   if (mode === 'resume' && sessionId) {
     codexCmd =
       `${codexBin} resume ${sessionId} ` +
       `--model ${preset.model} ` +
       `-c model_reasoning_effort="${preset.effort}" ` +
-      `-s workspace-write --full-auto ` +
+      `--dangerously-bypass-approvals-and-sandbox ` +
       `"$(cat "${promptFile}")"`;
   } else {
     codexCmd =
       `${codexBin} ` +
       `--model ${preset.model} ` +
       `-c model_reasoning_effort="${preset.effort}" ` +
-      `-s workspace-write --full-auto ` +
+      `--dangerously-bypass-approvals-and-sandbox ` +
       `"$(cat "${promptFile}")"`;
   }
 
@@ -389,10 +394,13 @@ export interface SpawnCodexInteractiveInPaneInput {
 }
 
 /**
- * Inject a `codex exec --full-auto` command into the tmux workspace pane for
- * interactive phases (1/3/5). Unlike spawnCodexInPane (gates), the shell wrapper
- * does NOT use `exec`, so sh survives codex exit and can write the sentinel.
- * Sentinel content = attemptId, enabling checkSentinelFreshness to verify it.
+ * Inject a top-level `codex` (TUI) command into the tmux workspace pane for
+ * interactive phases (1/3/5). Runs with
+ * `--dangerously-bypass-approvals-and-sandbox` so cross-worktree writes and
+ * git operations don't trip the sandbox or pop approval prompts. Unlike
+ * spawnCodexInPane (gates), the shell wrapper does NOT use `exec`, so sh
+ * survives codex exit and can write the sentinel. Sentinel content =
+ * attemptId, enabling checkSentinelFreshness to verify it.
  */
 export async function spawnCodexInteractiveInPane(
   input: SpawnCodexInteractiveInPaneInput,
@@ -432,19 +440,21 @@ export async function spawnCodexInteractiveInPane(
   if (fs.existsSync(pidFile)) fs.unlinkSync(pidFile);
 
   const codexBin = resolveCodexBin();
-  const sandbox = phase === 5 ? 'danger-full-access' : 'workspace-write';
   const codexHomeEnv = codexHome ? `CODEX_HOME="${codexHome}" ` : '';
 
   // Top-level `codex` TUI (matches gate pane spawn pattern). Trust entry in
   // the isolated CODEX_HOME (ensureCodexIsolation) bypasses git-repo check.
   // Prompt injected as positional arg via `cat` substitution at exec time.
+  // `--dangerously-bypass-approvals-and-sandbox` disables sandbox + all
+  // approval prompts so the autonomous loop never blocks on a yes/no inside
+  // the workspace pane (interactive phases routinely write across worktrees,
+  // run git, etc., which hits sandbox or approval gates otherwise).
   const wrappedCmd =
     `sh -c 'cd "${cwd}" && echo $$ > "${pidFile}" && ` +
     `${codexHomeEnv}exec ${codexBin} ` +
     `--model ${preset.model} ` +
     `-c model_reasoning_effort="${preset.effort}" ` +
-    `--sandbox ${sandbox} ` +
-    `--full-auto ` +
+    `--dangerously-bypass-approvals-and-sandbox ` +
     `"$(cat "${promptFile}")"'`;
 
   sendKeysToPane(sessionName, workspacePane, wrappedCmd);

--- a/tests/runners/codex.test.ts
+++ b/tests/runners/codex.test.ts
@@ -164,8 +164,9 @@ describe('spawnCodexInteractiveInPane — pane injection', () => {
     expect(cmd).not.toMatch(/\bcodex\s+exec\b/);
     expect(cmd).not.toMatch(/--skip-git-repo-check/);
     expect(cmd).toContain('CODEX_HOME="/iso/interactive"');
-    expect(cmd).toContain('--sandbox workspace-write');
-    expect(cmd).toContain('--full-auto');
+    expect(cmd).toContain('--dangerously-bypass-approvals-and-sandbox');
+    expect(cmd).not.toMatch(/--sandbox\s+workspace-write/);
+    expect(cmd).not.toMatch(/--full-auto/);
     // Prompt as cat-substitution positional arg, not stdin redirect.
     expect(cmd).toContain(`"$(cat "${promptPath}")"`);
     expect(cmd).not.toMatch(/<\s+"[^"]*p\.txt"/);
@@ -176,7 +177,7 @@ describe('spawnCodexInteractiveInPane — pane injection', () => {
     fs.rmSync(tmp, { recursive: true, force: true });
   });
 
-  it('uses danger-full-access sandbox for phase 5', async () => {
+  it('uses --dangerously-bypass-approvals-and-sandbox for phase 5', async () => {
     const fs = await import('fs');
     const os = await import('os');
     const path = await import('path');
@@ -209,7 +210,9 @@ describe('spawnCodexInteractiveInPane — pane injection', () => {
     const cmd: string = vi.mocked(sendKeysToPane).mock.calls.at(-1)![2];
     expect(cmd).toMatch(/\bcodex\s+--model\b/);
     expect(cmd).not.toMatch(/\bcodex\s+exec\b/);
-    expect(cmd).toContain('--sandbox danger-full-access');
+    expect(cmd).toContain('--dangerously-bypass-approvals-and-sandbox');
+    expect(cmd).not.toMatch(/--sandbox\s+/);
+    expect(cmd).not.toMatch(/--full-auto/);
     expect(cmd).not.toContain('CODEX_HOME');
 
     fs.rmSync(tmp, { recursive: true, force: true });
@@ -423,9 +426,11 @@ describe('spawnCodexInPane — fresh', () => {
     expect(wrappedCmd).toMatch(/\bcodex\s+--model\b/);
     expect(wrappedCmd).not.toMatch(/\bcodex\s+exec\b/);
     expect(wrappedCmd).not.toMatch(/--skip-git-repo-check/);
-    // Sandbox + auto-approval still required so codex can write verdict + sentinel.
-    expect(wrappedCmd).toMatch(/-s\s+workspace-write/);
-    expect(wrappedCmd).toMatch(/--full-auto/);
+    // Yolo flag (sandbox + approval bypass) so codex can write verdict +
+    // sentinel and reach across worktrees without prompting.
+    expect(wrappedCmd).toMatch(/--dangerously-bypass-approvals-and-sandbox/);
+    expect(wrappedCmd).not.toMatch(/-s\s+workspace-write/);
+    expect(wrappedCmd).not.toMatch(/--full-auto/);
     // Prompt is injected via shell command substitution at execution time so
     // tmux send-keys carries only the short wrapper, not the 40+ KB prompt.
     expect(wrappedCmd).toContain(`"$(cat "${promptFile}")"`);
@@ -486,13 +491,14 @@ describe('spawnCodexInPane — resume', () => {
     const wrappedCmd = cmds.find(c => c.includes('resume'));
     expect(wrappedCmd).toBeDefined();
     // Top-level `codex resume <id>`, NOT `codex exec resume`. Top-level resume
-    // accepts -s and --full-auto (unlike exec resume), so fresh and resume
-    // share the same flag set.
+    // accepts the yolo flag (unlike exec resume), so fresh and resume share
+    // the same flag set.
     expect(wrappedCmd).toMatch(/\bcodex\s+resume\s+sess-abc-123\b/);
     expect(wrappedCmd).not.toMatch(/\bcodex\s+exec\s+resume\b/);
     expect(wrappedCmd).not.toMatch(/--skip-git-repo-check/);
-    expect(wrappedCmd).toMatch(/-s\s+workspace-write/);
-    expect(wrappedCmd).toMatch(/--full-auto/);
+    expect(wrappedCmd).toMatch(/--dangerously-bypass-approvals-and-sandbox/);
+    expect(wrappedCmd).not.toMatch(/-s\s+workspace-write/);
+    expect(wrappedCmd).not.toMatch(/--full-auto/);
     expect(wrappedCmd).toContain(`"$(cat "${promptFile}")"`);
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary
- Replace `-s workspace-write --full-auto` (gates) and `--sandbox <level> --full-auto` (interactive 1/3/5) with `--dangerously-bypass-approvals-and-sandbox` at all three Codex spawn sites in `src/runners/codex.ts`.
- Motivation: Codex was prompting for approval whenever the model proposed a write outside the sandbox writable roots — e.g. `git add -f` against a sibling worktree's git metadata during dogfood runs. The prompt blocked the autonomous TUI loop on a yes/no inside the workspace pane, defeating the point of running unattended.
- Trust boundary stays at the harness invocation; codex no longer gates per-command. Phase 5's `danger-full-access` branch is removed since the yolo flag subsumes it.
- `docs/HOW-IT-WORKS.{md,ko.md}` updated to match.

## Test plan
- [x] `pnpm lint` (tsc --noEmit) clean
- [x] `pnpm vitest run` — 1051 passed / 1 skipped (pre-existing)
- [x] `pnpm vitest run tests/runners/codex.test.ts` — 21/21 pass after expectation updates (4 blocks: interactive 1/3, phase 5, gate fresh, gate resume)
- [x] `pnpm build` clean
- [ ] Dogfood: run a `--light` flow that triggers cross-worktree `git add -f` and confirm no approval prompt surfaces in the workspace pane