### PR TITLE
fix(tmux): atomic pane reset between phases via respawn-pane (#88, #90)

### DIFF
--- a/src/phases/interactive.ts
+++ b/src/phases/interactive.ts
@@ -343,9 +343,14 @@ export async function runInteractivePhase(
     }
 
     try { clearLockChild(harnessDir); } catch { /* best-effort */ }
-    updatedState.lastWorkspacePid = null;
-    updatedState.lastWorkspacePidStartTime = null;
-    writeState(runDir, updatedState);
+    // NOTE: lastWorkspacePid is intentionally NOT cleared here. PR #85
+    // switched the Codex runner to a TUI that stays in REPL mode after
+    // writing the sentinel (it does NOT auto-exit like the prior `codex
+    // exec`). Clearing the PID here would orphan the still-live process
+    // from harness-exit cleanup. The next phase's runner calls respawnPane
+    // first, which atomically kills the leaked process and then re-zeroes
+    // these fields before the new spawn — so this PID never confuses the
+    // next phase. (See issue #90 for the original send-keys leak.)
 
     return { ...result, attemptId };
   }

--- a/src/runners/claude.ts
+++ b/src/runners/claude.ts
@@ -4,8 +4,8 @@ import path from 'path';
 import type { HarnessState, GatePhaseResult } from '../types.js';
 import type { ModelPreset } from '../config.js';
 import { GATE_TIMEOUT_MS, SIGTERM_WAIT_MS } from '../config.js';
-import { sendKeysToPane, pollForPidFile } from '../tmux.js';
-import { isPidAlive, getProcessStartTime, killProcessGroup } from '../process.js';
+import { sendKeysToPane, pollForPidFile, respawnPane } from '../tmux.js';
+import { getProcessStartTime, killProcessGroup } from '../process.js';
 import { updateLockChild, clearLockChild } from '../lock.js';
 import { writeState } from '../state.js';
 import { buildGateResult } from '../phases/verdict.js';
@@ -27,31 +27,18 @@ export async function runClaudeInteractive(
   const sessionName = state.tmuxSession;
   const workspacePane = state.tmuxWorkspacePane;
 
-  // Kill previous workspace process if alive (and matches saved start-time).
-  // Claude Code does not exit after writing the sentinel — it stays idle awaiting input.
-  // If we don't kill it, the next sendKeysToPane below types the wrapper command INTO
-  // Claude's input box (not a shell prompt), the PID file never appears, and phase reopen fails.
-  if (state.lastWorkspacePid !== null && isPidAlive(state.lastWorkspacePid)) {
-    const savedStart = state.lastWorkspacePidStartTime;
-    const actualStart = getProcessStartTime(state.lastWorkspacePid);
-    if (savedStart !== null && actualStart !== null && Math.abs(actualStart - savedStart) <= 2) {
-      sendKeysToPane(sessionName, workspacePane, 'C-c');
-      const deadline = Date.now() + 5000;
-      while (isPidAlive(state.lastWorkspacePid) && Date.now() < deadline) {
-        await new Promise<void>((r) => setTimeout(r, 200));
-      }
-      if (isPidAlive(state.lastWorkspacePid)) {
-        await killProcessGroup(state.lastWorkspacePid, SIGTERM_WAIT_MS);
-      }
-    }
-    state.lastWorkspacePid = null;
-    state.lastWorkspacePidStartTime = null;
-    writeState(runDir, state);
-  }
-
-  // Safety: Ctrl+C + wait
-  sendKeysToPane(sessionName, workspacePane, 'C-c');
-  await new Promise<void>((r) => setTimeout(r, 500));
+  // Atomically reset the workspace pane before spawning the new runner.
+  // Claude Code does not exit after writing the sentinel — it stays idle
+  // awaiting input. send-keys to such a pane lands inside Claude's input
+  // box (not a shell prompt), the PID file never appears, and phase reopen
+  // fails. respawn-pane -k kills whatever is running and starts a fresh
+  // shell with clean TTY state, eliminating the race window. The 300 ms
+  // delay lets the new shell finish initialising before sendKeysToPane.
+  respawnPane(sessionName, workspacePane, cwd);
+  await new Promise<void>((r) => setTimeout(r, 300));
+  state.lastWorkspacePid = null;
+  state.lastWorkspacePidStartTime = null;
+  writeState(runDir, state);
 
   // PID file (phase/attempt scoped)
   const attemptId = state.phaseAttemptId[String(phase)] ?? '';

--- a/src/runners/codex.ts
+++ b/src/runners/codex.ts
@@ -5,8 +5,8 @@ import type { HarnessState, GatePhaseResult } from '../types.js';
 import type { ModelPreset } from '../config.js';
 import { GATE_TIMEOUT_MS, SIGTERM_WAIT_MS } from '../config.js';
 import { updateLockChild, clearLockChild } from '../lock.js';
-import { getProcessStartTime, killProcessGroup, isPidAlive } from '../process.js';
-import { sendKeysToPane, pollForPidFile } from '../tmux.js';
+import { getProcessStartTime, killProcessGroup } from '../process.js';
+import { sendKeysToPane, pollForPidFile, respawnPane } from '../tmux.js';
 import { writeState } from '../state.js';
 import { buildGateResult, extractCodexMetadata } from '../phases/verdict.js';
 import { isInGitRepo } from '../git.js';
@@ -297,27 +297,18 @@ export async function spawnCodexInPane(input: SpawnCodexInPaneInput): Promise<Co
   const sessionName = state.tmuxSession;
   const workspacePane = state.tmuxWorkspacePane;
 
-  // Kill previous workspace process if alive (same guard as runClaudeInteractive)
-  if (state.lastWorkspacePid !== null && isPidAlive(state.lastWorkspacePid)) {
-    const savedStart = state.lastWorkspacePidStartTime;
-    const actualStart = getProcessStartTime(state.lastWorkspacePid);
-    if (savedStart !== null && actualStart !== null && Math.abs(actualStart - savedStart) <= 2) {
-      sendKeysToPane(sessionName, workspacePane, 'C-c');
-      const deadline = Date.now() + 5000;
-      while (isPidAlive(state.lastWorkspacePid) && Date.now() < deadline) {
-        await new Promise<void>((r) => setTimeout(r, 200));
-      }
-      if (isPidAlive(state.lastWorkspacePid)) {
-        await killProcessGroup(state.lastWorkspacePid, SIGTERM_WAIT_MS);
-      }
-    }
-    state.lastWorkspacePid = null;
-    state.lastWorkspacePidStartTime = null;
-    writeState(runDir, state);
-  }
-
-  sendKeysToPane(sessionName, workspacePane, 'C-c');
-  await new Promise<void>((r) => setTimeout(r, 500));
+  // Atomically reset the workspace pane before spawning the new runner.
+  // Codex CLI TUI / Claude TUI do not exit after writing the sentinel — they
+  // stay in REPL mode holding the pane. send-keys to such a pane lands in the
+  // REPL's input field, not a shell prompt (issue #90). respawn-pane -k
+  // kills whatever is running and starts a fresh shell with clean TTY state
+  // (issue #88). The 300 ms delay lets the new shell finish initialising
+  // before sendKeysToPane below.
+  respawnPane(sessionName, workspacePane, cwd);
+  await new Promise<void>((r) => setTimeout(r, 300));
+  state.lastWorkspacePid = null;
+  state.lastWorkspacePidStartTime = null;
+  writeState(runDir, state);
 
   const pidFile = path.join(runDir, `codex-gate-${phase}.pid`);
   if (fs.existsSync(pidFile)) fs.unlinkSync(pidFile);
@@ -415,26 +406,12 @@ export async function spawnCodexInteractiveInPane(
   const sessionName = state.tmuxSession;
   const workspacePane = state.tmuxWorkspacePane;
 
-  if (state.lastWorkspacePid !== null && isPidAlive(state.lastWorkspacePid)) {
-    const savedStart = state.lastWorkspacePidStartTime;
-    const actualStart = getProcessStartTime(state.lastWorkspacePid);
-    if (savedStart !== null && actualStart !== null && Math.abs(actualStart - savedStart) <= 2) {
-      sendKeysToPane(sessionName, workspacePane, 'C-c');
-      const deadline = Date.now() + 5000;
-      while (isPidAlive(state.lastWorkspacePid) && Date.now() < deadline) {
-        await new Promise<void>((r) => setTimeout(r, 200));
-      }
-      if (isPidAlive(state.lastWorkspacePid)) {
-        await killProcessGroup(state.lastWorkspacePid, SIGTERM_WAIT_MS);
-      }
-    }
-    state.lastWorkspacePid = null;
-    state.lastWorkspacePidStartTime = null;
-    writeState(runDir, state);
-  }
-
-  sendKeysToPane(sessionName, workspacePane, 'C-c');
-  await new Promise<void>((r) => setTimeout(r, 500));
+  // See spawnCodexInPane above — same rationale (issues #88, #90).
+  respawnPane(sessionName, workspacePane, cwd);
+  await new Promise<void>((r) => setTimeout(r, 300));
+  state.lastWorkspacePid = null;
+  state.lastWorkspacePidStartTime = null;
+  writeState(runDir, state);
 
   const pidFile = path.join(runDir, `codex-interactive-${phase}.pid`);
   if (fs.existsSync(pidFile)) fs.unlinkSync(pidFile);

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -124,6 +124,27 @@ export function sendKeysToPane(_session: string, paneTarget: string, keys: strin
 }
 
 /**
+ * Atomically reset a pane: kill any process currently running in it (-k) and
+ * start a fresh default shell with the given cwd. Restores a clean TTY (raw
+ * mode cleared, foreground process is a shell prompt) so the next
+ * sendKeysToPane lands on a shell rather than a prior runner's REPL input.
+ *
+ * Used between phase boundaries because Codex CLI / Claude Code TUI do NOT
+ * exit after writing the phase sentinel — they stay in REPL mode holding the
+ * pane, and Ctrl-C alone does not reliably terminate them. respawn-pane
+ * sidesteps both pitfalls atomically. Required tmux ≥ 2.4 for `-k`.
+ */
+export function respawnPane(_session: string, paneTarget: string, cwd: string): void {
+  // Pane IDs (%N) are globally unique — target directly, no session prefix needed.
+  // No shell-command argument: tmux uses the default shell, so the pane stays
+  // open after the runner exits (preserving state.tmuxWorkspacePane validity).
+  execSync(
+    `tmux respawn-pane -k -t ${escSmart(paneTarget)} -c ${esc(cwd)}`,
+    { stdio: 'pipe' },
+  );
+}
+
+/**
  * Focus a specific pane.
  */
 export function selectPane(_session: string, paneTarget: string): void {

--- a/tests/phases/interactive.test.ts
+++ b/tests/phases/interactive.test.ts
@@ -39,6 +39,7 @@ vi.mock('../../src/runners/codex-isolation.js', async () => {
 vi.mock('../../src/tmux.js', () => ({
   sendKeysToPane: vi.fn(),
   pollForPidFile: vi.fn().mockResolvedValue(12345),
+  respawnPane: vi.fn(),
 }));
 
 vi.mock('../../src/process.js', () => ({

--- a/tests/runners/claude.test.ts
+++ b/tests/runners/claude.test.ts
@@ -7,6 +7,7 @@ import type { ModelPreset } from '../../src/config.js';
 vi.mock('../../src/tmux.js', () => ({
   sendKeysToPane: vi.fn(),
   pollForPidFile: vi.fn().mockResolvedValue(null),
+  respawnPane: vi.fn(),
 }));
 
 vi.mock('../../src/process.js', () => ({

--- a/tests/runners/codex.test.ts
+++ b/tests/runners/codex.test.ts
@@ -30,6 +30,7 @@ vi.mock('../../src/process.js', () => ({
 vi.mock('../../src/tmux.js', () => ({
   sendKeysToPane: vi.fn(),
   pollForPidFile: vi.fn().mockResolvedValue(12345),
+  respawnPane: vi.fn(),
 }));
 vi.mock('../../src/state.js', () => ({
   writeState: vi.fn(),

--- a/tests/tmux.test.ts
+++ b/tests/tmux.test.ts
@@ -9,7 +9,7 @@ vi.mock('child_process', async (importActual) => {
 });
 
 import { execSync } from 'child_process';
-import { createSession, sessionExists, createWindow, killWindow, killSession, sendKeys, isInsideTmux, getCurrentSessionName, getActiveWindowId, windowExists, selectWindow, splitPane, sendKeysToPane, selectPane, paneExists, getDefaultPaneId, pollForPidFile } from '../src/tmux.js';
+import { createSession, sessionExists, createWindow, killWindow, killSession, sendKeys, isInsideTmux, getCurrentSessionName, getActiveWindowId, windowExists, selectWindow, splitPane, sendKeysToPane, selectPane, paneExists, getDefaultPaneId, pollForPidFile, respawnPane } from '../src/tmux.js';
 
 describe('tmux utilities', () => {
   beforeEach(() => {
@@ -166,6 +166,17 @@ describe('tmux utilities', () => {
     expect(cmd).toContain('send-keys');
     expect(cmd).toContain('echo hello');
     expect(cmd).toContain('Enter');
+  });
+
+  it('respawnPane uses tmux respawn-pane -k with cwd and pane ID', () => {
+    respawnPane('sess', '%7', '/tmp/repo');
+    const cmd = vi.mocked(execSync).mock.calls[0][0] as string;
+    expect(cmd).toContain('respawn-pane');
+    expect(cmd).toContain('-k');
+    expect(cmd).toContain('%7');
+    expect(cmd).toContain('/tmp/repo');
+    // No shell-command argument — defaults to user shell (preserves pane).
+    expect(cmd).not.toMatch(/sh\s+-c/);
   });
 
   it('selectPane is best-effort (no throw on error)', () => {


### PR DESCRIPTION
## Summary

Both issues share one root cause: **the workspace pane is not reliably reset between phases.**

- **#90 (P3→P4 send-keys leak):** PR #80 added `lastWorkspacePid = null` cleanup after Codex interactive phases when the runner was `codex exec` (auto-exits). PR #85 switched to the Codex TUI which **stays in REPL mode** after writing the sentinel — the cleanup wasn't updated. State forgot the live codex PID, the next phase's kill block silently skipped, and `tmux send-keys` typed the new `sh -c '...exec codex...'` into codex's input draft instead of a shell prompt.
- **#88 (`stdin is not a terminal`):** The original `< prompt-file` surface was already removed in PR #85. The remaining fragility — "fresh pane works, dirty pane fails" — is the same class of bug: `send-keys` assumes the pane's foreground is a clean shell, only true when no prior runner is still holding it.

## Fix

Switch all three runner spawn paths to a single atomic `tmux respawn-pane -k -t <pane> -c <cwd>` followed by `send-keys` of the existing wrapped command:

- `spawnCodexInPane` (gates 2/4/7)
- `spawnCodexInteractiveInPane` (interactive 1/3/5)
- `runClaudeInteractive`

`respawn-pane -k`:
- kills any process holding the pane (fixes #90)
- starts a fresh default shell with clean TTY state (fixes #88's pane-state-dependent surface)
- no shell-command argument → pane survives runner exit (preserves `state.tmuxWorkspacePane` validity)

Also drops the buggy `lastWorkspacePid = null` in `interactive.ts` post-Codex (regression from PR #80→#85). Keeping the live PID lets orphan-cleanup on harness exit reach the leaked process; the next phase's `respawnPane` zeroes the field after killing.

## Test plan

- [x] `pnpm lint` (tsc --noEmit) clean
- [x] `pnpm vitest run` — 76/76 files, 1052/1052 tests pass (1 skipped)
- [x] New unit test for `respawnPane` in `tests/tmux.test.ts`
- [ ] **Live tmux smoke test** (recommended, not run here): full-flow with codex preset on both sides of P3→P4 to confirm the gate fires automatically without manual intervention

Fixes #88
Fixes #90