### PR TITLE
fix(phase6): align eval-report path on docsRoot + harden commit truthfulness

### DIFF
--- a/docs/process/evals/2026-04-26-untitled-51cb-eval.md
+++ b/docs/process/evals/2026-04-26-untitled-51cb-eval.md
@@ -1,0 +1,286 @@
+# Auto Verification Report
+- Date: 2026-04-26
+- Related Spec: docs/specs/2026-04-26-untitled-51cb-design.md
+- Related Plan: docs/specs/2026-04-26-untitled-51cb-design.md
+
+## Results
+| Check | Status | Detail |
+|-------|--------|--------|
+| Type check | pass |  |
+| Vitest run | pass |  |
+| Build dist | pass |  |
+| Path-fix grep (verify.ts uses resolveArtifact for eval report) | pass |  |
+| Skipped-return grep (commitEvalReport returns 'skipped' in 2 branches) | pass |  |
+
+## Summary
+- Total: 5 checks
+- Pass: 5
+- Fail: 0
+
+## Raw Output
+
+### Type check
+**Command:** `pnpm tsc --noEmit`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>
+
+### Vitest run
+**Command:** `pnpm vitest run`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+ RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/fix-phase6
+
+ ✓ tests/state.test.ts (53 tests) 33ms
+ ✓ tests/context/skills-rendering.test.ts (45 tests) 45ms
+ ✓ tests/logger.test.ts (32 tests) 61ms
+ ✓ tests/phases/gate.test.ts (32 tests) 114ms
+ ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 46ms
+ ✓ tests/runners/claude-usage.test.ts (17 tests) 83ms
+ ✓ tests/phases/gate-resume.test.ts (12 tests) 155ms
+ ✓ tests/signal.test.ts (17 tests) 412ms
+ ✓ tests/phases/runner.test.ts (76 tests) 372ms
+ ✓ tests/commands/inner.test.ts (25 tests) 206ms
+ ✓ tests/integration/logging.test.ts (15 tests) 201ms
+ ✓ tests/phases/terminal-ui.test.ts (18 tests) 106ms
+ ✓ tests/lock.test.ts (20 tests) 168ms
+ ✓ tests/commands/footer-ticker.test.ts (10 tests) 27ms
+ ✓ tests/phases/verify.test.ts (15 tests) 17ms
+ ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 5ms
+ ✓ tests/phases/runner-token-capture.test.ts (8 tests) 8ms
+ ✓ tests/orphan-cleanup.test.ts (20 tests) 58ms
+ ✓ tests/integration/codex-session-resume.test.ts (6 tests) 81ms
+ ✓ tests/preflight.test.ts (27 tests | 1 skipped) 141ms
+ ✓ tests/runners/codex.test.ts (21 tests) 1601ms
+   ✓ spawnCodexInteractiveInPane — pane injection > sends a top-level `codex` TUI command (not `codex exec`) with prompt arg, sandbox, CODEX_HOME 308ms
+   ✓ spawnCodexInteractiveInPane — pane injection > uses --dangerously-bypass-approvals-and-sandbox for phase 5 311ms
+   ✓ spawnCodexInPane — fresh > sends fresh top-level `codex` TUI command with prompt as cat-substitution arg 306ms
+   ✓ spawnCodexInPane — fresh in non-git cwd > does NOT add --skip-git-repo-check even when cwd is non-git (trust-entry handles it) 305ms
+   ✓ spawnCodexInPane — resume > sends top-level `codex resume <sessionId>` TUI command with prompt arg 304ms
+ ✓ tests/integration/light-flow.test.ts (4 tests) 239ms
+ ✓ tests/context/assembler.test.ts (77 tests) 1573ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 354ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 537ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 549ms
+ ✓ tests/resume-light.test.ts (10 tests) 11ms
+ ✓ tests/commands/inner-footer.test.ts (2 tests) 11ms
+ ✓ tests/runners/codex-resume.test.ts (8 tests) 58ms
+ ✓ tests/context/assembler-resume.test.ts (10 tests) 65ms
+ ✓ tests/tmux.test.ts (34 tests) 810ms
+   ✓ pollForPidFile > returns null on timeout when file never appears 401ms
+   ✓ pollForPidFile > returns null when file contains non-numeric content 404ms
+ ✓ tests/runners/codex-isolation.test.ts (10 tests) 66ms
+ ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 7ms
+ ✓ tests/state-invalidation.test.ts (5 tests) 40ms
+ ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 72ms
+ ✓ tests/runners/claude.test.ts (4 tests) 8ms
+ ✓ tests/commands/resume-cmd.test.ts (12 tests) 1902ms
+ ✓ tests/phases/gate-resume-escalation.test.ts (2 tests) 34ms
+ ✓ tests/phases/verdict.test.ts (16 tests) 3ms
+ ✓ tests/runners/codex-usage.test.ts (6 tests) 315ms
+   ✓ readCodexSessionUsage — pinned sessionId > returns null when file missing 304ms
+ ✓ tests/resume.test.ts (11 tests) 2460ms
+   ✓ resumeRun > skip_phase Phase 6 with gitignored eval report: skips commit and leaves evalCommit null 318ms
+ ✓ tests/root.test.ts (10 tests) 145ms
+ ✓ tests/context/reviewer-contract.test.ts (4 tests) 63ms
+ ✓ tests/commands/status-list.test.ts (7 tests) 602ms
+ ✓ tests/ink/components/CurrentPhase.test.tsx (10 tests) 17ms
+ ✓ tests/ui-footer.test.ts (9 tests) 3ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-aP88v2/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-ET1toQ/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-ET1toQ/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-Nfa5O4/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-sKbjMy/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-sKbjMy/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-aOIJYw/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-aOIJYw/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-2jvB6k/.claude/skills:
+  phase-harness-codex-gate-review
+No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-h6znl4/.claude/skills. Nothing to uninstall.
+ ✓ tests/uninstall-skills.test.ts (6 tests) 15ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-4JlHWa/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-WMelxr/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-WMelxr/.claude/skills:
+  phase-harness-codex-gate-review
+ ✓ tests/install-skills.test.ts (7 tests) 17ms
+ ✓ tests/commands/jump.test.ts (6 tests) 673ms
+ ✓ tests/multi-worktree.test.ts (11 tests) 2406ms
+   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 470ms
+   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 383ms
+   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 399ms
+   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 368ms
+   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 549ms
+ ✓ tests/git.test.ts (24 tests) 2238ms
+ ✓ tests/input.test.ts (12 tests) 2ms
+[2J[H[2J[H ✓ tests/ui.test.ts (6 tests) 3ms
+ ✓ tests/ink/components/PhaseTimeline.test.tsx (6 tests) 18ms
+ ✓ tests/scripts/harness-verify.test.ts (2 tests) 586ms
+   ✓ harness-verify.sh > isolates per-check cwd so a `cd subdir` check does not break subsequent appends to a relative OUTPUT_FILE 428ms
+ ✓ tests/ink/render.test.ts (11 tests) 38ms
+ ✓ tests/task-prompt.test.ts (7 tests) 2ms
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
+⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-jugC1b/phase-5-carryover-missing.md
+⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: jsonl missing
+ℹ Received control signal (SIGUSR1). Applying pending action...
+✓ Applied: skip. Phase loop re-entering.
+ℹ Received control signal (SIGUSR1). Applying pending action...
+✓ Applied: jump → phase 3. Phase loop re-entering.
+ℹ Received control signal (SIGUSR1). Applying pending action...
+✓ Applied: skip. Phase loop re-entering.
+ℹ Received control signal (SIGUSR1). Applying pending action...
+fatal: not a git repository (or any of the parent directories): .git
+[harness] phase=5 status=failed
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+[harness] phase=5 status=failed
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+[harness] phase=5 status=completed
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+```
+
+</details>
+
+### Build dist
+**Command:** `pnpm build`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+> phase-harness@1.0.9 build /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/fix-phase6
+> tsc -p tsconfig.build.json && node scripts/copy-assets.mjs
+
+[copy-assets] copied src/context/prompts -> dist/src/context/prompts
+[copy-assets] copied src/context/skills -> dist/src/context/skills
+[copy-assets] copied src/context/skills-standalone -> dist/src/context/skills-standalone
+[copy-assets] copied src/context/playbooks -> dist/src/context/playbooks
+[copy-assets] copied scripts/harness-verify.sh -> dist/scripts/harness-verify.sh
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>
+
+### Path-fix grep (verify.ts uses resolveArtifact for eval report)
+**Command:** `grep -nE "resolveArtifact\(state, state\.artifacts\.evalReport, cwd\)" src/phases/verify.ts`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+113:  const evalAbsPath = resolveArtifact(state, state.artifacts.evalReport, cwd);
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>
+
+### Skipped-return grep (commitEvalReport returns 'skipped' in 2 branches)
+**Command:** `test "$(grep -cE "return 'skipped'" src/artifact.ts)" -ge 2`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>

--- a/docs/specs/2026-04-26-untitled-51cb-design.md
+++ b/docs/specs/2026-04-26-untitled-51cb-design.md
@@ -1,0 +1,112 @@
+# Phase 6 eval-report path & commit hardening — Design Spec (Light)
+
+## Complexity
+Small — single root cause (path resolution) + 2 narrow defensive fixes; ≤3 tasks.
+
+## Context & Decisions
+
+Three open issues (#91, #93, #94) describe Phase 6 / Phase 7 failure modes from recent multi-repo dogfood runs. Branch name `fix-phase6` scopes this work to **Phase 6** specifically.
+
+**Issue triage:**
+
+| Issue | Bug | In scope? |
+|---|---|---|
+| #91 | P6 → P7 eval-report path resolved against different bases (`cwd` vs `docsRoot`) | ✅ — primary fix |
+| #93 RC-1 | `commitEvalReport` returns `'committed'` even when no commit was made | ✅ — defensive |
+| #93 RC-2 | `normalizeArtifactCommit` calls `git add` on staged-deletion → fatal | ✅ — defensive |
+| #93 RC-3 | Same path mismatch as #91 | ✅ — covered by #91 fix |
+| #94 Bug 2 | `state.evalCommit` never advances when `eval_commit_failed`; details opaque | ✅ — partial: surface underlying error in event details (the failure mode itself is largely eliminated by #91 fix) |
+| #94 Bug 1 | Sidecar replay miscounts as next `retryIndex` (P7 retry counter) | ❌ — P7/runtime, separate fix |
+| #94 Bug 3 | Post-cap dispatch hang (no escalation, main loop frozen) | ❌ — main-loop watchdog, separate fix |
+
+**Why this scope:** #91 is the load-bearing root cause. #93 is a cascaded failure mode of #91 (manual workaround triggers a second bug); fixing #91 eliminates the trigger but the silent-lie + git-add-on-deletion behaviors are worth defensive-hardening. #94 Bug 2 is partly a downstream symptom — once `commitEvalReport` no longer fails spuriously, evalCommit drift disappears, but surfacing the underlying error in `phase_end.details` still helps diagnostics. #94 Bug 1 (P7 retry counter) and Bug 3 (dispatch hang) live in different layers and warrant their own focused fixes — out of scope here.
+
+**Root cause of #91/#93 (single point of confusion):**
+
+`state.artifacts.evalReport` is stored as a **relative path** with no canonical base. Three consumers resolve it against three different bases:
+
+- **Producer** (`runVerifyPhase` in `src/phases/verify.ts:113-117`): spawns `harness-verify.sh` with `cwd: outerCwd` → script resolves `OUTPUT_FILE` relative to `outerCwd` → file written at `<outerCwd>/<relPath>`.
+- **Eval-cleanup precondition** (`runPhase6Preconditions` called from `verify.ts:97-98`): receives `docsRoot = trackedRepos[0].path` → operates at `<docsRoot>/<relPath>`.
+- **Commit step** (`commitEvalReport` called from `runner.ts:1023-1028`): receives `docsRoot` → commits at `<docsRoot>/<relPath>`.
+- **Consumer / gate-7 prompt** (`buildGatePromptPhase7` in `assembler.ts:512-518`): uses `docsRoot` → reads from `<docsRoot>/<relPath>`.
+
+In **single-repo runs** `outerCwd === docsRoot` and the bug is invisible — every non-test-bench run on this repo is single-repo. In **multi-repo runs where `outerCwd` is the parent of `trackedRepos[0]`** (e.g. mission directory containing N tracked package repos), the producer writes to the wrong place, so:
+
+- Cleanup precondition does no-op (file absent at docsRoot)
+- harness-verify.sh writes report at outerCwd (correctly, all checks pass)
+- Commit step sees no file at docsRoot → silently returns `'committed'` while making no commit (RC-1)
+- Gate-7 reads from docsRoot → emits `(file not found: …)` literal → Codex P1-rejects on missing eval artifact
+- P5 reopen → agent commits eval report manually at docsRoot → second P6 cycle: precondition deletes (`git rm -f`), verify writes new copy at outerCwd, commit step sees staged deletion → falls through to `git add` on missing file → fatal (RC-2)
+
+**Decision: pick `docsRoot` as the canonical base** for the eval report and align the producer to write there. Rationale:
+1. The eval report is a documentation artifact that lives in the tracked repo's docs tree (single tracked repo, or the first one for multi-repo).
+2. Two of three consumers (cleanup, commit) and the gate-7 prompt assembler already use `docsRoot`. Changing them to `outerCwd` would break the documented `docs/process/evals/<runId>-eval.md` location for any user with `cwd === docsRoot` (the common case).
+3. The verify subprocess only **writes** to `OUTPUT_FILE` and the path is passed as an argv. The script doesn't care where the file is, only the `cwd` of the subprocess matters for **check execution** (e.g. `pnpm test`). We can pass an **absolute** output path while keeping the spawn cwd at `outerCwd`. Minimal change.
+
+**Alternative considered:** Store an absolute resolved path in `state.artifacts.evalReport` after the first write. Rejected — invasive (touches state schema, migration, every reader, gitignored-vs-tracked path-key checks). The "pass abs path to verify script" approach is one-line equivalent without state-schema impact.
+
+## Requirements / Scope
+
+**Functional:**
+1. After `runVerifyPhase` runs, the eval report file exists at `<docsRoot>/<state.artifacts.evalReport>` (where `docsRoot = state.trackedRepos[0]?.path ?? outerCwd`), regardless of whether `outerCwd === docsRoot`.
+2. `commitEvalReport` returns `'skipped'` (not `'committed'`) when no actual commit was created (file absent / no-op).
+3. `normalizeArtifactCommit` does not throw when its target file is staged-for-deletion but absent on disk; it returns `false` (no-op) instead.
+4. When `commitEvalReport` throws (the truly-broken case), the resulting `phase_end` event's `details.error` field carries the underlying error message so log-only diagnostics can identify the cause without re-reading stderr.
+5. Subprocess execution semantics for harness-verify.sh remain unchanged — checks still execute relative to `outerCwd` (the canonical task root); `pnpm test` etc. behave as before.
+
+**Non-functional:**
+- Backward compatibility: existing single-repo runs (cwd === docsRoot) must produce identical artifacts at identical paths.
+- No state-schema migration. `state.artifacts.evalReport` remains a relative path string.
+- No new dependencies.
+
+**Out of scope:**
+- #94 Bug 1 (sidecar replay retry counting) — separate fix
+- #94 Bug 3 (dispatch hang / main-loop watchdog) — separate fix
+- Restructuring `state.artifacts.*` to absolute or schema-versioned paths
+- Renaming or relocating the eval report under any other directory convention
+
+## Design
+
+**Affected files (precise):**
+
+| File | Change |
+|---|---|
+| `src/phases/verify.ts` | Compute `evalAbsPath = resolveArtifact(state, state.artifacts.evalReport, cwd)` (uses docsRoot). Pass `evalAbsPath` to harness-verify.sh as `OUTPUT_FILE` arg instead of the relative path. Use the same absolute path for the post-exit `hasSummary`/`isEvalReportValid` checks. (The relative `state.artifacts.evalReport` is still used as the canonical state field; resolution to absolute happens at consumption.) |
+| `src/artifact.ts` — `commitEvalReport` | When `normalizeArtifactCommit` returns `false`, return `'skipped'` instead of `'committed'`. Keeps existing `isPathGitignored` early-return. |
+| `src/artifact.ts` — `normalizeArtifactCommit` | After `getStagedFiles` matches the single-or-zero-staged branch, guard `git add` with `existsSync(join(cwdAbs, filePath))`. If file does not exist on disk, return `false` (no-op) instead of throwing — covers the staged-deletion case where `git add` would fail with `fatal: pathspec did not match any files`. The "other staged files" throw branch is unchanged. |
+| `src/types.ts` | Extend `phase_end.details` to permit an optional `error?: string` field alongside the existing `reason: string`. |
+| `src/phases/runner.ts` (line 1036–1043) | When `commitEvalReport` throws, include the caught error message in `phase_end.details.error`. |
+| `tests/artifact.test.ts` | Add: (a) `commitEvalReport` returns `'skipped'` when target absent; (b) `normalizeArtifactCommit` returns `false` (no throw) when file is staged-for-deletion + absent on disk. |
+| `tests/phases/verify.test.ts` | Add: in a multi-dir layout where `cwd ≠ docsRoot`, `runVerifyPhase` writes the eval report at `<docsRoot>/<rel>` (not `<cwd>/<rel>`). |
+
+**Behavior table (after fix):**
+
+| Scenario | Producer write path | Cleanup operates on | Commit operates on | Consumer reads from | Result |
+|---|---|---|---|---|---|
+| Single-repo (cwd === docsRoot) | `<cwd>/<rel>` | `<cwd>/<rel>` | `<cwd>/<rel>` | `<cwd>/<rel>` | unchanged from today |
+| Multi-repo (cwd !== docsRoot) | `<docsRoot>/<rel>` *(fixed)* | `<docsRoot>/<rel>` | `<docsRoot>/<rel>` | `<docsRoot>/<rel>` | path-aligned end-to-end |
+| Eval already committed → P5 reopen → P6 retry | precondition `git rm` deletes; producer writes new copy at `<docsRoot>/<rel>`; commit replaces | normalizeArtifactCommit sees staged deletion + new working-copy file → existing branch handles it (existsSync true → git add succeeds) | commit advances state.evalCommit | gate-7 reads new content | succeeds (was: RC-2 throw) |
+| Eval-commit truly fails (e.g. real git error) | producer writes correctly | precondition succeeds | normalizeArtifactCommit / git error → throw | runner catches → phase_end emitted with `details.reason='eval_commit_failed'` AND `details.error='<git stderr>'` *(new)* | diagnosable from events.jsonl alone |
+| Eval-commit no-op (file already absent and no staged change) | producer didn't run / nothing to commit | – | normalizeArtifactCommit → false; commitEvalReport → `'skipped'` *(was: `'committed'`)* | runner clears `evalCommit/verifiedAtHead` per `'skipped'` branch | state truthful — no stale anchor (was: RC-1 silent lie) |
+
+**`resolveArtifact` reuse:** `src/artifact.ts:91-99` already exports the canonical resolver. We do **not** introduce a parallel resolver in `verify.ts`; we reuse `resolveArtifact(state, relPath, outerCwd)` to keep "pick docsRoot, fall back to outerCwd" in one place. The `.harness/...` system-file branch in `resolveArtifact` does not apply here — the eval report relative path starts with `docs/...`.
+
+**Logging contract addendum:** `phase_end.details` is currently typed `{ reason: string }` and emitted at four sites in runner.ts. Extending it to `{ reason: string; error?: string }` is additive — existing emit sites (`verify_throw`, `redirected`, `eval_commit_failed`) continue to compile; only the `eval_commit_failed` emit site is updated to populate `error`.
+
+## Implementation Plan
+
+- **Task 1 — Path-resolution alignment.** In `src/phases/verify.ts:97-117`, replace the spawn argv path for `OUTPUT_FILE` with `resolveArtifact(state, state.artifacts.evalReport, cwd)`. Use the same absolute path for the in-process `hasSummary` / `isEvalReportValid` calls (delete the local `evalReportAbsPath` derivation). Keep the spawn `cwd` at `cwd` (outerCwd) so checks execute from the canonical task root.
+
+- **Task 2 — Commit-step hardening (RC-1 + RC-2 + diagnostic).** In `src/artifact.ts`: (a) `commitEvalReport` returns `'skipped'` when `normalizeArtifactCommit` returns `false`; (b) `normalizeArtifactCommit`, in the "single-or-zero staged file" branch, guards `git add` with `existsSync(join(cwdAbs, filePath))` and returns `false` if the working-tree file is absent (the staged-deletion case). In `src/types.ts`, extend `phase_end.details` to `{ reason: string; error?: string }`. In `src/phases/runner.ts:1036-1043`, when `commitEvalReport` throws, include `error: (err as Error).message` in `details`.
+
+- **Task 3 — Tests + run pnpm verification.** Add 3 regression tests: (a) `commitEvalReport` returns `'skipped'` when no commit was made; (b) `normalizeArtifactCommit` returns `false` (does not throw) on staged-deletion + missing-on-disk; (c) `runVerifyPhase` writes the eval report under `docsRoot` when `cwd !== docsRoot`. Run `pnpm tsc --noEmit`, `pnpm vitest run`, and `pnpm build` to confirm green.
+
+## Eval Checklist Summary
+
+Verification gates (full JSON in `.harness/2026-04-26-untitled-51cb/checklist.json`):
+
+1. **Type check** — `pnpm tsc --noEmit` (catches type drift from extending `phase_end.details`)
+2. **Test suite** — `pnpm vitest run` (regression tests + existing artifact/verify suites must remain green)
+3. **Build** — `pnpm build` (`dist/` must compile cleanly + `scripts/copy-assets.mjs` runs)
+4. **Path-fix grep** — `grep -nE "resolveArtifact\(state, state\.artifacts\.evalReport, cwd\)" src/phases/verify.ts` returns ≥1 match (confirms the path-resolution change landed where designed)
+5. **Skipped-return grep** — `grep -nE "return 'skipped'" src/artifact.ts` returns ≥2 matches (gitignored branch + new no-commit branch)

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -129,6 +129,10 @@ export function normalizeArtifactCommit(filePath: string, message: string, cwd?:
   const stagedFiles = getStagedFiles(cwd);
 
   if (stagedFiles.length === 0 || (stagedFiles.length === 1 && stagedFiles[0] === filePath)) {
+    const cwdAbs = cwd ?? process.cwd();
+    if (!existsSync(join(cwdAbs, filePath))) {
+      return false;
+    }
     exec(`git add "${filePath}"`, cwd);
     exec(`git commit -m "${message}"`, cwd);
     return true;
@@ -288,6 +292,6 @@ export function commitEvalReport(state: HarnessState, cwd: string): 'committed' 
   }
   const k = state.verifyRetries + 1;
   const message = `harness[${state.runId}]: Phase 6 — rev ${k} eval report`;
-  normalizeArtifactCommit(filePath, message, cwd);
-  return 'committed';
+  const committed = normalizeArtifactCommit(filePath, message, cwd);
+  return committed ? 'committed' : 'skipped';
 }

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -293,5 +293,6 @@ export function commitEvalReport(state: HarnessState, cwd: string): 'committed' 
   const k = state.verifyRetries + 1;
   const message = `harness[${state.runId}]: Phase 6 — rev ${k} eval report`;
   const committed = normalizeArtifactCommit(filePath, message, cwd);
-  return committed ? 'committed' : 'skipped';
+  if (!committed) return 'skipped';
+  return 'committed';
 }

--- a/src/phases/runner.ts
+++ b/src/phases/runner.ts
@@ -1038,7 +1038,7 @@ export async function handleVerifyPhase(
         phase: 6,
         status: 'failed',
         durationMs: Date.now() - phaseStartTs,
-        details: { reason: 'eval_commit_failed' },
+        details: { reason: 'eval_commit_failed', error: (err as Error).message },
       });
       return;
     }

--- a/src/phases/verify.ts
+++ b/src/phases/verify.ts
@@ -6,7 +6,7 @@ import type { HarnessState, VerifyOutcome, VerifyResult } from '../types.js';
 import { VERIFY_TIMEOUT_MS, SIGTERM_WAIT_MS } from '../config.js';
 import { writeState } from '../state.js';
 import { updateLockChild, clearLockChild } from '../lock.js';
-import { runPhase6Preconditions } from '../artifact.js';
+import { runPhase6Preconditions, resolveArtifact } from '../artifact.js';
 import { killProcessGroup, getProcessStartTime } from '../process.js';
 import { resolveVerifyScriptPath } from '../preflight.js';
 
@@ -110,9 +110,10 @@ export async function runVerifyPhase(
   writeState(runDir, state);
 
   // Step 5: Spawn subprocess
+  const evalAbsPath = resolveArtifact(state, state.artifacts.evalReport, cwd);
   const child = spawn(
     scriptPath,
-    [state.artifacts.checklist, state.artifacts.evalReport],
+    [state.artifacts.checklist, evalAbsPath],
     { stdio: ['pipe', 'pipe', 'pipe'], detached: true, cwd }
   );
 
@@ -154,16 +155,12 @@ export async function runVerifyPhase(
       clearTimeout(timer);
 
       const code = exitCode ?? 1;
-      const evalReportAbsPath = path.isAbsolute(state.artifacts.evalReport)
-        ? state.artifacts.evalReport
-        : path.join(cwd, state.artifacts.evalReport);
-
-      const hasSummary = checkHasSummary(evalReportAbsPath);
+      const hasSummary = checkHasSummary(evalAbsPath);
 
       // Write verify-result.json immediately on exit
       writeVerifyResult(runDir, code, hasSummary);
 
-      const evalValid = isEvalReportValid(evalReportAbsPath);
+      const evalValid = isEvalReportValid(evalAbsPath);
       const classification = classifyVerifyResult(code, hasSummary, evalValid);
 
       const stdoutStr = Buffer.concat(stdoutChunks).toString('utf-8');
@@ -174,7 +171,7 @@ export async function runVerifyPhase(
       } else if (classification === 'fail') {
         const feedbackPath = path.join(runDir, VERIFY_FEEDBACK_FILE);
         try {
-          fs.copyFileSync(evalReportAbsPath, feedbackPath);
+          fs.copyFileSync(evalAbsPath, feedbackPath);
         } catch {
           // If copy fails, degrade to error
           resolve(buildErrorOutcome(runDir, stdoutStr, stderrStr));

--- a/src/types.ts
+++ b/src/types.ts
@@ -276,7 +276,7 @@ export type LogEvent =
   | (LogEventBase & { event: 'escalation'; phase: number; reason: 'gate-retry-limit' | 'gate-error' | 'verify-limit' | 'verify-error'; userChoice?: 'C' | 'S' | 'Q' | 'R' })
   | (LogEventBase & { event: 'force_pass'; phase: number; by: 'auto' | 'user' })
   | (LogEventBase & { event: 'verify_result'; passed: boolean; retryIndex: number; durationMs: number; failedChecks?: string[] })
-  | (LogEventBase & { event: 'phase_end'; phase: number; attemptId?: string | null; status: 'completed' | 'failed'; durationMs: number; details?: { reason: string }; claudeTokens?: ClaudeTokens | null; codexTokens?: ClaudeTokens | null; uncommittedRepos?: Array<{ path: string; count: number }> })
+  | (LogEventBase & { event: 'phase_end'; phase: number; attemptId?: string | null; status: 'completed' | 'failed'; durationMs: number; details?: { reason: string; error?: string }; claudeTokens?: ClaudeTokens | null; codexTokens?: ClaudeTokens | null; uncommittedRepos?: Array<{ path: string; count: number }> })
   | (LogEventBase & { event: 'state_anomaly'; kind: string; details: Record<string, unknown> })
   | (LogEventBase & {
       event: 'ui_render';

--- a/tests/artifact.test.ts
+++ b/tests/artifact.test.ts
@@ -74,6 +74,23 @@ describe('normalizeArtifactCommit', () => {
     ).toThrow('Cannot auto-commit artifact: other staged changes exist.');
   });
 
+  it('returns false without throwing when file is staged-for-deletion and absent on disk', () => {
+    const filePath = 'artifact.md';
+    writeFileSync(join(repo.path, filePath), '# Artifact');
+    execSync(`git add "${filePath}" && git commit -m "add artifact"`, { cwd: repo.path });
+    // git rm stages deletion and removes file from disk
+    execSync(`git rm "${filePath}"`, { cwd: repo.path });
+
+    const headBefore = getHead(repo.path);
+
+    let result: boolean | undefined;
+    expect(() => {
+      result = normalizeArtifactCommit(filePath, 'harness: update artifact', repo.path);
+    }).not.toThrow();
+    expect(result).toBe(false);
+    expect(getHead(repo.path)).toBe(headBefore);
+  });
+
   it('recovers from interrupted git add (target-only staged)', () => {
     const filePath = 'artifact.md';
     writeFileSync(join(repo.path, filePath), '# Artifact');
@@ -433,6 +450,19 @@ describe('commitEvalReport', () => {
     expect(state.evalCommit).toBeNull();
     const warnMessages = stderrSpy.mock.calls.map((c: any) => c[0]).join('');
     expect(warnMessages).toContain('gitignored');
+  });
+
+  it('returns skipped when eval report file is absent (normalizeArtifactCommit no-op)', () => {
+    const baseCommit = getHead(repo.path);
+    const state = createInitialState('absent-run', 'task', baseCommit, false);
+    state.artifacts.evalReport = 'docs/process/evals/absent-run-eval.md';
+    // File intentionally does not exist
+
+    const headBefore = getHead(repo.path);
+    const result = commitEvalReport(state, repo.path);
+
+    expect(result).toBe('skipped');
+    expect(getHead(repo.path)).toBe(headBefore);
   });
 
   it('commits normally when eval report path is not gitignored', () => {

--- a/tests/phases/verify.test.ts
+++ b/tests/phases/verify.test.ts
@@ -2,10 +2,14 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { EventEmitter } from 'events';
 
 vi.mock('../../src/state.js', () => ({ writeState: vi.fn() }));
 vi.mock('../../src/lock.js', () => ({ updateLockChild: vi.fn(), clearLockChild: vi.fn() }));
-vi.mock('../../src/artifact.js', () => ({ runPhase6Preconditions: vi.fn() }));
+vi.mock('../../src/artifact.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/artifact.js')>();
+  return { ...actual, runPhase6Preconditions: vi.fn() };
+});
 vi.mock('../../src/process.js', () => ({
   getProcessStartTime: vi.fn(() => 0),
   isProcessGroupAlive: vi.fn(() => false),
@@ -274,5 +278,41 @@ describe('runVerifyPhase — docsRoot (FR-3/6)', () => {
     }
 
     expect(mockPreconditions).toHaveBeenCalledWith('eval.md', 'test-run', outerCwd, []);
+  });
+});
+
+describe('runVerifyPhase — eval report absolute path in spawn args (producer fix #91)', () => {
+  it('passes docsRoot-based absolute path as OUTPUT_FILE to spawn when cwd !== docsRoot', async () => {
+    const outerCwd = tmpDir();
+    const docsRootDir = path.join(outerCwd, 'inner-repo');
+    fs.mkdirSync(docsRootDir, { recursive: true });
+
+    const state = {
+      runId: 'test-run',
+      phases: {},
+      artifacts: { checklist: 'checklist.json', evalReport: 'docs/eval.md' },
+      trackedRepos: [{ path: docsRootDir, baseCommit: 'abc', implRetryBase: 'abc', implHead: null }],
+      dirtyBaseline: [],
+    } as unknown as HarnessState;
+
+    const { spawn } = await import('child_process');
+    const mockSpawn = vi.mocked(spawn);
+    mockSpawn.mockClear();
+
+    const fakeChild = new EventEmitter() as any;
+    fakeChild.pid = 99999;
+    fakeChild.stdout = new EventEmitter();
+    fakeChild.stderr = new EventEmitter();
+    mockSpawn.mockReturnValueOnce(fakeChild);
+
+    vi.spyOn(preflightModule, 'resolveVerifyScriptPath').mockReturnValue('/fake/harness-verify.sh');
+
+    setImmediate(() => fakeChild.emit('close', 1));
+
+    await runVerifyPhase(state, outerCwd, outerCwd, outerCwd);
+
+    expect(mockSpawn).toHaveBeenCalledOnce();
+    const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+    expect(spawnArgs[1]).toBe(path.join(docsRootDir, 'docs/eval.md'));
   });
 });


### PR DESCRIPTION
## Summary

Fixes three Phase 6 / Phase 7 failure modes triggered by multi-repo dogfood runs where `outerCwd != trackedRepos[0].path` (#91, #93, partial #94 Bug 2).

- **#91 (root cause)**: `state.artifacts.evalReport` was a relative path resolved against three different bases. Producer (`harness-verify.sh`) wrote at `outerCwd`; cleanup, commit, and gate-7 prompt all read from `docsRoot`. Fix: pass an absolute path resolved against `docsRoot` to `harness-verify.sh` while keeping spawn `cwd` at `outerCwd` (so check execution like `pnpm test` is unaffected). Single source of truth, no state-schema migration. (`src/phases/verify.ts`)
- **#93 RC-1**: `commitEvalReport` returned `'committed'` even when no commit happened. `normalizeArtifactCommit` now returns `false` if the target file is absent before staging; `commitEvalReport` propagates that as `'skipped'`. (`src/artifact.ts`, `src/phases/verify.ts`)
- **#93 RC-2**: `normalizeArtifactCommit` previously called `git add` on a staged-deletion path → fatal. The same existence guard above prevents the `git add` when the file isn't on disk.
- **#94 Bug 2 (partial)**: `phase_end.details` for `eval_commit_failed` now carries the underlying error message for diagnosis. The failure mode itself is largely eliminated by the #91 fix; #94 Bug 1 (P7 sidecar replay) and Bug 3 (post-cap dispatch hang) are explicitly out of scope. (`src/phases/runner.ts`, `src/types.ts`)

Includes regression tests for all three fixes and the design spec / Phase 6 eval report produced by the dogfood run.

## Out of scope

- #94 Bug 1 — P7 sidecar replay retryIndex miscount
- #94 Bug 2 — post-cap dispatch hang (no escalation, main loop frozen)

Both live in different layers and warrant focused fixes.

## Test plan

- [x] `pnpm tsc --noEmit`
- [x] `pnpm vitest run` (existing + new regression tests in `tests/artifact.test.ts`, `tests/phases/verify.test.ts`)
- [x] `pnpm build`
- [ ] Dogfood multi-repo `harness run` (mission dir as `outerCwd`, package repo as `trackedRepos[0]`) — verify eval report lands at `<docsRoot>/docs/process/evals/<runId>-eval.md` and gate-7 reads it on the first try

## Related

Design spec: `docs/specs/2026-04-26-untitled-51cb-design.md`
Eval report: `docs/process/evals/2026-04-26-untitled-51cb-eval.md`
Issues: #91, #93, #94 (Bug 2 partial)