### PR TITLE
feat(gate): detect retry oscillation to replace auto-mode force-pass with escalation

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -227,6 +227,18 @@ phase-harness start --root /tmp/demo "task"
 - `--require-clean`을 주면 staged/unstaged 둘 다 차단됩니다
 - 첫 실행 시 `.gitignore`에 `.harness/`가 없으면 자동으로 추가합니다
 
+**자율 모드 게이트 스태그네이션 감지:**
+`--auto`로 실행할 때, harness는 *정체된* 게이트 재시도 사이클을 감지합니다 — 각 재시도의 리뷰어 피드백이 이전과 본질적으로 동일한 경우 — 조용히 강제 통과하는 대신 사용자에게 에스컬레이션합니다 (C/S/Q 프롬프트). 정체는 인접한 리뷰어 피드백 텍스트 사이의 토큰 집합 Jaccard 유사도로 측정합니다. 네 가지 환경 변수로 이 동작을 제어합니다:
+
+| 변수 | 기본값 | 설명 |
+|---|---|---|
+| `HARNESS_GATE_STAGNATION` | `on` (자율 모드) | `off`로 설정하면 감지 전 강제 통과 동작으로 복원 |
+| `HARNESS_GATE_STAGNATION_THRESHOLD` | `0.70` | Jaccard 유사도 임계값 [0, 1]; 높을수록 엄격 |
+| `HARNESS_GATE_STAGNATION_RUN` | `2` | 에스컬레이션 전 연속 정체 쌍 수 (최소 2) |
+| `HARNESS_GATE_STAGNATION_WINDOW` | `2` | 향후 사용 예약; 현재 2로 고정 (쌍 비교) |
+
+처음 세 변수에 잘못된 값이 있으면 해당 프로세스에서 기능이 비활성화되고 stderr에 경고 하나가 출력됩니다. 수동 모드에서는 항상 비활성화됩니다.
+
 ### `phase-harness resume [runId]`
 
 현재 run 또는 특정 run을 재개합니다.

--- a/README.md
+++ b/README.md
@@ -227,6 +227,18 @@ Important behavior:
 - if `--require-clean` is set, both staged and unstaged changes are blocked
 - on first run, harness ensures `.harness/` is present in `.gitignore`
 
+**Auto-mode gate stagnation detection:**
+When running with `--auto`, harness detects *stagnant* gate retry cycles — where each retry's reviewer feedback is essentially the same as the previous one — and escalates to the user (C/S/Q prompt) instead of silently force-passing. Stagnation is measured by token-set Jaccard similarity between adjacent reviewer feedback texts. Four environment variables control this behaviour:
+
+| Variable | Default | Description |
+|---|---|---|
+| `HARNESS_GATE_STAGNATION` | `on` (auto-mode) | Set to `off` to restore pre-detection force-pass behaviour |
+| `HARNESS_GATE_STAGNATION_THRESHOLD` | `0.70` | Jaccard similarity threshold [0, 1]; higher = stricter |
+| `HARNESS_GATE_STAGNATION_RUN` | `2` | Consecutive stagnant pairs required before escalation (min 2) |
+| `HARNESS_GATE_STAGNATION_WINDOW` | `2` | Reserved for future use; currently fixed at 2 (pair comparison) |
+
+Any invalid value for the first three variables disables the feature for that process and emits one warning to stderr. The feature is always off in manual mode.
+
 ### `phase-harness resume [runId]`
 
 Resumes the current run or a specific run.

--- a/docs/HOW-IT-WORKS.ko.md
+++ b/docs/HOW-IT-WORKS.ko.md
@@ -79,6 +79,23 @@ light flow 특이사항:
 - flow는 run 생성 시 고정되므로 `phase-harness resume --light`는 거부됩니다
 - P2 (pre-impl gate): Codex가 결합 design doc를 4축 루브릭으로 리뷰합니다. REJECT 시 즉시 P1 재진입 — feedback은 `pendingAction.feedbackPaths`로만 전달되고 `state.carryoverFeedback`는 Gate 2에서 설정되지 않습니다. Gate retry limit 3 (풀 플로우 P2와 동일). P2 활성화 이전에 생성된 legacy light run은 `phases['2']='skipped'` 상태를 유지합니다 — activation은 `createInitialState`를 통한 forward-only이고 retroactive migration이 아닙니다.
 - gate retry limit: light P2 = 3회, light P7 = 5회, 풀 플로우 = 3회
+
+### 게이트 스태그네이션 감지 (자율 모드)
+
+자율 모드에서 게이트 페이즈가 `retryLimit`번 연속으로 거부되면, harness는 강제 통과 전에 거부가 *정체 상태*인지 확인합니다. 정체는 마지막 두 인접 리뷰어 피드백 텍스트가 NFKC 정규화 후 토큰 집합 Jaccard 유사도 ≥70%인 경우로 정의됩니다. 두 조건이 모두 충족되면 (자율 모드 + 정체 감지) harness는 강제 통과 대신 C/S/Q 프롬프트로 에스컬레이션합니다. 이는 처리되지 않은 근본 원인이 다음 페이즈로 조용히 넘어가는 것을 방지합니다.
+
+**설정:** 네 가지 환경 변수로 감지를 제어합니다; 전체 표는 README를 참조하세요. 주요 기본값:
+- `HARNESS_GATE_STAGNATION=on` (자율 모드 기본값; `=off`로 기존 강제 통과 동작으로 복원)
+- `HARNESS_GATE_STAGNATION_THRESHOLD=0.70`
+- `HARNESS_GATE_STAGNATION_RUN=2` (연속 정체 쌍 2개 필요)
+- `HARNESS_GATE_STAGNATION_WINDOW=2` (예약됨; v1에서는 no-op)
+
+처음 세 변수의 잘못된 값은 기능을 fail-open으로 비활성화합니다 (프로세스당 키당 최대 1회 stderr 경고). 감지기 버퍼는 메모리 내에만 존재하며, 일시정지된 실행을 재개하면 빈 상태로 시작됩니다.
+
+**새 `events.jsonl` 이벤트:** `gate_stagnation`은 트리거된 감지당 한 번 `escalation` 이벤트 바로 전에 발생하며, `phase`, `retryIndex`, `similarities[]`, `threshold`, `run`, `action: 'escalate'` 필드를 포함합니다.
+
+**확장된 스키마:** `escalation.reason`은 기존 네 가지 값에 더해 `'gate-stagnation'`을 포함합니다.
+
 - P7 `REJECT` 시:
   - `Scope: impl` → P5 재오픈
   - `Scope: design`, `Scope: mixed`, scope 누락 → P1 재오픈 + carryover feedback을 P5까지 유지
@@ -307,7 +324,7 @@ light flow에서는 skipped phase로 jump할 수 없습니다.
   summary.json
 ```
 
-주요 이벤트는 `phase_start`, `phase_end`, `gate_verdict`, `gate_error`, `gate_retry`, `verify_result`, `ui_render`, `terminal_action`, `session_end` 등입니다.
+주요 이벤트는 `phase_start`, `phase_end`, `gate_verdict`, `gate_error`, `gate_retry`, `gate_stagnation`, `verify_result`, `ui_render`, `terminal_action`, `session_end` 등입니다. `gate_stagnation` 이벤트는 `phase`, `retryIndex`, `similarities` (number[]), `threshold`, `run`, `action: 'escalate'` 필드를 포함합니다.
 control pane footer는 이 로그를 바탕으로 경과 시간과 Claude/gate 토큰 합계를 집계합니다.
 
 ---

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -79,6 +79,23 @@ Light-flow specifics:
 - `phase-harness resume --light` is rejected because flow is frozen at run creation
 - P2 (pre-impl gate): Codex reviews the combined design doc using a 4-axis rubric. REJECT → immediate P1 reopen with feedback delivered via `pendingAction.feedbackPaths` only; `state.carryoverFeedback` is not set at Gate 2. Gate retry limit 3 (same as full-flow P2). Legacy light runs created before P2 activation keep `phases['2']='skipped'` — activation is forward-only via `createInitialState`, not retroactive migration.
 - gate retry limit: light P2 = 3, light P7 = 5, full flow = 3
+
+### Gate stagnation detection (auto-mode)
+
+In auto-mode, when a gate phase is rejected `retryLimit` times in a row, harness checks whether the rejections are *stagnant* before force-passing. Stagnation is defined as: the last two adjacent reviewer feedback texts are ≥70% token-Jaccard similar (token union/intersection after NFKC normalisation). If both conditions hold (auto-mode + stagnation detected), harness escalates to the C/S/Q prompt instead of force-passing. This prevents silently inheriting an unaddressed root cause across phases.
+
+**Configuration:** four env vars control detection; see README for the full table. Key defaults:
+- `HARNESS_GATE_STAGNATION=on` (auto-mode default; `=off` to restore old force-pass behaviour)
+- `HARNESS_GATE_STAGNATION_THRESHOLD=0.70`
+- `HARNESS_GATE_STAGNATION_RUN=2` (two consecutive stagnant pairs required)
+- `HARNESS_GATE_STAGNATION_WINDOW=2` (reserved; no-op in v1)
+
+Invalid values for the first three vars disable the feature fail-open (one stderr warn per key per process). The detector buffer is in-memory only; resuming a paused run starts empty.
+
+**New `events.jsonl` event:** `gate_stagnation` is emitted once per triggered detection, immediately before the `escalation` event, with fields `phase`, `retryIndex`, `similarities[]`, `threshold`, `run`, `action: 'escalate'`.
+
+**Extended schema:** `escalation.reason` now includes `'gate-stagnation'` in addition to the four pre-existing values.
+
 - on P7 `REJECT`:
   - `Scope: impl` → reopen P5
   - `Scope: design`, `Scope: mixed`, or missing scope → reopen P1 and preserve carryover feedback for P5
@@ -326,7 +343,7 @@ When enabled, harness writes under:
   summary.json
 ```
 
-Important logged events include `phase_start`, `phase_end`, `gate_verdict`, `gate_error`, `gate_retry`, `verify_result`, `ui_render`, `terminal_action`, and `session_end`.
+Important logged events include `phase_start`, `phase_end`, `gate_verdict`, `gate_error`, `gate_retry`, `gate_stagnation`, `verify_result`, `ui_render`, `terminal_action`, and `session_end`. The `gate_stagnation` event carries fields `phase`, `retryIndex`, `similarities` (number[]), `threshold`, `run`, `action: 'escalate'`.
 The control-pane footer aggregates elapsed time plus Claude/gate token totals from those logs.
 
 ---

--- a/docs/plans/2026-05-06-phase-harness-gate-retry-8ea9.md
+++ b/docs/plans/2026-05-06-phase-harness-gate-retry-8ea9.md
@@ -81,21 +81,27 @@ export class StagnationDetector {
 }
 
 const warnedKeys = new Set<string>();
+let featureDisabledForProcess = false;
 
 export function loadStagnationConfig(autoMode: boolean): {
   enabled: boolean; threshold: number; run: number; window: number;
 } {
   const base = { threshold: 0.70, run: 2, window: 2 };
 
+  // Once any validated env is misconfigured, the feature stays disabled for the process.
+  if (featureDisabledForProcess) return { enabled: false, ...base };
+
   const envMain      = process.env['HARNESS_GATE_STAGNATION'];
   const envThreshold = process.env['HARNESS_GATE_STAGNATION_THRESHOLD'];
   const envRun       = process.env['HARNESS_GATE_STAGNATION_RUN'];
   // HARNESS_GATE_STAGNATION_WINDOW is reserved/no-op in v1 — intentionally not read
 
+  let anyInvalid = false;
   let enabled   = autoMode;   // default: on in auto, off in manual
   let threshold = base.threshold;
   let run       = base.run;
 
+  // Check all three validated envs (no early return) so each invalid key warns exactly once.
   if (envMain !== undefined) {
     const lower = envMain.toLowerCase();
     if (lower === 'on') {
@@ -107,7 +113,7 @@ export function loadStagnationConfig(autoMode: boolean): {
         console.warn(`[stagnation] invalid HARNESS_GATE_STAGNATION="${envMain}" — feature disabled`);
         warnedKeys.add('HARNESS_GATE_STAGNATION');
       }
-      return { enabled: false, ...base };
+      anyInvalid = true;
     }
   }
 
@@ -118,9 +124,10 @@ export function loadStagnationConfig(autoMode: boolean): {
         console.warn(`[stagnation] invalid HARNESS_GATE_STAGNATION_THRESHOLD="${envThreshold}" — feature disabled`);
         warnedKeys.add('HARNESS_GATE_STAGNATION_THRESHOLD');
       }
-      return { enabled: false, ...base };
+      anyInvalid = true;
+    } else {
+      threshold = parsed;
     }
-    threshold = parsed;
   }
 
   if (envRun !== undefined) {
@@ -130,17 +137,24 @@ export function loadStagnationConfig(autoMode: boolean): {
         console.warn(`[stagnation] invalid HARNESS_GATE_STAGNATION_RUN="${envRun}" — feature disabled`);
         warnedKeys.add('HARNESS_GATE_STAGNATION_RUN');
       }
-      return { enabled: false, ...base };
+      anyInvalid = true;
+    } else {
+      run = parsed;
     }
-    run = parsed;
+  }
+
+  if (anyInvalid) {
+    featureDisabledForProcess = true;
+    return { enabled: false, ...base };
   }
 
   return { enabled, threshold, run, window: 2 };
 }
 
-// Test hook — resets the per-process warn dedup set.
+// Test hook — resets warn dedup set and process-level disabled latch.
 export function __resetWarnCache(): void {
   warnedKeys.clear();
+  featureDisabledForProcess = false;
 }
 ```
 
@@ -429,6 +443,31 @@ describe('loadStagnationConfig', () => {
     expect(cfg.threshold).toBe(0.80);
     expect(cfg.run).toBe(3);
     expect(cfg.window).toBe(2);
+  });
+
+  it('two invalid validated envs → both keys warned once each, feature disabled', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION', 'maybe');      // invalid
+    vi.stubEnv('HARNESS_GATE_STAGNATION_THRESHOLD', '999'); // invalid
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    loadStagnationConfig(true);
+    loadStagnationConfig(true); // second call — neither key warns again
+    const mainWarns = warnSpy.mock.calls.filter(args => String(args[0]).includes('HARNESS_GATE_STAGNATION"'));
+    const threshWarns = warnSpy.mock.calls.filter(args => String(args[0]).includes('HARNESS_GATE_STAGNATION_THRESHOLD'));
+    expect(mainWarns).toHaveLength(1);
+    expect(threshWarns).toHaveLength(1);
+    expect(loadStagnationConfig(true).enabled).toBe(false);
+  });
+
+  it('process latch: once any key is invalid, enabled=false survives env correction until __resetWarnCache', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION', 'maybe'); // invalid → sets latch
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    loadStagnationConfig(true); // latch engaged
+    vi.unstubAllEnvs();          // env is now "corrected" (no bad values)
+    // Latch still set → must stay disabled
+    expect(loadStagnationConfig(true).enabled).toBe(false);
+    // Reset latch → re-enabled
+    __resetWarnCache();
+    expect(loadStagnationConfig(true).enabled).toBe(true);
   });
 });
 ```
@@ -721,16 +760,24 @@ Add `dropDetector(phase)` after `state.phases` mutation:
 
 - [ ] **Step 7: Intercept the force-pass branch in handleGateReject**
 
-Find `handleGateReject` (around line 695). After the first line `state.phases[String(phase)] = 'pending';`, insert the config load + record call:
+Find `handleGateReject` (around line 695). After the first line `state.phases[String(phase)] = 'pending';`, insert the config load + record call — wrapped in a try/catch so that any exception from `loadStagnationConfig`, `getOrCreateDetector`, or `record` is caught fail-open (I-3):
 
 ```typescript
   state.phases[String(phase)] = 'pending';
 
-  const cfg = loadStagnationConfig(state.autoMode);
+  // Stagnation setup — fail-open: any exception skips detection for this call.
+  let cfg: { enabled: boolean; threshold: number; run: number; window: number } | undefined;
   let detector: StagnationDetector | undefined;
-  if (cfg.enabled) {
-    detector = getOrCreateDetector(phase, cfg);
-    detector.record(comments);
+  try {
+    cfg = loadStagnationConfig(state.autoMode);
+    if (cfg.enabled) {
+      const det = getOrCreateDetector(phase, cfg);
+      det.record(comments);
+      detector = det; // assign only after record succeeds
+    }
+  } catch (err) {
+    console.warn(`[stagnation] setup error: ${(err as Error).message} — detection skipped`);
+    // cfg and detector remain undefined; stagnation check is bypassed below
   }
 ```
 
@@ -744,11 +791,11 @@ Then find the existing auto-mode force-pass branch (around line 727):
     }
 ```
 
-Replace with:
+Replace with (note `cfg?.enabled` — optional chain guards against setup exception leaving cfg undefined):
 
 ```typescript
     if (retryCount >= retryLimit && state.autoMode) {
-      if (cfg.enabled && detector !== undefined) {
+      if (cfg?.enabled && detector !== undefined) {
         let triggered = false;
         let similarities: number[] = [];
         try {

--- a/docs/plans/2026-05-06-phase-harness-gate-retry-8ea9.md
+++ b/docs/plans/2026-05-06-phase-harness-gate-retry-8ea9.md
@@ -1,0 +1,1481 @@
+# Gate-Retry Stagnation Detection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the unconditional auto-mode force-pass rule with a stagnation check: if the last two adjacent gate-reject feedbacks are ≥70% token-Jaccard similar (two consecutive stagnant pairs), escalate to user instead of silently force-passing.
+
+**Architecture:** A new pure module `src/phases/stagnation.ts` provides `tokenJaccard`, `StagnationDetector`, and `loadStagnationConfig`. `runner.ts` maintains a module-scope `Map<phase, StagnationDetector>` and intercepts the auto-mode force-pass branch in `handleGateReject`. The escalation reuses the existing `handleGateEscalation` prompt; a new optional `reason: 'gate-stagnation'` is passed via opts to distinguish the log event.
+
+**Tech Stack:** TypeScript, Vitest, Node.js process.env
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `src/phases/stagnation.ts` | **new** — `tokenJaccard`, `StagnationDetector`, `loadStagnationConfig`, `__resetWarnCache` |
+| `tests/phases/stagnation.test.ts` | **new** — unit tests for all stagnation module exports |
+| `src/types.ts` | **edit** — add `gate_stagnation` LogEvent variant; extend `escalation.reason` enum |
+| `src/logger.ts` | **edit** — add `stagnationEscalations` counter in `finalizeSummary` |
+| `src/phases/runner.ts` | **edit** — detector map, `handleGateEscalation` opts, `handleGateReject` interception, detector drops on APPROVE/forcePass/escalation-C |
+| `tests/phases/runner.test.ts` | **edit** — add 7 new test cases (stagnation happy path, regression guards) |
+| `tests/integration/gate-stagnation.test.ts` | **new** — event-ordering integration test |
+| `README.md`, `README.ko.md` | **edit** — document 4 env vars (one paragraph each) |
+| `docs/HOW-IT-WORKS.md`, `docs/HOW-IT-WORKS.ko.md` | **edit** — add stagnation sub-section under gate retry; update events schema table |
+
+---
+
+## Task 1: src/phases/stagnation.ts — core detection module
+
+**Files:**
+- Create: `src/phases/stagnation.ts`
+
+- [ ] **Step 1: Write the module**
+
+```typescript
+// src/phases/stagnation.ts
+
+function tokenize(text: string): string[] {
+  return Array.from(
+    text.normalize('NFKC').toLowerCase().matchAll(/[\p{L}\p{N}_]+/gu),
+    m => m[0],
+  );
+}
+
+export function tokenJaccard(a: string, b: string): number | null {
+  const A = new Set(tokenize(a));
+  const B = new Set(tokenize(b));
+  if (A.size === 0 || B.size === 0) return null;
+  let inter = 0;
+  for (const x of A) { if (B.has(x)) inter++; }
+  const union = A.size + B.size - inter;
+  if (union === 0) return null;
+  return inter / union;
+}
+
+export class StagnationDetector {
+  private buf: string[] = [];
+  private readonly capacity: number;
+
+  constructor(private readonly cfg: { threshold: number; run: number; window: number }) {
+    this.capacity = cfg.run + (cfg.window - 1);
+  }
+
+  record(comments: string): void {
+    this.buf.push(comments);
+    if (this.buf.length > this.capacity) this.buf.shift();
+  }
+
+  shouldEscalate(): { triggered: boolean; similarities: number[] } {
+    const { run, threshold } = this.cfg;
+    if (this.buf.length < run + 1) return { triggered: false, similarities: [] };
+    const similarities: number[] = [];
+    for (let i = this.buf.length - run - 1; i < this.buf.length - 1; i++) {
+      const sim = tokenJaccard(this.buf[i], this.buf[i + 1]);
+      if (sim === null || sim < threshold) return { triggered: false, similarities: [] };
+      similarities.push(sim);
+    }
+    return { triggered: true, similarities };
+  }
+}
+
+const warnedKeys = new Set<string>();
+
+export function loadStagnationConfig(autoMode: boolean): {
+  enabled: boolean; threshold: number; run: number; window: number;
+} {
+  const base = { threshold: 0.70, run: 2, window: 2 };
+
+  const envMain      = process.env['HARNESS_GATE_STAGNATION'];
+  const envThreshold = process.env['HARNESS_GATE_STAGNATION_THRESHOLD'];
+  const envRun       = process.env['HARNESS_GATE_STAGNATION_RUN'];
+  // HARNESS_GATE_STAGNATION_WINDOW is reserved/no-op in v1 — intentionally not read
+
+  let enabled   = autoMode;   // default: on in auto, off in manual
+  let threshold = base.threshold;
+  let run       = base.run;
+
+  if (envMain !== undefined) {
+    const lower = envMain.toLowerCase();
+    if (lower === 'on') {
+      enabled = true;
+    } else if (lower === 'off') {
+      enabled = false;
+    } else {
+      if (!warnedKeys.has('HARNESS_GATE_STAGNATION')) {
+        console.warn(`[stagnation] invalid HARNESS_GATE_STAGNATION="${envMain}" — feature disabled`);
+        warnedKeys.add('HARNESS_GATE_STAGNATION');
+      }
+      return { enabled: false, ...base };
+    }
+  }
+
+  if (envThreshold !== undefined) {
+    const parsed = parseFloat(envThreshold);
+    if (Number.isNaN(parsed) || parsed < 0 || parsed > 1) {
+      if (!warnedKeys.has('HARNESS_GATE_STAGNATION_THRESHOLD')) {
+        console.warn(`[stagnation] invalid HARNESS_GATE_STAGNATION_THRESHOLD="${envThreshold}" — feature disabled`);
+        warnedKeys.add('HARNESS_GATE_STAGNATION_THRESHOLD');
+      }
+      return { enabled: false, ...base };
+    }
+    threshold = parsed;
+  }
+
+  if (envRun !== undefined) {
+    const parsed = parseInt(envRun, 10);
+    if (Number.isNaN(parsed) || parsed < 2) {
+      if (!warnedKeys.has('HARNESS_GATE_STAGNATION_RUN')) {
+        console.warn(`[stagnation] invalid HARNESS_GATE_STAGNATION_RUN="${envRun}" — feature disabled`);
+        warnedKeys.add('HARNESS_GATE_STAGNATION_RUN');
+      }
+      return { enabled: false, ...base };
+    }
+    run = parsed;
+  }
+
+  return { enabled, threshold, run, window: 2 };
+}
+
+// Test hook — resets the per-process warn dedup set.
+export function __resetWarnCache(): void {
+  warnedKeys.clear();
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/improve-cycle
+pnpm tsc --noEmit
+```
+
+Expected: exits 0, no errors about the new file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/phases/stagnation.ts
+git commit -m "feat(stagnation): add tokenJaccard, StagnationDetector, loadStagnationConfig"
+```
+
+---
+
+## Task 2: tests/phases/stagnation.test.ts — unit tests
+
+**Files:**
+- Create: `tests/phases/stagnation.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// tests/phases/stagnation.test.ts
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { tokenJaccard, StagnationDetector, loadStagnationConfig, __resetWarnCache } from '../../src/phases/stagnation.js';
+
+beforeEach(() => {
+  __resetWarnCache();
+  vi.unstubAllEnvs();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  __resetWarnCache();
+});
+
+// ─── tokenJaccard ────────────────────────────────────────────────────────────
+
+describe('tokenJaccard', () => {
+  it('identical strings return 1', () => {
+    expect(tokenJaccard('the quick brown fox', 'the quick brown fox')).toBe(1);
+  });
+
+  it('disjoint strings return 0', () => {
+    expect(tokenJaccard('alpha beta', 'gamma delta')).toBe(0);
+  });
+
+  it('one-side empty returns null', () => {
+    expect(tokenJaccard('', 'hello world')).toBeNull();
+    expect(tokenJaccard('hello world', '')).toBeNull();
+  });
+
+  it('both empty returns null', () => {
+    expect(tokenJaccard('', '')).toBeNull();
+  });
+
+  it('NFKC normalisation: ½ tokenises the same as 1 2', () => {
+    // '½' normalises to '1/2' under NFKC → tokens ['1', '2']
+    const sim = tokenJaccard('½ cup', '1 2 cup');
+    expect(sim).not.toBeNull();
+    expect(sim!).toBeGreaterThan(0.5);
+  });
+
+  it('case insensitive', () => {
+    expect(tokenJaccard('Hello World', 'hello world')).toBe(1);
+  });
+
+  it('mixed Korean and English', () => {
+    const sim = tokenJaccard('플랜이 누락됨 plan missing', '플랜이 누락됨 plan missing');
+    expect(sim).toBe(1);
+  });
+
+  it('partial overlap returns value in (0, 1)', () => {
+    const sim = tokenJaccard('plan is missing tests', 'plan needs tests and docs');
+    expect(sim).not.toBeNull();
+    expect(sim!).toBeGreaterThan(0);
+    expect(sim!).toBeLessThan(1);
+  });
+
+  it('very long strings produce a finite result (length-stable)', () => {
+    const long = 'word '.repeat(10_000).trim();
+    const sim = tokenJaccard(long, long);
+    expect(sim).toBe(1);
+  });
+});
+
+// ─── StagnationDetector.record ────────────────────────────────────────────────
+
+describe('StagnationDetector.record — FIFO buffer', () => {
+  it('drops oldest entry when buffer exceeds RUN + WINDOW - 1 = 3', () => {
+    const d = new StagnationDetector({ threshold: 0.70, run: 2, window: 2 });
+    // push 4 items — capacity is 3
+    d.record('a');
+    d.record('b');
+    d.record('c');
+    d.record('d'); // 'a' should be evicted
+
+    // Only last 3 entries matter; verify by checking shouldEscalate doesn't see 'a'
+    // (if 'a' were still in buffer, we'd have 4 entries, but capacity is 3)
+    // We check indirectly: 'a','b','c' → diverse; 'b','c','d' → b/c differ from d
+    const { triggered } = d.shouldEscalate();
+    // 'b' vs 'c' and 'c' vs 'd' — all distinct — should not trigger
+    expect(triggered).toBe(false);
+  });
+
+  it('accepts RUN=3 and capacity is RUN + WINDOW - 1 = 4', () => {
+    const d = new StagnationDetector({ threshold: 0.70, run: 3, window: 2 });
+    const same = 'plan is missing tests and docs and coverage';
+    d.record(same);
+    d.record(same);
+    d.record(same);
+    d.record(same); // 4 entries, 3 adjacent pairs all sim=1.0
+    const { triggered, similarities } = d.shouldEscalate();
+    expect(triggered).toBe(true);
+    expect(similarities).toHaveLength(3);
+  });
+});
+
+// ─── StagnationDetector.shouldEscalate ────────────────────────────────────────
+
+describe('StagnationDetector.shouldEscalate', () => {
+  const SAME = 'plan does not cover spec requirements; tests are missing; docs incomplete';
+  const DIFF = 'implementation looks correct but formatting needs work';
+
+  it('buffer < RUN+1 entries → triggered false', () => {
+    const d = new StagnationDetector({ threshold: 0.70, run: 2, window: 2 });
+    d.record(SAME); // 1 entry, need ≥3
+    d.record(SAME); // 2 entries, need ≥3
+    expect(d.shouldEscalate().triggered).toBe(false);
+  });
+
+  it('last RUN pairs all ≥ threshold → triggered true', () => {
+    const d = new StagnationDetector({ threshold: 0.70, run: 2, window: 2 });
+    d.record(SAME);
+    d.record(SAME);
+    d.record(SAME);
+    const { triggered, similarities } = d.shouldEscalate();
+    expect(triggered).toBe(true);
+    expect(similarities).toHaveLength(2);
+    similarities.forEach(s => expect(s).toBeGreaterThanOrEqual(0.70));
+  });
+
+  it('one pair below threshold → triggered false', () => {
+    const d = new StagnationDetector({ threshold: 0.70, run: 2, window: 2 });
+    d.record(SAME);
+    d.record(DIFF); // this pair will be < threshold
+    d.record(SAME);
+    expect(d.shouldEscalate().triggered).toBe(false);
+  });
+
+  it('pair where one side tokenizes to empty → triggered false (null similarity)', () => {
+    const d = new StagnationDetector({ threshold: 0.70, run: 2, window: 2 });
+    d.record(SAME);
+    d.record(''); // empty → null similarity
+    d.record(SAME);
+    expect(d.shouldEscalate().triggered).toBe(false);
+  });
+
+  it('threshold 0 → always triggers when buffer is full', () => {
+    const d = new StagnationDetector({ threshold: 0, run: 2, window: 2 });
+    d.record('alpha');
+    d.record('beta');
+    d.record('gamma'); // all disjoint but sim ≥ 0
+    const { triggered } = d.shouldEscalate();
+    expect(triggered).toBe(true);
+  });
+});
+
+// ─── loadStagnationConfig ─────────────────────────────────────────────────────
+
+describe('loadStagnationConfig', () => {
+  it('manual mode default: enabled=false', () => {
+    const cfg = loadStagnationConfig(false);
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.threshold).toBe(0.70);
+    expect(cfg.run).toBe(2);
+    expect(cfg.window).toBe(2);
+  });
+
+  it('auto mode default: enabled=true', () => {
+    const cfg = loadStagnationConfig(true);
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.threshold).toBe(0.70);
+    expect(cfg.run).toBe(2);
+    expect(cfg.window).toBe(2);
+  });
+
+  it('HARNESS_GATE_STAGNATION=off overrides auto-mode default', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION', 'off');
+    expect(loadStagnationConfig(true).enabled).toBe(false);
+  });
+
+  it('HARNESS_GATE_STAGNATION=on overrides manual-mode default', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION', 'on');
+    expect(loadStagnationConfig(false).enabled).toBe(true);
+  });
+
+  it('HARNESS_GATE_STAGNATION=ON (uppercase) is accepted', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION', 'ON');
+    expect(loadStagnationConfig(true).enabled).toBe(true);
+  });
+
+  it('invalid HARNESS_GATE_STAGNATION → enabled=false + exactly one warn', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION', 'maybe');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    loadStagnationConfig(true);
+    loadStagnationConfig(true); // second call — warn must NOT fire again
+    const stagnationWarns = warnSpy.mock.calls.filter(args => String(args[0]).includes('HARNESS_GATE_STAGNATION'));
+    expect(stagnationWarns).toHaveLength(1);
+    expect(loadStagnationConfig(true).enabled).toBe(false);
+  });
+
+  it('valid HARNESS_GATE_STAGNATION_THRESHOLD is parsed', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION_THRESHOLD', '0.85');
+    const cfg = loadStagnationConfig(true);
+    expect(cfg.threshold).toBe(0.85);
+    expect(cfg.enabled).toBe(true);
+  });
+
+  it('invalid HARNESS_GATE_STAGNATION_THRESHOLD → enabled=false + one warn for that key', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION_THRESHOLD', 'not-a-number');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    loadStagnationConfig(true);
+    loadStagnationConfig(true);
+    const warns = warnSpy.mock.calls.filter(args => String(args[0]).includes('HARNESS_GATE_STAGNATION_THRESHOLD'));
+    expect(warns).toHaveLength(1);
+  });
+
+  it('HARNESS_GATE_STAGNATION_THRESHOLD out of [0,1] range → enabled=false', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION_THRESHOLD', '1.5');
+    expect(loadStagnationConfig(true).enabled).toBe(false);
+    __resetWarnCache();
+    vi.stubEnv('HARNESS_GATE_STAGNATION_THRESHOLD', '-0.1');
+    expect(loadStagnationConfig(true).enabled).toBe(false);
+  });
+
+  it('valid HARNESS_GATE_STAGNATION_RUN is parsed', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION_RUN', '3');
+    const cfg = loadStagnationConfig(true);
+    expect(cfg.run).toBe(3);
+    expect(cfg.enabled).toBe(true);
+  });
+
+  it('invalid HARNESS_GATE_STAGNATION_RUN → enabled=false + one warn', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION_RUN', 'bad');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    loadStagnationConfig(true);
+    loadStagnationConfig(true);
+    const warns = warnSpy.mock.calls.filter(args => String(args[0]).includes('HARNESS_GATE_STAGNATION_RUN'));
+    expect(warns).toHaveLength(1);
+  });
+
+  it('HARNESS_GATE_STAGNATION_RUN < 2 → enabled=false', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION_RUN', '1');
+    expect(loadStagnationConfig(true).enabled).toBe(false);
+  });
+
+  it('HARNESS_GATE_STAGNATION_WINDOW set to any value → window=2, no warn, enabled unaffected', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    for (const val of ['5', '-1', 'not-a-number', '']) {
+      __resetWarnCache();
+      vi.stubEnv('HARNESS_GATE_STAGNATION_WINDOW', val);
+      const cfg = loadStagnationConfig(true);
+      expect(cfg.window).toBe(2);
+      expect(cfg.enabled).toBe(true);
+      const windowWarns = warnSpy.mock.calls.filter(args => String(args[0]).includes('HARNESS_GATE_STAGNATION_WINDOW'));
+      expect(windowWarns).toHaveLength(0);
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('all-valid envs return parsed values with enabled=true in auto-mode', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION', 'on');
+    vi.stubEnv('HARNESS_GATE_STAGNATION_THRESHOLD', '0.80');
+    vi.stubEnv('HARNESS_GATE_STAGNATION_RUN', '3');
+    vi.stubEnv('HARNESS_GATE_STAGNATION_WINDOW', '5'); // no-op
+    const cfg = loadStagnationConfig(true);
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.threshold).toBe(0.80);
+    expect(cfg.run).toBe(3);
+    expect(cfg.window).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect pass (or verify failures only from missing imports)**
+
+```bash
+pnpm vitest run tests/phases/stagnation.test.ts
+```
+
+Expected: all tests in this file pass.
+
+- [ ] **Step 3: Run full typecheck**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/phases/stagnation.test.ts
+git commit -m "test(stagnation): add unit tests for tokenJaccard, StagnationDetector, loadStagnationConfig"
+```
+
+---
+
+## Task 3: src/types.ts — type extensions
+
+**Files:**
+- Modify: `src/types.ts`
+
+- [ ] **Step 1: Add gate_stagnation event variant to LogEvent union**
+
+In `src/types.ts`, find the `LogEvent` union type (around line 233). Add the new variant after the `gate_retry` entry (around line 275):
+
+Old line 275:
+```typescript
+  | (LogEventBase & { event: 'gate_retry'; phase: number; retryIndex: number; retryCount: number; retryLimit: number; feedbackPath: string; feedbackBytes: number; feedbackPreview: string })
+  | (LogEventBase & { event: 'escalation'; phase: number; reason: 'gate-retry-limit' | 'gate-error' | 'verify-limit' | 'verify-error'; userChoice?: 'C' | 'S' | 'Q' | 'R' })
+```
+
+New lines (insert the `gate_stagnation` variant between `gate_retry` and `escalation`; also extend the `escalation.reason` enum):
+
+```typescript
+  | (LogEventBase & { event: 'gate_retry'; phase: number; retryIndex: number; retryCount: number; retryLimit: number; feedbackPath: string; feedbackBytes: number; feedbackPreview: string })
+  | (LogEventBase & {
+      event: 'gate_stagnation';
+      phase: number;
+      retryIndex: number;
+      similarities: number[];
+      threshold: number;
+      run: number;
+      action: 'escalate';
+    })
+  | (LogEventBase & { event: 'escalation'; phase: number; reason: 'gate-retry-limit' | 'gate-error' | 'verify-limit' | 'verify-error' | 'gate-stagnation'; userChoice?: 'C' | 'S' | 'Q' | 'R' })
+```
+
+- [ ] **Step 2: Run typecheck to confirm no breakage**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: exits 0.
+
+- [ ] **Step 3: Verify grep rules from Success Criterion #2**
+
+```bash
+grep -n "event: 'gate_stagnation'" src/types.ts
+grep -n "'gate-stagnation'" src/types.ts
+```
+
+Expected: each returns ≥ 1 hit.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types.ts
+git commit -m "feat(types): add gate_stagnation LogEvent variant and gate-stagnation escalation reason"
+```
+
+---
+
+## Task 4: src/logger.ts — stagnationEscalations counter
+
+**Files:**
+- Modify: `src/logger.ts`
+
+- [ ] **Step 1: Add stagnationEscalations to finalizeSummary**
+
+In `src/logger.ts`, find `finalizeSummary` (line ~159). Find the `totals` variable declaration (around line 183):
+
+```typescript
+      let gateTokens = 0, gateRejects = 0, gateErrors = 0, escalations = 0, verifyFailures = 0, forcePasses = 0;
+```
+
+Change to:
+
+```typescript
+      let gateTokens = 0, gateRejects = 0, gateErrors = 0, escalations = 0, verifyFailures = 0, forcePasses = 0, stagnationEscalations = 0;
+```
+
+Find the `gate_stagnation` event handling — add a counter increment in the event loop (around line 193, after `force_pass` handling):
+
+```typescript
+        } else if (e.event === 'force_pass') {
+          forcePasses++;
+        } else if (e.event === 'gate_stagnation' && (e as any).action === 'escalate') {
+          stagnationEscalations++;
+        } else if (e.event === 'verify_result' && !e.passed) {
+```
+
+Find the `summary.totals` object (around line 244):
+
+```typescript
+        totals: { gateTokens, gateRejects, gateErrors, escalations, verifyFailures, forcePasses },
+```
+
+Change to:
+
+```typescript
+        totals: { gateTokens, gateRejects, gateErrors, escalations, verifyFailures, forcePasses, stagnationEscalations },
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: exits 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/logger.ts
+git commit -m "feat(logger): add stagnationEscalations counter to finalizeSummary"
+```
+
+---
+
+## Task 5: src/phases/runner.ts — detection wiring
+
+**Files:**
+- Modify: `src/phases/runner.ts`
+
+This task has multiple sub-changes. Apply them all, then typecheck and commit at the end.
+
+- [ ] **Step 1: Add imports at the top of runner.ts**
+
+Find the existing imports at the top of `src/phases/runner.ts`. Add:
+
+```typescript
+import { StagnationDetector, loadStagnationConfig } from './stagnation.js';
+```
+
+(Place it near other local-module imports, e.g., after the `import ... from './verdict.js'` line.)
+
+- [ ] **Step 2: Add module-scope detector map + helpers after imports**
+
+Find the first non-import line in `src/phases/runner.ts` (e.g. the first `const` or `function` declaration). Add the following block immediately before it:
+
+```typescript
+// ─── Stagnation detector map ──────────────────────────────────────────────────
+// In-memory only; never serialised. Keyed by gate phase number.
+const detectorMap = new Map<string, StagnationDetector>();
+
+function getOrCreateDetector(phase: number, cfg: { threshold: number; run: number; window: number }): StagnationDetector {
+  const key = String(phase);
+  if (!detectorMap.has(key)) detectorMap.set(key, new StagnationDetector(cfg));
+  return detectorMap.get(key)!;
+}
+
+function dropDetector(phase: number): void {
+  detectorMap.delete(String(phase));
+}
+
+// Test hook — reset all detector state between test cases.
+export function __resetDetectors(): void {
+  detectorMap.clear();
+}
+```
+
+- [ ] **Step 3: Extend handleGateEscalation signature with opts**
+
+Find the `handleGateEscalation` function definition (around line 798). Change its signature from:
+
+```typescript
+export async function handleGateEscalation(
+  phase: GatePhase,
+  comments: string,
+  scope: Scope | undefined,
+  retryIndex: number,
+  state: HarnessState,
+  runDir: string,
+  cwd: string,
+  inputManager: InputManager,
+  logger: SessionLogger,
+): Promise<void> {
+```
+
+To:
+
+```typescript
+export async function handleGateEscalation(
+  phase: GatePhase,
+  comments: string,
+  scope: Scope | undefined,
+  retryIndex: number,
+  state: HarnessState,
+  runDir: string,
+  cwd: string,
+  inputManager: InputManager,
+  logger: SessionLogger,
+  opts?: { reason?: 'gate-retry-limit' | 'gate-stagnation' },
+): Promise<void> {
+```
+
+Find the escalation event emission inside `handleGateEscalation` (around line 823):
+
+```typescript
+  logger.logEvent({
+    event: 'escalation',
+    phase,
+    reason: 'gate-retry-limit',
+    userChoice: choice as 'C' | 'S' | 'Q',
+  });
+```
+
+Change to:
+
+```typescript
+  logger.logEvent({
+    event: 'escalation',
+    phase,
+    reason: opts?.reason ?? 'gate-retry-limit',
+    userChoice: choice as 'C' | 'S' | 'Q',
+  });
+```
+
+- [ ] **Step 4: Drop detector in handleGateEscalation choice 'C'**
+
+Inside `handleGateEscalation`, find the block that increments `gateEscalationCycles` (around line 848-849):
+
+```typescript
+    state.gateEscalationCycles = state.gateEscalationCycles ?? {};
+    state.gateEscalationCycles[key] = (state.gateEscalationCycles[key] ?? 0) + 1;
+```
+
+Add `dropDetector(phase)` immediately after:
+
+```typescript
+    state.gateEscalationCycles = state.gateEscalationCycles ?? {};
+    state.gateEscalationCycles[key] = (state.gateEscalationCycles[key] ?? 0) + 1;
+    dropDetector(phase);
+```
+
+- [ ] **Step 5: Drop detector in forcePassGate**
+
+Find `forcePassGate` (around line 899). After `logger.logEvent({ event: 'force_pass', phase, by })` (around line 911), add:
+
+```typescript
+  logger.logEvent({ event: 'force_pass', phase, by });
+  dropDetector(phase);
+```
+
+- [ ] **Step 6: Drop detector on gate APPROVE in handleGatePhase**
+
+Find the APPROVE branch in `handleGatePhase` (around line 614):
+
+```typescript
+      state.phases[String(phase)] = 'completed';
+
+      // Post-success sidecar cleanup
+      deleteGateSidecars(runDir, phase);
+```
+
+Add `dropDetector(phase)` after `state.phases` mutation:
+
+```typescript
+      state.phases[String(phase)] = 'completed';
+      dropDetector(phase);
+
+      // Post-success sidecar cleanup
+      deleteGateSidecars(runDir, phase);
+```
+
+- [ ] **Step 7: Intercept the force-pass branch in handleGateReject**
+
+Find `handleGateReject` (around line 695). After the first line `state.phases[String(phase)] = 'pending';`, insert the config load + record call:
+
+```typescript
+  state.phases[String(phase)] = 'pending';
+
+  const cfg = loadStagnationConfig(state.autoMode);
+  let detector: StagnationDetector | undefined;
+  if (cfg.enabled) {
+    detector = getOrCreateDetector(phase, cfg);
+    detector.record(comments);
+  }
+```
+
+Then find the existing auto-mode force-pass branch (around line 727):
+
+```typescript
+    if (retryCount >= retryLimit && state.autoMode) {
+      // Auto-mode force pass (no gate_retry event — force_pass covers this path)
+      await forcePassGate(phase, state, runDir, cwd, 'auto', logger);
+      return;
+    }
+```
+
+Replace with:
+
+```typescript
+    if (retryCount >= retryLimit && state.autoMode) {
+      if (cfg.enabled && detector !== undefined) {
+        let triggered = false;
+        let similarities: number[] = [];
+        try {
+          const r = detector.shouldEscalate();
+          triggered = r.triggered;
+          similarities = r.similarities;
+        } catch (err) {
+          console.warn(`[stagnation] detector error: ${(err as Error).message} — falling back to force-pass`);
+        }
+        if (triggered) {
+          logger.logEvent({
+            event: 'gate_stagnation',
+            phase, retryIndex,
+            similarities,
+            threshold: cfg.threshold,
+            run: cfg.run,
+            action: 'escalate',
+          });
+          await handleGateEscalation(
+            phase, comments, scope, retryIndex,
+            state, runDir, cwd, inputManager, logger,
+            { reason: 'gate-stagnation' },
+          );
+          return;
+        }
+      }
+      // Auto-mode force pass (no gate_retry event — force_pass covers this path)
+      await forcePassGate(phase, state, runDir, cwd, 'auto', logger);
+      return;
+    }
+```
+
+- [ ] **Step 8: Typecheck the entire codebase**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: exits 0, no type errors.
+
+- [ ] **Step 9: Verify grep rules from Success Criterion #3**
+
+```bash
+grep -n "loadStagnationConfig\|gate_stagnation" src/phases/runner.ts
+```
+
+Expected: ≥ 2 hits both inside the `handleGateReject` function body.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/phases/runner.ts
+git commit -m "feat(runner): intercept auto-mode force-pass with stagnation detection; add detector lifecycle management"
+```
+
+---
+
+## Task 6: tests/phases/runner.test.ts — stagnation regression tests
+
+**Files:**
+- Modify: `tests/phases/runner.test.ts`
+
+- [ ] **Step 1: Update the import from runner.ts to include new exports**
+
+Find the existing `import { ... } from '../../src/phases/runner.js'` (around line 76). Add `__resetDetectors` to the import list:
+
+```typescript
+import {
+  runPhaseLoop,
+  handleInteractivePhase,
+  handleGatePhase,
+  handleGateReject,
+  handleGateEscalation,
+  handleGateError,
+  forcePassGate,
+  forcePassVerify,
+  handleVerifyPhase,
+  handleVerifyFail,
+  handleVerifyEscalation,
+  handleVerifyError,
+  __resetDetectors,
+} from '../../src/phases/runner.js';
+```
+
+Also add import of `__resetWarnCache` from stagnation:
+
+```typescript
+import { __resetWarnCache } from '../../src/phases/stagnation.js';
+```
+
+- [ ] **Step 2: Reset detector state in afterEach**
+
+Find the existing `afterEach` block (around line 104):
+
+```typescript
+afterEach(() => {
+  vi.clearAllMocks();
+  for (const dir of tmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tmpDirs.length = 0;
+});
+```
+
+Change to:
+
+```typescript
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+  __resetDetectors();
+  __resetWarnCache();
+  for (const dir of tmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tmpDirs.length = 0;
+});
+```
+
+- [ ] **Step 3: Add stagnation test block at end of file**
+
+Append the following describe block at the very end of `tests/phases/runner.test.ts`:
+
+```typescript
+// ─── Stagnation detection in handleGateReject ─────────────────────────────────
+
+const STAGNANT = 'plan does not cover spec requirements; tests are missing; docs incomplete';
+const DIVERSE_A = 'the implementation is mostly correct but tests need edge case coverage';
+const DIVERSE_B = 'formatting issues found; please fix indentation and remove dead code';
+const DIVERSE_C = 'critical bug in error handler path; stack overflow under high load';
+
+describe('Stagnation — Test 5: auto-mode + 3 stagnant rejects → gate_stagnation + handleGateEscalation', () => {
+  it('emits gate_stagnation and calls handleGateEscalation with reason gate-stagnation', async () => {
+    __resetDetectors();
+    const runDir = makeTmpDir();
+    const state = makeState({ autoMode: true, currentPhase: 2 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    vi.mocked(promptChoice).mockResolvedValueOnce('Q');
+
+    try {
+      // 3 rejects, same text — buffer fills with 3 identical entries
+      await handleGateReject(2, STAGNANT, undefined, 0, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+      await handleGateReject(2, STAGNANT, undefined, 1, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+      // 3rd reject: retryCount = 3 = retryLimit → stagnation fires
+      await handleGateReject(2, STAGNANT, undefined, 2, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+
+      const events = readEvents(eventsPath);
+      const stagnation = events.find((e: any) => e.event === 'gate_stagnation');
+      expect(stagnation).toBeDefined();
+      expect(stagnation.phase).toBe(2);
+      expect(stagnation.action).toBe('escalate');
+      expect(Array.isArray(stagnation.similarities)).toBe(true);
+      expect(stagnation.similarities.length).toBeGreaterThanOrEqual(1);
+
+      const escalation = events.find((e: any) => e.event === 'escalation');
+      expect(escalation).toBeDefined();
+      expect(escalation.reason).toBe('gate-stagnation');
+
+      const forcePassEvents = events.filter((e: any) => e.event === 'force_pass');
+      expect(forcePassEvents).toHaveLength(0);
+
+      // forcePassGate must NOT have been called
+      expect(vi.mocked(promptChoice)).toHaveBeenCalledTimes(1);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('Stagnation — Test 6: auto-mode + 3 diverse rejects → forcePassGate, no gate_stagnation', () => {
+  it('calls forcePassGate and does NOT emit gate_stagnation', async () => {
+    __resetDetectors();
+    const runDir = makeTmpDir();
+    const state = makeState({ autoMode: true, currentPhase: 2 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    try {
+      await handleGateReject(2, DIVERSE_A, undefined, 0, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+      await handleGateReject(2, DIVERSE_B, undefined, 1, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+      await handleGateReject(2, DIVERSE_C, undefined, 2, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+
+      const events = readEvents(eventsPath);
+      expect(events.find((e: any) => e.event === 'gate_stagnation')).toBeUndefined();
+      expect(events.find((e: any) => e.event === 'force_pass')).toBeDefined();
+
+      const writes = vi.mocked(writeState).mock.calls.map(([, s]) => s);
+      const forcePassState = writes.find(s => s.phases['2'] === 'completed');
+      expect(forcePassState).toBeDefined();
+
+      expect(vi.mocked(promptChoice)).not.toHaveBeenCalled();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('Stagnation — Test 7: manual mode + 3 stagnant rejects → escalation reason=gate-retry-limit (no change)', () => {
+  it('preserves existing manual-mode escalation path', async () => {
+    __resetDetectors();
+    const runDir = makeTmpDir();
+    const state = makeState({ autoMode: false, currentPhase: 2,
+      gateRetries: { '2': FULL_GATE_RETRY_LIMIT, '4': 0, '7': 0 } });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    vi.mocked(promptChoice).mockResolvedValueOnce('Q');
+
+    try {
+      await handleGateReject(2, STAGNANT, undefined, FULL_GATE_RETRY_LIMIT, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+
+      const events = readEvents(eventsPath);
+      const escalation = events.find((e: any) => e.event === 'escalation');
+      expect(escalation).toBeDefined();
+      expect(escalation.reason).toBe('gate-retry-limit');
+      expect(events.find((e: any) => e.event === 'gate_stagnation')).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('Stagnation — Test 8: HARNESS_GATE_STAGNATION=off in auto-mode → forcePassGate', () => {
+  it('disables stagnation via env; falls back to force-pass', async () => {
+    __resetDetectors();
+    __resetWarnCache();
+    vi.stubEnv('HARNESS_GATE_STAGNATION', 'off');
+
+    const runDir = makeTmpDir();
+    const state = makeState({ autoMode: true, currentPhase: 2 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    try {
+      await handleGateReject(2, STAGNANT, undefined, 0, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+      await handleGateReject(2, STAGNANT, undefined, 1, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+      await handleGateReject(2, STAGNANT, undefined, 2, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+
+      const events = readEvents(eventsPath);
+      expect(events.find((e: any) => e.event === 'gate_stagnation')).toBeUndefined();
+      expect(events.find((e: any) => e.event === 'force_pass')).toBeDefined();
+      expect(vi.mocked(promptChoice)).not.toHaveBeenCalled();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('Stagnation — Test 9: detector throws → forcePassGate, single warn, no gate_stagnation', () => {
+  it('catches detector exception and falls back to force-pass', async () => {
+    __resetDetectors();
+    const runDir = makeTmpDir();
+    const state = makeState({ autoMode: true, currentPhase: 2 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    // Populate buffer so stagnation would normally trigger
+    await handleGateReject(2, STAGNANT, undefined, 0, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+    await handleGateReject(2, STAGNANT, undefined, 1, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+
+    // Make shouldEscalate throw on the 3rd call
+    const { StagnationDetector: SD } = await import('../../src/phases/stagnation.js');
+    const origShouldEscalate = SD.prototype.shouldEscalate;
+    SD.prototype.shouldEscalate = function() { throw new Error('detector exploded'); };
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await handleGateReject(2, STAGNANT, undefined, 2, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+
+      const events = readEvents(eventsPath);
+      expect(events.find((e: any) => e.event === 'gate_stagnation')).toBeUndefined();
+      expect(events.find((e: any) => e.event === 'force_pass')).toBeDefined();
+
+      const stagnationWarns = warnSpy.mock.calls.filter(args => String(args[0]).includes('detector error'));
+      expect(stagnationWarns).toHaveLength(1);
+
+      expect(vi.mocked(promptChoice)).not.toHaveBeenCalled();
+    } finally {
+      SD.prototype.shouldEscalate = origShouldEscalate;
+      cleanup();
+    }
+  });
+});
+
+describe('Stagnation — Test 9a: invalid THRESHOLD env in auto-mode → forcePassGate, one warn', () => {
+  it('unified fail-open: invalid validated env disables feature', async () => {
+    __resetDetectors();
+    __resetWarnCache();
+    vi.stubEnv('HARNESS_GATE_STAGNATION_THRESHOLD', 'not-a-number');
+
+    const runDir = makeTmpDir();
+    const state = makeState({ autoMode: true, currentPhase: 2 });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await handleGateReject(2, STAGNANT, undefined, 0, state, HDIR, runDir, CWD, createNoOpInputManager(), new NoopLogger());
+      await handleGateReject(2, STAGNANT, undefined, 1, state, HDIR, runDir, CWD, createNoOpInputManager(), new NoopLogger());
+      await handleGateReject(2, STAGNANT, undefined, 2, state, HDIR, runDir, CWD, createNoOpInputManager(), new NoopLogger());
+
+      expect(vi.mocked(promptChoice)).not.toHaveBeenCalled();
+
+      const writes = vi.mocked(writeState).mock.calls.map(([, s]) => s);
+      const forcePassState = writes.find(s => s.phases['2'] === 'completed');
+      expect(forcePassState).toBeDefined();
+
+      const warns = warnSpy.mock.calls.filter(args => String(args[0]).includes('HARNESS_GATE_STAGNATION_THRESHOLD'));
+      expect(warns).toHaveLength(1);
+    } finally {
+      // no cleanup needed (NoopLogger)
+    }
+  });
+});
+
+describe('Stagnation — Test 9b: WINDOW env set to non-2 value → stagnation still fires, no warn', () => {
+  it('WINDOW is a no-op; feature remains enabled when only WINDOW is set', async () => {
+    __resetDetectors();
+    __resetWarnCache();
+    vi.stubEnv('HARNESS_GATE_STAGNATION_WINDOW', '5');
+
+    const runDir = makeTmpDir();
+    const state = makeState({ autoMode: true, currentPhase: 2 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    vi.mocked(promptChoice).mockResolvedValueOnce('Q');
+
+    try {
+      await handleGateReject(2, STAGNANT, undefined, 0, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+      await handleGateReject(2, STAGNANT, undefined, 1, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+      await handleGateReject(2, STAGNANT, undefined, 2, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+
+      const events = readEvents(eventsPath);
+      const stagnation = events.find((e: any) => e.event === 'gate_stagnation');
+      expect(stagnation).toBeDefined();
+
+      const escalation = events.find((e: any) => e.event === 'escalation');
+      expect(escalation?.reason).toBe('gate-stagnation');
+
+      const windowWarns = warnSpy.mock.calls.filter(args => String(args[0]).includes('HARNESS_GATE_STAGNATION_WINDOW'));
+      expect(windowWarns).toHaveLength(0);
+    } finally {
+      cleanup();
+    }
+  });
+});
+```
+
+- [ ] **Step 4: Run the new tests**
+
+```bash
+pnpm vitest run tests/phases/runner.test.ts
+```
+
+Expected: all tests in the file pass, including the new 7 describe blocks above.
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+pnpm vitest run
+```
+
+Expected: exits 0 with all tests passing.
+
+- [ ] **Step 6: Typecheck**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: exits 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/phases/runner.test.ts
+git commit -m "test(runner): add stagnation detection tests (Tests 5-9b)"
+```
+
+---
+
+## Task 7: tests/integration/gate-stagnation.test.ts — event ordering integration test
+
+**Files:**
+- Create: `tests/integration/gate-stagnation.test.ts`
+
+This test drives `handleGateReject` directly with a real `FileSessionLogger` to assert the exact event ordering in `events.jsonl`.
+
+- [ ] **Step 1: Write the integration test**
+
+```typescript
+// tests/integration/gate-stagnation.test.ts
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { HarnessState } from '../../src/types.js';
+import { createInitialState } from '../../src/state.js';
+import { getGateRetryLimit } from '../../src/config.js';
+import { FileSessionLogger, computeRepoKey } from '../../src/logger.js';
+import { __resetWarnCache } from '../../src/phases/stagnation.js';
+
+vi.mock('../../src/phases/interactive.js', () => ({
+  runInteractivePhase: vi.fn(),
+  preparePhase: vi.fn(),
+  checkSentinelFreshness: vi.fn(),
+  validatePhaseArtifacts: vi.fn(),
+}));
+
+vi.mock('../../src/phases/gate.js', () => ({
+  runGatePhase: vi.fn(),
+  checkGateSidecars: vi.fn(),
+  buildGateResult: vi.fn(),
+  parseVerdict: vi.fn(),
+}));
+
+vi.mock('../../src/phases/verify.js', () => ({
+  runVerifyPhase: vi.fn(),
+  readVerifyResult: vi.fn(),
+  isEvalReportValid: vi.fn(),
+}));
+
+vi.mock('../../src/ui.js', () => ({
+  promptChoice: vi.fn(),
+  printPhaseTransition: vi.fn(),
+  renderControlPanel: vi.fn(),
+  printWarning: vi.fn(),
+  printError: vi.fn(),
+  printSuccess: vi.fn(),
+  printInfo: vi.fn(),
+}));
+
+vi.mock('../../src/artifact.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/artifact.js')>();
+  return { ...actual, commitEvalReport: vi.fn().mockReturnValue('committed'), normalizeArtifactCommit: vi.fn().mockReturnValue(true), runPhase6Preconditions: vi.fn() };
+});
+
+vi.mock('../../src/git.js', () => ({
+  getHead: vi.fn().mockReturnValue('mock-sha'),
+  getGitRoot: vi.fn(),
+  isAncestor: vi.fn(),
+  isWorkingTreeClean: vi.fn(),
+  hasStagedChanges: vi.fn(),
+  getStagedFiles: vi.fn(),
+  getFileStatus: vi.fn(),
+  generateRunId: vi.fn(),
+  detectExternalCommits: vi.fn(),
+  isPathGitignored: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../../src/state.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/state.js')>();
+  return { ...actual, writeState: vi.fn() };
+});
+
+import { handleGateReject, __resetDetectors } from '../../src/phases/runner.js';
+import { promptChoice } from '../../src/ui.js';
+import { InputManager } from '../../src/input.js';
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+  __resetDetectors();
+  __resetWarnCache();
+  for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true });
+  tmpDirs.length = 0;
+});
+
+function makeTmpDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'stagnation-int-'));
+  tmpDirs.push(d);
+  return d;
+}
+
+function makeTestLogger(runId: string): { logger: FileSessionLogger; eventsPath: string; cleanup: () => void } {
+  const harnessDir = makeTmpDir();
+  const sessionsRoot = path.join(harnessDir, 'sessions');
+  const logger = new FileSessionLogger(runId, harnessDir, { sessionsRoot });
+  logger.writeMeta({ task: 't' });
+  const eventsPath = path.join(sessionsRoot, computeRepoKey(harnessDir), runId, 'events.jsonl');
+  return { logger, eventsPath, cleanup: () => {} };
+}
+
+function readEvents(eventsPath: string): any[] {
+  if (!fs.existsSync(eventsPath)) return [];
+  return fs.readFileSync(eventsPath, 'utf-8').trim().split('\n').filter(Boolean).map(l => JSON.parse(l));
+}
+
+function makeState(overrides: Partial<HarnessState> = {}): HarnessState {
+  return { ...createInitialState('int-run', '/task.md', 'sha', false), ...overrides };
+}
+
+const HDIR = '/tmp/harness-dir';
+const CWD = '/tmp/cwd';
+const FULL_LIMIT = getGateRetryLimit('full');
+const STAGNANT = 'plan does not cover spec requirements; tests are missing; edge cases unhandled';
+
+// ─── Test 10: Integration — 3 stagnant rejects → event ordering ──────────────
+
+describe('Integration Test 10: 3 stagnant auto-mode rejects → gate_retry×2, gate_stagnation, escalation(gate-stagnation), no force_pass', () => {
+  it('events appear in correct order with no force_pass', async () => {
+    const runDir = makeTmpDir();
+    const state = makeState({ autoMode: true, currentPhase: 2 });
+    const { logger, eventsPath } = makeTestLogger(state.runId);
+
+    vi.mocked(promptChoice).mockResolvedValueOnce('Q');
+
+    // 3 rejects with identical feedback
+    await handleGateReject(2, STAGNANT, undefined, 0, state, HDIR, runDir, CWD, new InputManager(), logger);
+    await handleGateReject(2, STAGNANT, undefined, 1, state, HDIR, runDir, CWD, new InputManager(), logger);
+    await handleGateReject(2, STAGNANT, undefined, 2, state, HDIR, runDir, CWD, new InputManager(), logger);
+
+    const events = readEvents(eventsPath);
+
+    // gate_retry × 2 (retryIndex 0 and 1 only; retryIndex 2 goes to stagnation)
+    const gateRetries = events.filter((e: any) => e.event === 'gate_retry');
+    expect(gateRetries).toHaveLength(2);
+    expect(gateRetries[0].retryIndex).toBe(0);
+    expect(gateRetries[1].retryIndex).toBe(1);
+
+    // gate_stagnation × 1
+    const stagnations = events.filter((e: any) => e.event === 'gate_stagnation');
+    expect(stagnations).toHaveLength(1);
+    expect(stagnations[0].phase).toBe(2);
+    expect(stagnations[0].action).toBe('escalate');
+    expect(stagnations[0].threshold).toBe(0.70);
+
+    // escalation × 1 with reason gate-stagnation
+    const escalations = events.filter((e: any) => e.event === 'escalation');
+    expect(escalations).toHaveLength(1);
+    expect(escalations[0].reason).toBe('gate-stagnation');
+    expect(escalations[0].phase).toBe(2);
+
+    // NO force_pass
+    expect(events.filter((e: any) => e.event === 'force_pass')).toHaveLength(0);
+
+    // Order: last gate_retry < gate_stagnation < escalation
+    const lastRetryIdx  = events.map((e: any, i: number) => e.event === 'gate_retry'      ? i : -1).filter(i => i >= 0).pop()!;
+    const stagnationIdx = events.findIndex((e: any) => e.event === 'gate_stagnation');
+    const escalationIdx = events.findIndex((e: any) => e.event === 'escalation');
+    expect(lastRetryIdx).toBeLessThan(stagnationIdx);
+    expect(stagnationIdx).toBeLessThan(escalationIdx);
+  });
+});
+
+// ─── Test 11: Regression — pre-existing event shapes are unchanged ─────────────
+
+describe('Integration Test 11: regression — force_pass and escalation event shapes unchanged for non-stagnant runs', () => {
+  it('non-stagnant auto-mode run produces force_pass with by=auto, no gate_stagnation', async () => {
+    const runDir = makeTmpDir();
+    const state = makeState({ autoMode: true, currentPhase: 2 });
+    const { logger, eventsPath } = makeTestLogger(state.runId);
+
+    const feedback = ['the type signatures are wrong', 'missing null check in handler', 'lint errors in new file'];
+    for (let i = 0; i < FULL_LIMIT; i++) {
+      await handleGateReject(2, feedback[i] ?? `distinct feedback ${i}`, undefined, i, state, HDIR, runDir, CWD, new InputManager(), logger);
+    }
+
+    const events = readEvents(eventsPath);
+    const forcePass = events.find((e: any) => e.event === 'force_pass');
+    expect(forcePass).toBeDefined();
+    expect(forcePass.by).toBe('auto');
+    expect(forcePass.phase).toBe(2);
+    expect(events.find((e: any) => e.event === 'gate_stagnation')).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run integration test**
+
+```bash
+pnpm vitest run tests/integration/gate-stagnation.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+pnpm vitest run
+```
+
+Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/gate-stagnation.test.ts
+git commit -m "test(integration): add gate-stagnation event-ordering integration test (Test 10 + regression Test 11)"
+```
+
+---
+
+## Task 8: Documentation — README and HOW-IT-WORKS
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README.ko.md`
+- Modify: `docs/HOW-IT-WORKS.md`
+- Modify: `docs/HOW-IT-WORKS.ko.md`
+
+- [ ] **Step 1: README.md — add stagnation env vars paragraph**
+
+Find the `--auto` flag description under `### phase-harness start` (around line 218):
+
+```markdown
+- `--auto` — autonomous mode for escalation handling
+```
+
+Add the following paragraph after the flags list (or at the end of the "Important behavior" block):
+
+```markdown
+**Auto-mode gate stagnation detection:**
+When running with `--auto`, harness detects *stagnant* gate retry cycles — where each retry's reviewer feedback is essentially the same as the previous one — and escalates to the user (C/S/Q prompt) instead of silently force-passing. Stagnation is measured by token-set Jaccard similarity between adjacent reviewer feedback texts. Four environment variables control this behaviour:
+
+| Variable | Default | Description |
+|---|---|---|
+| `HARNESS_GATE_STAGNATION` | `on` (auto-mode) | Set to `off` to restore pre-detection force-pass behaviour |
+| `HARNESS_GATE_STAGNATION_THRESHOLD` | `0.70` | Jaccard similarity threshold [0, 1]; higher = stricter |
+| `HARNESS_GATE_STAGNATION_RUN` | `2` | Consecutive stagnant pairs required before escalation (min 2) |
+| `HARNESS_GATE_STAGNATION_WINDOW` | `2` | Reserved for future use; currently fixed at 2 (pair comparison) |
+
+Any invalid value for the first three variables disables the feature for that process and emits one warning to stderr. The feature is always off in manual mode.
+```
+
+- [ ] **Step 2: README.ko.md — add Korean equivalent**
+
+Find the equivalent `--auto` flag description in `README.ko.md`. Add the same paragraph translated to Korean:
+
+```markdown
+**자율 모드 게이트 스태그네이션 감지:**
+`--auto`로 실행할 때, harness는 *정체된* 게이트 재시도 사이클을 감지합니다 — 각 재시도의 리뷰어 피드백이 이전과 본질적으로 동일한 경우 — 조용히 강제 통과하는 대신 사용자에게 에스컬레이션합니다 (C/S/Q 프롬프트). 정체는 인접한 리뷰어 피드백 텍스트 사이의 토큰 집합 Jaccard 유사도로 측정합니다. 네 가지 환경 변수로 이 동작을 제어합니다:
+
+| 변수 | 기본값 | 설명 |
+|---|---|---|
+| `HARNESS_GATE_STAGNATION` | `on` (자율 모드) | `off`로 설정하면 감지 전 강제 통과 동작으로 복원 |
+| `HARNESS_GATE_STAGNATION_THRESHOLD` | `0.70` | Jaccard 유사도 임계값 [0, 1]; 높을수록 엄격 |
+| `HARNESS_GATE_STAGNATION_RUN` | `2` | 에스컬레이션 전 연속 정체 쌍 수 (최소 2) |
+| `HARNESS_GATE_STAGNATION_WINDOW` | `2` | 향후 사용 예약; 현재 2로 고정 (쌍 비교) |
+
+처음 세 변수에 잘못된 값이 있으면 해당 프로세스에서 기능이 비활성화되고 stderr에 경고 하나가 출력됩니다. 수동 모드에서는 항상 비활성화됩니다.
+```
+
+- [ ] **Step 3: docs/HOW-IT-WORKS.md — add stagnation sub-section**
+
+Find the gate retry limit reference (around line 81):
+
+```markdown
+- gate retry limit: light P2 = 3, light P7 = 5, full flow = 3
+```
+
+Add the following subsection immediately after:
+
+```markdown
+### Gate stagnation detection (auto-mode)
+
+In auto-mode, when a gate phase is rejected `retryLimit` times in a row, harness checks whether the rejections are *stagnant* before force-passing. Stagnation is defined as: the last two adjacent reviewer feedback texts are ≥70% token-Jaccard similar (token union/intersection after NFKC normalisation). If both conditions hold (auto-mode + stagnation detected), harness escalates to the C/S/Q prompt instead of force-passing. This prevents silently inheriting an unaddressed root cause across phases.
+
+**Configuration:** four env vars control detection; see README for the full table. Key defaults:
+- `HARNESS_GATE_STAGNATION=on` (auto-mode default; `=off` to restore old force-pass behaviour)
+- `HARNESS_GATE_STAGNATION_THRESHOLD=0.70`
+- `HARNESS_GATE_STAGNATION_RUN=2` (two consecutive stagnant pairs required)
+- `HARNESS_GATE_STAGNATION_WINDOW=2` (reserved; no-op in v1)
+
+Invalid values for the first three vars disable the feature fail-open (one stderr warn per key per process). The detector buffer is in-memory only; resuming a paused run starts empty.
+
+**New `events.jsonl` event:** `gate_stagnation` is emitted once per triggered detection, immediately before the `escalation` event, with fields `phase`, `retryIndex`, `similarities[]`, `threshold`, `run`, `action: 'escalate'`.
+
+**Extended schema:** `escalation.reason` now includes `'gate-stagnation'` in addition to the four pre-existing values.
+```
+
+Also update the events.jsonl schema table in `docs/HOW-IT-WORKS.md`. Find the events table (search for `gate_retry` in the table). Add a `gate_stagnation` row:
+
+```markdown
+| `gate_stagnation` | `phase`, `retryIndex`, `similarities` (number[]), `threshold`, `run`, `action: 'escalate'` |
+```
+
+- [ ] **Step 4: docs/HOW-IT-WORKS.ko.md — add Korean equivalent**
+
+Add the same stagnation sub-section translated to Korean in `docs/HOW-IT-WORKS.ko.md`, in the equivalent location.
+
+- [ ] **Step 5: Verify grep rules from Success Criterion #7**
+
+```bash
+grep -l "HARNESS_GATE_STAGNATION" README.md README.ko.md docs/HOW-IT-WORKS.md docs/HOW-IT-WORKS.ko.md
+```
+
+Expected: lists all four files.
+
+- [ ] **Step 6: Run typecheck and full test suite**
+
+```bash
+pnpm tsc --noEmit && pnpm vitest run
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add README.md README.ko.md docs/HOW-IT-WORKS.md docs/HOW-IT-WORKS.ko.md
+git commit -m "docs: add gate stagnation detection documentation and env var reference"
+```
+
+---
+
+## Self-Review: Spec Coverage Audit
+
+| Spec requirement | Covered by task |
+|---|---|
+| SC #1: `stagnation.ts` exports `tokenJaccard`, `StagnationDetector`, `loadStagnationConfig` | T1 |
+| SC #2: `types.ts` has `gate_stagnation` event + `gate-stagnation` reason | T3 |
+| SC #3: `runner.ts` calls `loadStagnationConfig` + dispatches to `handleGateEscalation` when triggered | T5 |
+| SC #4: `pnpm tsc --noEmit` exits 0; `pnpm vitest run` exits 0 with ≥11 new tests | T2+T6+T7 |
+| SC #5: existing `force_pass`/`gate_retry`/`escalation` event shapes unchanged (regression test 11) | T7 |
+| SC #6: `package.json` unchanged | No deps added in any task |
+| SC #7: 4 docs contain `HARNESS_GATE_STAGNATION` | T8 |
+| SC #8: invalid validated env → forcePassGate; WINDOW not validated (tests 9a, 9b) | T6 |
+| I-1 (no-regress when disabled) | T6 test 6, 7, 8 |
+| I-2 (auto-mode-only default) | T2 + T6 test 7 |
+| I-3 (fail-open on exception) | T6 test 9 |
+| I-4 (event additivity) | T3 (enum extension only) + T7 regression test 11 |
+| I-5 (in-memory only, no state.json change) | T5 (no state.ts edits) |
+| I-6 (no new dep) | No package.json changes |
+| I-7 (no CLI surface) | No command-file changes |
+| I-8 (one warn per misconfig) | T2 + T6 test 9a |
+| I-9 (idempotent on resume) | In-memory buffer reset on module load (no serialization) |
+| D13: unified fail-open on any validated-env misconfig | T2 + T6 test 9a |
+| D14: WINDOW reserved no-op | T2 + T6 test 9b |
+
+**No gaps found.** All spec requirements and invariants are covered.

--- a/docs/process/evals/2026-05-06-phase-harness-gate-retry-8ea9-eval.md
+++ b/docs/process/evals/2026-05-06-phase-harness-gate-retry-8ea9-eval.md
@@ -1,0 +1,347 @@
+# Auto Verification Report
+- Date: 2026-05-06
+- Related Spec: N/A
+- Related Plan: N/A
+
+## Results
+| Check | Status | Detail |
+|-------|--------|--------|
+| typecheck | pass |  |
+| test suite | pass |  |
+| stagnation.ts exports tokenJaccard, StagnationDetector, loadStagnationConfig (SC#1) | pass |  |
+| types.ts has gate_stagnation event variant (SC#2) | pass |  |
+| types.ts has gate-stagnation escalation reason (SC#2) | pass |  |
+| runner.ts wires loadStagnationConfig and gate_stagnation (SC#3) | pass |  |
+| no new package.json dependency (SC#6) | pass |  |
+| all four docs contain HARNESS_GATE_STAGNATION (SC#7) | pass |  |
+
+## Summary
+- Total: 8 checks
+- Pass: 8
+- Fail: 0
+
+## Raw Output
+
+### typecheck
+**Command:** `pnpm tsc --noEmit`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>
+
+### test suite
+**Command:** `pnpm vitest run`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+ RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/improve-cycle
+
+ ✓ tests/state.test.ts (53 tests) 41ms
+ ✓ tests/context/skills-rendering.test.ts (45 tests) 51ms
+ ✓ tests/logger.test.ts (32 tests) 70ms
+ ✓ tests/phases/gate.test.ts (32 tests) 181ms
+ ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 40ms
+ ✓ tests/phases/gate-resume.test.ts (12 tests) 187ms
+ ✓ tests/runners/claude-usage.test.ts (17 tests) 132ms
+ ✓ tests/signal.test.ts (17 tests) 501ms
+ ✓ tests/commands/inner.test.ts (25 tests) 266ms
+ ✓ tests/integration/logging.test.ts (15 tests) 292ms
+ ✓ tests/phases/terminal-ui.test.ts (18 tests) 118ms
+ ✓ tests/phases/runner.test.ts (83 tests) 695ms
+ ✓ tests/lock.test.ts (20 tests) 195ms
+ ✓ tests/commands/footer-ticker.test.ts (10 tests) 16ms
+ ✓ tests/phases/stagnation.test.ts (32 tests) 11ms
+ ✓ tests/phases/verify.test.ts (15 tests) 23ms
+ ✓ tests/phases/runner-token-capture.test.ts (8 tests) 16ms
+ ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 14ms
+ ✓ tests/orphan-cleanup.test.ts (20 tests) 23ms
+ ✓ tests/integration/codex-session-resume.test.ts (6 tests) 141ms
+ ✓ tests/preflight.test.ts (27 tests | 1 skipped) 180ms
+ ✓ tests/runners/codex.test.ts (21 tests) 1610ms
+   ✓ spawnCodexInteractiveInPane — pane injection > sends a top-level `codex` TUI command (not `codex exec`) with prompt arg, sandbox, CODEX_HOME 321ms
+   ✓ spawnCodexInteractiveInPane — pane injection > uses --dangerously-bypass-approvals-and-sandbox for phase 5 304ms
+   ✓ spawnCodexInPane — fresh > sends fresh top-level `codex` TUI command with prompt as cat-substitution arg 307ms
+   ✓ spawnCodexInPane — fresh in non-git cwd > does NOT add --skip-git-repo-check even when cwd is non-git (trust-entry handles it) 304ms
+   ✓ spawnCodexInPane — resume > sends top-level `codex resume <sessionId>` TUI command with prompt arg 303ms
+ ✓ tests/context/assembler.test.ts (77 tests) 1826ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 458ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 575ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 613ms
+ ✓ tests/resume-light.test.ts (10 tests) 49ms
+ ✓ tests/integration/light-flow.test.ts (4 tests) 237ms
+ ✓ tests/runners/codex-resume.test.ts (8 tests) 61ms
+ ✓ tests/commands/inner-footer.test.ts (2 tests) 11ms
+ ✓ tests/runners/codex-isolation.test.ts (10 tests) 26ms
+ ✓ tests/context/assembler-resume.test.ts (10 tests) 74ms
+ ✓ tests/tmux.test.ts (34 tests) 820ms
+   ✓ pollForPidFile > returns null on timeout when file never appears 404ms
+   ✓ pollForPidFile > returns null when file contains non-numeric content 404ms
+ ✓ tests/commands/resume-cmd.test.ts (12 tests) 2058ms
+ ✓ tests/integration/gate-stagnation.test.ts (2 tests) 12ms
+ ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 9ms
+ ✓ tests/state-invalidation.test.ts (5 tests) 31ms
+ ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 60ms
+ ✓ tests/runners/claude.test.ts (4 tests) 7ms
+ ✓ tests/phases/verdict.test.ts (16 tests) 4ms
+ ✓ tests/phases/gate-resume-escalation.test.ts (2 tests) 39ms
+ ✓ tests/resume.test.ts (11 tests) 2749ms
+   ✓ resumeRun > errors when specCommit is not in git history 312ms
+ ✓ tests/runners/codex-usage.test.ts (6 tests) 316ms
+   ✓ readCodexSessionUsage — pinned sessionId > returns null when file missing 307ms
+ ✓ tests/root.test.ts (10 tests) 175ms
+ ✓ tests/context/reviewer-contract.test.ts (4 tests) 65ms
+ ✓ tests/commands/status-list.test.ts (7 tests) 624ms
+ ✓ tests/ink/components/CurrentPhase.test.tsx (10 tests) 20ms
+ ✓ tests/ui-footer.test.ts (9 tests) 5ms
+ ✓ tests/commands/jump.test.ts (6 tests) 695ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-JZkpMZ/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-JZkpMZ/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-Ga0BjE/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-Ga0BjE/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-6zqY4h/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-6zqY4h/.claude/skills:
+  phase-harness-codex-gate-review
+No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-czcwDT/.claude/skills. Nothing to uninstall.
+ ✓ tests/uninstall-skills.test.ts (6 tests) 10ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-SezYzC/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-fL9VG6/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-RXf3HL/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-QpOVcN/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-Gc3UX9/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-Gc3UX9/.claude/skills:
+  phase-harness-codex-gate-review
+ ✓ tests/install-skills.test.ts (7 tests) 18ms
+ ✓ tests/input.test.ts (12 tests) 4ms
+ ✓ tests/git.test.ts (24 tests) 2508ms
+[2J[H[2J[H ✓ tests/ui.test.ts (6 tests) 5ms
+ ✓ tests/multi-worktree.test.ts (11 tests) 2685ms
+   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 506ms
+   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 522ms
+   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 457ms
+   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 478ms
+   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 508ms
+ ✓ tests/ink/components/PhaseTimeline.test.tsx (6 tests) 44ms
+ ✓ tests/ink/render.test.ts (11 tests) 31ms
+ ✓ tests/scripts/harness-verify.test.ts (2 tests) 326ms
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
+⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-g7zGS7/phase-5-carryover-missing.md
+⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: jsonl missing
+ℹ Received control signal (SIGUSR1). Applying pending action...
+✓ Applied: skip. Phase loop re-entering.
+ℹ Received control signal (SIGUSR1). Applying pending action...
+✓ Applied: jump → phase 3. Phase loop re-entering.
+ℹ Received control signal (SIGUSR1). Applying pending action...
+✓ Applied: skip. Phase loop re-entering.
+ℹ Received control signal (SIGUSR1). Applying pending action...
+[harness] phase=5 status=failed
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+[harness] phase=5 status=failed
+fatal: not a git repository (or any of the parent directories): .git
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+[harness] phase=5 status=completed
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+```
+
+</details>
+
+### stagnation.ts exports tokenJaccard, StagnationDetector, loadStagnationConfig (SC#1)
+**Command:** `grep -q 'export function tokenJaccard' src/phases/stagnation.ts && grep -q 'export class StagnationDetector' src/phases/stagnation.ts && grep -q 'export function loadStagnationConfig' src/phases/stagnation.ts`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>
+
+### types.ts has gate_stagnation event variant (SC#2)
+**Command:** `grep -q "event: 'gate_stagnation'" src/types.ts`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>
+
+### types.ts has gate-stagnation escalation reason (SC#2)
+**Command:** `grep -q "'gate-stagnation'" src/types.ts`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>
+
+### runner.ts wires loadStagnationConfig and gate_stagnation (SC#3)
+**Command:** `grep -q 'loadStagnationConfig' src/phases/runner.ts && grep -q 'gate_stagnation' src/phases/runner.ts`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>
+
+### no new package.json dependency (SC#6)
+**Command:** `git diff --exit-code main -- package.json`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>
+
+### all four docs contain HARNESS_GATE_STAGNATION (SC#7)
+**Command:** `grep -q 'HARNESS_GATE_STAGNATION' README.md && grep -q 'HARNESS_GATE_STAGNATION' README.ko.md && grep -q 'HARNESS_GATE_STAGNATION' docs/HOW-IT-WORKS.md && grep -q 'HARNESS_GATE_STAGNATION' docs/HOW-IT-WORKS.ko.md`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>

--- a/docs/specs/2026-05-06-phase-harness-gate-retry-8ea9-design.md
+++ b/docs/specs/2026-05-06-phase-harness-gate-retry-8ea9-design.md
@@ -1,0 +1,330 @@
+# Auto-mode Gate Retry Stagnation Detection — Design
+
+- runId: `2026-05-06-phase-harness-gate-retry-8ea9`
+- task spec: `.harness/2026-05-06-phase-harness-gate-retry-8ea9/task.md`
+- decisions log: `.harness/2026-05-06-phase-harness-gate-retry-8ea9/decisions.md`
+- impl plan: written by Phase 3 (`docs/plans/2026-05-06-phase-harness-gate-retry-8ea9.md`)
+- eval report: written by Phase 6 (`docs/eval-reports/2026-05-06-phase-harness-gate-retry-8ea9.md`)
+
+## Context & Decisions
+
+### Failure mode being fixed
+`phase-harness` autonomous mode (`state.autoMode === true`) currently force-passes any gate that has been rejected `retryLimit` times in a row, regardless of *why* it keeps being rejected. The retry counter (`state.gateRetries[phase]`) is the only signal feeding the decision in `src/phases/runner.ts:726–731`. As a result the runtime cannot distinguish two qualitatively different failure traces:
+
+1. **Converging retries** — each retry's reviewer feedback is materially different from the previous one; the implementer is moving toward approval but ran out of attempts. Force-pass is acceptable: the next phase is likely close to working state.
+2. **Stagnant retries** — each retry's reviewer feedback is essentially the same text as the previous one; the implementer is unable to address the root cause (often because the reviewer's request is outside the implementer's reach, or because of a misread spec). Force-pass is *harmful*: the next phase inherits an unaddressed defect and explodes downstream.
+
+Today's auto-mode treats (1) and (2) identically. The user observed downstream blow-ups concentrated on case (2).
+
+### Reference signal
+Q00/ouroboros's stagnation detection literature describes four canonical patterns (spinning, oscillation, no-drift, diminishing returns) with a repetitive-feedback threshold around 70% similarity. We adopt the *single most informative* signal — adjacent-retry feedback overlap — as v1; the remaining patterns can be layered on the same event surface in a later iteration without schema breakage.
+
+### Decision summary (rationale captured in `decisions.md`)
+1. **Detection scope:** single signal — adjacent-retry token-Jaccard ≥ threshold for `RUN` consecutive pairs. (Alternatives weighed: 2-signal hybrid, full 4-pattern. Rejected for surface-area + tuning cost.)
+2. **Default activation:** `on` in auto-mode, `off` in manual mode. Env-overridable. Manual mode already escalates at retry limit, so the new code path only changes auto-mode semantics.
+3. **Detected action:** call existing `handleGateEscalation(...)` (the C/S/Q prompt) instead of `forcePassGate(...)`. Reuses existing UX, ev­ents, and metrics aggregator. New `escalation.reason` enum value `'gate-stagnation'` distinguishes the path in logs.
+4. **Window:** `WINDOW=2`, `RUN=2` (two adjacent stagnant pairs required). With `retryLimit=3`, the check fires exactly at the moment the runner would otherwise force-pass; this is a 1:1 replacement of the failure-prone branch.
+5. **Algorithm:** token-set Jaccard. Tokenization: `NFKC + toLowerCase + /[\p{L}\p{N}_]+/gu`. Deterministic, language-neutral, no dependencies, O(n) per gate.
+6. **Configuration surface:** four env vars (`HARNESS_GATE_STAGNATION{,_THRESHOLD,_RUN,_WINDOW}`) — no CLI flags. Invalid values → fall back to defaults + single stderr warn.
+7. **State persistence:** detector ring buffer is **in-memory only** — not serialised to `state.json`. Resume after crash starts the buffer empty; this is a deliberate, fail-open behaviour (a resumed run must accumulate ≥`RUN + (WINDOW − 1)` rejects again before stagnation can fire — by default 3).
+8. **Backward compatibility:** new `gate_stagnation` event is an additional optional `LogEvent` variant; new `escalation.reason` value is an enum extension. No existing event signature changes. `force_pass.by` stays `'auto' | 'user'` — when stagnation routes to escalation, force-pass either does not happen or happens with `by: 'user'` from the user choosing 'S'.
+
+## Complexity
+
+Medium — single new module (`src/phases/stagnation.ts`, ~150 LoC) plus one branch interception in `src/phases/runner.ts`, plus three test groups, plus README/HOW-IT-WORKS sync. Not a single-file change, not a new subsystem.
+
+## Goals
+
+1. In auto-mode, replace the *unconditional* "rejected `retryLimit` times → force-pass" rule with: *"rejected `retryLimit` times AND the last two reject pairs were stagnant → escalate to user; else force-pass as before"*.
+2. The escalation surface is the existing `handleGateEscalation` prompt (C / S / Q) — no new UI, no new sentinel/reopen logic.
+3. Stagnation detection is deterministic, dependency-free, O(text length) per gate retry, and never blocks a converging gate from reaching force-pass.
+4. The user can disable detection or tune its threshold/run/window via environment variables without rebuilding.
+5. The events.jsonl schema gains exactly one new optional event variant and one enum addition; no existing event field is renamed, removed, or retyped.
+6. On any internal failure (token parse error, ring buffer corruption, malformed env), behaviour falls back to the existing 3-strike force-pass with a single stderr warn — *never* harder than today.
+
+## Non-goals
+
+- No detection of the other three ouroboros patterns (spinning, no-drift, diminishing returns) in this iteration.
+- No CLI flag (`--stagnation-*`). Configuration is env-only.
+- No persistence of detector state across `phase-harness resume`. (Resume = empty buffer = fail-open; intentional.)
+- No change to manual-mode behaviour. Manual mode already prompts at retry limit; adding a stagnation hint there is out of scope.
+- No change to verify-loop retry semantics (Phase 6 `state.verifyRetries`). Only the gate retry branch in `handleGateReject` is touched.
+- No change to `force_pass.by` enum or to existing `escalation.reason` semantics for the four pre-existing values.
+- No telemetry beyond the new `gate_stagnation` event and `summary.json` counter.
+
+## Architecture
+
+### Module map (changes)
+
+| File | Type of change | Purpose |
+|---|---|---|
+| `src/phases/stagnation.ts` | **new** | `tokenJaccard`, `StagnationDetector`, `loadStagnationConfig` |
+| `src/phases/stagnation.test.ts` | **new** | Unit tests for the new module |
+| `src/phases/runner.ts` | edit | Lazy-init detectors per phase; intercept the auto-mode force-pass branch in `handleGateReject` |
+| `src/phases/runner.test.ts` | edit (add cases) | Auto-mode stagnation, manual-mode no-op, env-off no-op, fail-open |
+| `src/types.ts` | edit | Add `gate_stagnation` LogEvent variant; extend `escalation.reason` enum with `'gate-stagnation'` |
+| `src/logger.ts` | edit | Add optional `stagnationEscalations` counter to summary aggregation |
+| `tests/integration/gate-stagnation.test.ts` | **new** | End-to-end: simulate 3 stagnant rejects in auto-mode, verify event ordering + reason |
+| `README.md`, `README.ko.md` | edit | Document the four env vars + the new auto-mode behaviour (one paragraph each) |
+| `docs/HOW-IT-WORKS.md`, `docs/HOW-IT-WORKS.ko.md` | edit | Add stagnation sub-section under gate retry; update events.jsonl schema table |
+
+### Detection algorithm (deterministic spec)
+
+```
+function tokens(text: string): string[]
+  return Array.from(text.normalize('NFKC').toLowerCase().matchAll(/[\p{L}\p{N}_]+/gu)).map(m => m[0])
+
+function tokenJaccard(a: string, b: string): number | null
+  let A = new Set(tokens(a))
+  let B = new Set(tokens(b))
+  if A.size === 0 || B.size === 0 then return null
+  let inter = count of x in A where B.has(x)
+  let union = A.size + B.size - inter
+  if union === 0 then return null
+  return inter / union
+```
+
+### Detector contract
+
+```ts
+class StagnationDetector {
+  constructor(cfg: { threshold: number; run: number; window: number })
+  // Push a fresh feedback comments string. Maintains an in-memory ring buffer of size `RUN + (WINDOW - 1)`.
+  record(comments: string): void
+  // True iff the last `run` adjacent-pair similarities in the buffer are all defined and >= threshold.
+  // Also returns the underlying similarity numbers for telemetry.
+  shouldEscalate(): { triggered: boolean; similarities: number[] }
+}
+```
+
+The buffer holds the last `RUN + (WINDOW − 1)` feedback strings — at default `RUN=2, WINDOW=2` this is **3 strings** (s₀, s₁, s₂), enough to form the two adjacent pairs `(s₀,s₁)` and `(s₁,s₂)` required for trigger. Older entries roll off FIFO. `record` is total (no throws on empty/huge inputs); `shouldEscalate` is total (returns `{triggered: false, similarities: []}` when buffer too small).
+
+### Configuration loader
+
+```ts
+function loadStagnationConfig(autoMode: boolean): {
+  enabled: boolean; threshold: number; run: number; window: number
+}
+```
+
+Reads `process.env`. Each env var is parsed once per phase loop iteration entry (cheap). Invalid values fall back to defaults and emit *one* `console.warn` per misconfigured key per process (deduped via a module-private `Set`).
+
+| Env | Default | Parse rule | On invalid |
+|---|---|---|---|
+| `HARNESS_GATE_STAGNATION` | `'on'` if `autoMode` else `'off'` | `'on'`/`'off'` exact (case-insensitive) | warn + `'off'` |
+| `HARNESS_GATE_STAGNATION_THRESHOLD` | `0.70` | `parseFloat`, must be in `[0, 1]` | warn + `0.70` |
+| `HARNESS_GATE_STAGNATION_RUN` | `2` | `parseInt(base 10)`, must be `>= 2` | warn + `2` |
+| `HARNESS_GATE_STAGNATION_WINDOW` | `2` | `parseInt(base 10)`, must equal `2` | warn + `2` |
+
+### Integration point in `runner.ts`
+
+`handleGateReject` is currently the single producer of force-pass and escalation transitions for gate phases. The change is local to that function:
+
+1. At the **top** of `handleGateReject` (after `state.phases[String(phase)] = 'pending'`, before any state mutation that depends on retryCount): call `getOrCreateDetector(phase, state).record(comments)`. This guarantees the buffer reflects the just-rejected feedback before any branching decision.
+2. **Replace** the existing branch:
+   ```ts
+   if (retryCount >= retryLimit && state.autoMode) {
+     await forcePassGate(phase, state, runDir, cwd, 'auto', logger);
+     return;
+   }
+   ```
+   with:
+   ```ts
+   if (retryCount >= retryLimit && state.autoMode) {
+     const cfg = loadStagnationConfig(state.autoMode);
+     if (cfg.enabled) {
+       let triggered = false;
+       let similarities: number[] = [];
+       try {
+         const r = detector.shouldEscalate();
+         triggered = r.triggered;
+         similarities = r.similarities;
+       } catch (err) {
+         console.warn(`[stagnation] detector error: ${(err as Error).message} — falling back to force-pass`);
+       }
+       if (triggered) {
+         logger.logEvent({
+           event: 'gate_stagnation',
+           phase, retryIndex,
+           similarities,
+           threshold: cfg.threshold,
+           run: cfg.run,
+           action: 'escalate',
+         });
+         await handleGateEscalation(
+           phase, comments, scope, retryIndex,
+           state, runDir, cwd, inputManager, logger,
+           { reason: 'gate-stagnation' },     // new optional override
+         );
+         return;
+       }
+     }
+     await forcePassGate(phase, state, runDir, cwd, 'auto', logger);
+     return;
+   }
+   ```
+3. `handleGateEscalation` gains a single optional parameter `opts?: { reason?: 'gate-retry-limit' | 'gate-stagnation' }`. When omitted, current default `'gate-retry-limit'` stands.
+4. The detector map (`Map<GatePhaseKey, StagnationDetector>`) lives at module scope in `runner.ts` and is reset whenever `state.gateEscalationCycles[phase]` increments (a fresh escalation cycle should not be polluted by the previous cycle's buffer).
+
+### Detector lifetime
+
+| Event | Action on detector |
+|---|---|
+| First reject of a phase in this cycle | Lazy-init detector |
+| Subsequent reject (same cycle) | `record(comments)` only |
+| `handleGateEscalation` outcome 'C' (continue, retries reset) | Drop detector (next reject re-inits) |
+| `forcePassGate` invoked | Drop detector |
+| Phase completed (gate APPROVE) | Drop detector |
+| `phase-harness resume` (state loaded from disk) | Detector map starts empty (in-memory only) |
+| Process exit / SIGTERM | N/A |
+
+## Events / schema changes
+
+### New event
+
+```ts
+| (LogEventBase & {
+    event: 'gate_stagnation';
+    phase: number;          // 2 | 4 | 7
+    retryIndex: number;     // pre-mutation retryIndex of the just-failed retry
+    similarities: number[]; // last RUN values, all >= threshold by construction
+    threshold: number;      // active threshold at decision time
+    run: number;            // active RUN at decision time
+    action: 'escalate';     // future-extensible; v1 emits only on triggered=true
+  })
+```
+
+Emitted exactly once per stagnation-triggered escalation, immediately before `handleGateEscalation` is called. Not emitted when `triggered === false`.
+
+### Extended enum
+
+```ts
+event 'escalation' {
+  reason: 'gate-retry-limit' | 'gate-error' | 'verify-limit' | 'verify-error' | 'gate-stagnation'
+}
+```
+
+All existing readers that pattern-match the four prior values continue to work; readers that don't recognise `'gate-stagnation'` simply pass it through as an opaque string (TypeScript narrowing in our codebase already handles unknown via the union default).
+
+### summary.json
+
+`logger.ts`'s `finalizeSummary` aggregates a new optional counter `totals.stagnationEscalations` (number of `gate_stagnation` events with `action: 'escalate'`). Existing fields unchanged. Readers built before this change will see one additional field they don't read — backward compatible.
+
+### Footer / metrics aggregator
+
+`src/metrics/footer-aggregator.ts` is **not** changed in this iteration. The new event type is ignored by the aggregator (it only tracks the verdict-key set). Existing `escalations` counter already covers stagnation escalations because `handleGateEscalation` emits the `escalation` event regardless of `reason`.
+
+## Behavioural matrix
+
+Truth table for the new branch in `handleGateReject`:
+
+| `retryCount >= retryLimit` | `state.autoMode` | `cfg.enabled` | Detector `triggered` | Result |
+|---|---|---|---|---|
+| no | * | * | * | (unchanged) save feedback, reopen interactive phase |
+| yes | no | * | * | (unchanged) `handleGateEscalation` (reason: `'gate-retry-limit'`) |
+| yes | yes | no | * | (unchanged) `forcePassGate(by='auto')` |
+| yes | yes | yes | no | (unchanged) `forcePassGate(by='auto')` |
+| yes | yes | yes | yes | **new** `handleGateEscalation` (reason: `'gate-stagnation'`); `gate_stagnation` event emitted |
+
+Detector exception in any cell: warn + force-pass (matches the row "triggered=no").
+
+## Configuration surface (final)
+
+```
+HARNESS_GATE_STAGNATION             on (auto) | off (manual; or override)
+HARNESS_GATE_STAGNATION_THRESHOLD   0.70 (range [0, 1])
+HARNESS_GATE_STAGNATION_RUN         2    (>= 2)
+HARNESS_GATE_STAGNATION_WINDOW      2    (=== 2 in v1)
+```
+
+## Test plan
+
+### Unit — `src/phases/stagnation.test.ts`
+
+1. `tokenJaccard` — identical strings (= 1), disjoint strings (= 0), one-side empty (= null), NFKC normalisation (`½` ↔ `1/2` chars), case insensitivity, mixed Korean/English, very long strings (length-stable).
+2. `StagnationDetector.record` — buffer FIFO at capacity `RUN + (WINDOW − 1)` (= 3 by default).
+3. `StagnationDetector.shouldEscalate`:
+   - buffer < `RUN + 1`: `triggered = false`
+   - last `RUN` pairs all ≥ threshold: `triggered = true`
+   - last `RUN` pairs include one < threshold: `triggered = false`
+   - any pair returns null similarity: `triggered = false`
+4. `loadStagnationConfig` — defaults respect `autoMode`; invalid values warn-once + fall back; valid values parsed correctly.
+
+### Unit — `src/phases/runner.test.ts` additions
+
+5. Auto-mode + 3 rejects with stagnant comments → no `forcePassGate`, `handleGateEscalation` called with `reason: 'gate-stagnation'`, `gate_stagnation` event emitted.
+6. Auto-mode + 3 rejects with diverse comments → `forcePassGate` called, `gate_stagnation` not emitted (regression guard).
+7. Manual mode + 3 stagnant rejects → existing escalation path with reason `'gate-retry-limit'` (regression guard).
+8. `HARNESS_GATE_STAGNATION=off` in auto-mode + 3 stagnant rejects → `forcePassGate` called (regression guard).
+9. Detector throws inside `shouldEscalate` → fall back to `forcePassGate`, single warn, no `gate_stagnation` event.
+
+### Integration — `tests/integration/gate-stagnation.test.ts`
+
+10. Drive the runner with `--enable-logging` + simulated stagnant gate rejections (mock the gate phase result). Assert events.jsonl contains, in order:
+    - `gate_retry × 2`
+    - `gate_stagnation × 1`
+    - `escalation × 1` with `reason: 'gate-stagnation'`
+    - and *no* `force_pass` event in between.
+
+### Regression — existing suite
+
+11. The pre-existing `force_pass`, `gate_retry`, and `escalation` event-shape tests must pass unchanged. (Verifies backward-compat constraint #3.)
+
+## Success Criteria
+
+A change is *complete* when **all** of the following are true:
+
+1. **Code presence:** `src/phases/stagnation.ts` exists in the worktree and exports the symbols `tokenJaccard`, `StagnationDetector`, and `loadStagnationConfig`. Verifiable by: `grep -n "export function tokenJaccard\|export class StagnationDetector\|export function loadStagnationConfig" src/phases/stagnation.ts` returns three matching lines.
+2. **Type extension:** `src/types.ts` declares the `gate_stagnation` event variant and adds `'gate-stagnation'` to the `escalation.reason` enum. Verifiable by: `grep -n "event: 'gate_stagnation'" src/types.ts` returns ≥ 1 hit AND `grep -n "'gate-stagnation'" src/types.ts` returns ≥ 1 hit.
+3. **Branch interception:** `src/phases/runner.ts` calls `loadStagnationConfig` and dispatches to `handleGateEscalation` (not `forcePassGate`) when the detector returns `triggered`. Verifiable by: `grep -n "loadStagnationConfig\|gate_stagnation" src/phases/runner.ts` returns ≥ 2 hits inside the `handleGateReject` function body.
+4. **Tests pass:** `pnpm tsc --noEmit` exits 0; `pnpm vitest run` exits 0 with the new tests in the suite (≥ 11 new test names matching the plan above).
+5. **Backward compat:** a freshly built `dist/` produces an `events.jsonl` whose `force_pass`, `gate_retry`, and `escalation` event shapes are byte-identical to a baseline captured before the change for non-stagnant runs. Verifiable by: integration test 11 listed above (existing suite passes unchanged).
+6. **No new dependency:** `package.json` `dependencies` and `devDependencies` are unchanged. Verifiable by: `git diff main -- package.json` shows zero diff in these blocks.
+7. **Documentation sync (CLAUDE.md mandate):** `README.md`, `README.ko.md`, `docs/HOW-IT-WORKS.md`, `docs/HOW-IT-WORKS.ko.md` each contain the string `HARNESS_GATE_STAGNATION` at least once. Verifiable by: `grep -l "HARNESS_GATE_STAGNATION" README.md README.ko.md docs/HOW-IT-WORKS.md docs/HOW-IT-WORKS.ko.md` lists all four files.
+8. **Fail-open under env misconfiguration:** with `HARNESS_GATE_STAGNATION_THRESHOLD=not-a-number` and a 3-stagnant-reject auto-mode run, the result is `forcePassGate` (i.e., the single warn does not block force-pass). Verifiable by integration test variant of test 9.
+
+## Invariants
+
+The implementation MUST preserve the following at all times:
+
+- **I-1 (no-regress):** When `cfg.enabled === false` OR detector returns `triggered === false`, the runtime path through `handleGateReject` is byte-identical to the pre-change path. No new state mutation, no new event, no new file IO.
+- **I-2 (auto-mode-only by default):** In manual mode (`state.autoMode === false`) and with no env override, `loadStagnationConfig(false).enabled === false`. The detector may be constructed and recorded into, but `shouldEscalate` is never consulted on the manual-mode branch.
+- **I-3 (fail-open):** Any thrown exception from `tokenJaccard`, `record`, `shouldEscalate`, or `loadStagnationConfig` is caught at the call site in `handleGateReject` and routed to the existing `forcePassGate` path. Stagnation MUST NOT introduce a new way to crash the harness.
+- **I-4 (event additivity):** Existing `LogEvent` variant fields remain unchanged in name, type, and presence. The only schema deltas are: (a) a new top-level variant `gate_stagnation`; (b) an enum extension on `escalation.reason`. Verifiable by: `grep -nE "event: 'gate_retry'\|event: 'force_pass'\|event: 'escalation'" src/types.ts` shows the same line shapes (modulo the enum widening) as on `main`.
+- **I-5 (in-memory only):** `state.json` and `meta.json` schemas gain no new fields. The detector buffer is never serialised. Verifiable by: `grep -n "stagnation\|Stagnation" src/state.ts src/types.ts` returns hits ONLY in the LogEvent area, NOT in `HarnessState` / `SessionMeta` interfaces.
+- **I-6 (no new dependency):** `package.json` is unchanged in `dependencies` and `devDependencies`.
+- **I-7 (no CLI surface):** `src/commands/{run,resume,start,jump,skip,inner}.ts` gain zero new flags. Verifiable by: `grep -n "stagnation" src/commands/*.ts` returns zero hits (no command-layer surface).
+- **I-8 (one warn per misconfig):** Each invalid env var emits at most one `console.warn` per process, deduped by env-var name.
+- **I-9 (idempotent on resume):** Resuming a paused run starts the detector buffer empty for every phase; this MUST NOT cause a previously-decided escalation to be undone or a previously-decided force-pass to be retroactively converted.
+
+## Edge cases
+
+- **Two consecutive identical feedback strings of zero tokens** (e.g., reviewer returned an empty `## Reviewer Comments` block): `tokenJaccard` returns `null` for both pairs → `triggered = false` → force-pass. Acceptable: this is a reviewer-side anomaly, not a stagnation signal.
+- **Reviewer feedback uses code blocks with identical error stacks across retries:** these tokens contribute equally to both sides of the union → similarity rises, often well above 0.70. This is the *intended* signal for stagnation. No special handling.
+- **Phase 7 (`handleGateReject(phase=7, ...)`) interaction with light-flow's `state.carryoverFeedback`:** stagnation check runs *before* the existing carryover-feedback branch. If `triggered`, escalation runs and the carryover branch never executes for this round. Acceptable: escalation supersedes auto-reopen; user choice ('C') will reset retries and the next reject can re-establish carryover.
+- **`gateEscalationCycles[phase]` increment:** the detector is dropped at cycle boundary (see Detector lifetime). A user choosing 'C' resets retries to 0 and starts a fresh cycle; the new cycle must accumulate stagnant pairs from scratch.
+- **Gate APPROVE after stagnant rejects:** the detector is dropped on success; subsequent re-runs of this phase (e.g., later in the same harness session via REopen) start fresh.
+
+## Migration / rollout
+
+- **Feature flag default:** `on` for auto-mode means the change is live the moment a build ships. We accept this because (a) the existing default is buggy by user observation, (b) the failure mode of the new code is fail-open to the existing default, and (c) `HARNESS_GATE_STAGNATION=off` is a one-line escape hatch for any operator who wants the old behaviour.
+- **No state migration:** `state.json` schema is unchanged. Runs persisted before this change can be resumed without rewrites.
+- **No prompt template changes:** assembler, wrappers, and reviewer contracts are untouched. Only the runtime decision code changes.
+
+## Risks & mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| False positive: legitimate convergence flagged as stagnant because reviewer's prose is repetitive but the code is changing | Medium | Threshold `0.70` is conservative; `RUN=2` requires *two* consecutive stagnant pairs; user can override via env. The fallback action (escalation prompt) is non-destructive — user can choose 'S' to force-pass anyway. |
+| False negative: real stagnation slips through because reviewer changes wording each time but criticises the same root cause | Medium | Acceptable for v1 — degrades gracefully to today's behaviour. Future patterns (no-drift, diminishing returns) can be layered later via the same event surface. |
+| Performance regression from token Jaccard on large feedback (e.g., > 100 KB) | Low | Token set construction is O(n); two sets at most ~tens of thousands of unique tokens; intersection via Set ops is O(min). One call per gate retry. Negligible against gate runtime. |
+| Test flakiness from in-memory detector state leaking between vitest cases | Low | Detector map is scoped to `runner.ts` module; tests reset via the existing module-mocking pattern. New tests reset the map explicitly via an exported `__resetDetectors` test hook (or vi.resetModules). |
+| Documentation drift: env vars in code disagree with README | Medium | Success Criterion #7 makes the doc sync verifiable by grep — Phase 6 verify report fails if any of the four files lacks the env-var name. |
+
+## Out-of-scope future work
+
+- The other three ouroboros patterns (spinning, no-drift, diminishing returns).
+- A `--stagnation-threshold` CLI flag, should env-only configuration prove ergonomically insufficient.
+- Persisting the detector buffer in `state.json` to survive `phase-harness resume` mid-cycle.
+- A retroactive replay tool that runs stagnation detection over historical `events.jsonl` archives.
+- Per-phase threshold tuning (currently one threshold applies to phases 2 / 4 / 7).

--- a/docs/specs/2026-05-06-phase-harness-gate-retry-8ea9-design.md
+++ b/docs/specs/2026-05-06-phase-harness-gate-retry-8ea9-design.md
@@ -40,7 +40,7 @@ Medium — single new module (`src/phases/stagnation.ts`, ~150 LoC) plus one bra
 3. Stagnation detection is deterministic, dependency-free, O(text length) per gate retry, and never blocks a converging gate from reaching force-pass.
 4. The user can disable detection or tune its threshold/run/window via environment variables without rebuilding.
 5. The events.jsonl schema gains exactly one new optional event variant and one enum addition; no existing event field is renamed, removed, or retyped.
-6. On any internal failure (token parse error, ring buffer corruption, malformed env), behaviour falls back to the existing 3-strike force-pass with a single stderr warn — *never* harder than today.
+6. On any internal failure (token parse error, ring buffer corruption, malformed env), behaviour falls back to the existing 3-strike force-pass with at most one stderr warn per key — *never* harder than today. Specifically: malformed env values force `cfg.enabled = false` for the entire process (unified rule — see Configuration loader and I-3); detector exceptions are caught and routed to force-pass at the call site.
 
 ## Non-goals
 
@@ -107,20 +107,22 @@ function loadStagnationConfig(autoMode: boolean): {
 }
 ```
 
-Reads `process.env`. Each env var is parsed once per phase loop iteration entry (cheap). Invalid values fall back to defaults and emit *one* `console.warn` per misconfigured key per process (deduped via a module-private `Set`).
+Reads `process.env`. Each env var is parsed once per phase loop iteration entry (cheap). **Any invalid env value forces `enabled = false` for the entire process** (i.e., the feature self-disables on misconfiguration), and emits *one* `console.warn` per misconfigured key per process (deduped via a module-private `Set`). This unified rule guarantees that the runtime path on misconfig is byte-identical to today's 3-strike force-pass behaviour (Goal #6).
 
 | Env | Default | Parse rule | On invalid |
 |---|---|---|---|
-| `HARNESS_GATE_STAGNATION` | `'on'` if `autoMode` else `'off'` | `'on'`/`'off'` exact (case-insensitive) | warn + `'off'` |
-| `HARNESS_GATE_STAGNATION_THRESHOLD` | `0.70` | `parseFloat`, must be in `[0, 1]` | warn + `0.70` |
-| `HARNESS_GATE_STAGNATION_RUN` | `2` | `parseInt(base 10)`, must be `>= 2` | warn + `2` |
-| `HARNESS_GATE_STAGNATION_WINDOW` | `2` | `parseInt(base 10)`, must equal `2` | warn + `2` |
+| `HARNESS_GATE_STAGNATION` | `'on'` if `autoMode` else `'off'` | `'on'`/`'off'` exact (case-insensitive) | warn + force `enabled = false` |
+| `HARNESS_GATE_STAGNATION_THRESHOLD` | `0.70` | `parseFloat`, must be in `[0, 1]` | warn + force `enabled = false` |
+| `HARNESS_GATE_STAGNATION_RUN` | `2` | `parseInt(base 10)`, must be `>= 2` | warn + force `enabled = false` |
+| `HARNESS_GATE_STAGNATION_WINDOW` | `2` | `parseInt(base 10)`, must equal `2` | warn + force `enabled = false` |
+
+When valid, `threshold/run/window` are returned as their parsed values; when invalid, the loader returns `{ enabled: false, threshold: 0.70, run: 2, window: 2 }` (the defaults are still populated as inert placeholders, but `enabled: false` short-circuits all downstream consumers — see Integration point below).
 
 ### Integration point in `runner.ts`
 
 `handleGateReject` is currently the single producer of force-pass and escalation transitions for gate phases. The change is local to that function:
 
-1. At the **top** of `handleGateReject` (after `state.phases[String(phase)] = 'pending'`, before any state mutation that depends on retryCount): call `getOrCreateDetector(phase, state).record(comments)`. This guarantees the buffer reflects the just-rejected feedback before any branching decision.
+1. At the **top** of `handleGateReject` (after `state.phases[String(phase)] = 'pending'`, before any state mutation that depends on retryCount): call `cfg = loadStagnationConfig(state.autoMode)`. If `cfg.enabled === true`, then call `getOrCreateDetector(phase, cfg).record(comments)` — otherwise *skip both the detector construction and the record call entirely*. This way, when stagnation is disabled (manual mode, env-off, or env-misconfigured), `handleGateReject`'s control- and data-flow are byte-identical to today's code (the only delta is the `loadStagnationConfig` call itself, which is a pure read of `process.env` with no side effects beyond the deduped warn). The same `cfg` value is reused at the branch in step 2 — *do not call the loader twice in one invocation*.
 2. **Replace** the existing branch:
    ```ts
    if (retryCount >= retryLimit && state.autoMode) {
@@ -128,11 +130,10 @@ Reads `process.env`. Each env var is parsed once per phase loop iteration entry 
      return;
    }
    ```
-   with:
+   with (note: `cfg` is the same value already loaded in step 1; the detector here is the one that was constructed/recorded in step 1, or `undefined` if stagnation is disabled):
    ```ts
    if (retryCount >= retryLimit && state.autoMode) {
-     const cfg = loadStagnationConfig(state.autoMode);
-     if (cfg.enabled) {
+     if (cfg.enabled && detector !== undefined) {
        let triggered = false;
        let similarities: number[] = [];
        try {
@@ -218,15 +219,16 @@ All existing readers that pattern-match the four prior values continue to work; 
 
 Truth table for the new branch in `handleGateReject`:
 
-| `retryCount >= retryLimit` | `state.autoMode` | `cfg.enabled` | Detector `triggered` | Result |
-|---|---|---|---|---|
-| no | * | * | * | (unchanged) save feedback, reopen interactive phase |
-| yes | no | * | * | (unchanged) `handleGateEscalation` (reason: `'gate-retry-limit'`) |
-| yes | yes | no | * | (unchanged) `forcePassGate(by='auto')` |
-| yes | yes | yes | no | (unchanged) `forcePassGate(by='auto')` |
-| yes | yes | yes | yes | **new** `handleGateEscalation` (reason: `'gate-stagnation'`); `gate_stagnation` event emitted |
+| `retryCount >= retryLimit` | `state.autoMode` | env any-invalid | `cfg.enabled` | Detector `triggered` | Result |
+|---|---|---|---|---|---|
+| no | * | * | * | * | (unchanged) save feedback, reopen interactive phase |
+| yes | no | * | * | * | (unchanged) `handleGateEscalation` (reason: `'gate-retry-limit'`) |
+| yes | yes | yes | no | n/a (detector not constructed) | (unchanged) `forcePassGate(by='auto')` |
+| yes | yes | no | no | n/a (detector not constructed) | (unchanged) `forcePassGate(by='auto')` — covers `HARNESS_GATE_STAGNATION=off` |
+| yes | yes | no | yes | no | (unchanged) `forcePassGate(by='auto')` |
+| yes | yes | no | yes | yes | **new** `handleGateEscalation` (reason: `'gate-stagnation'`); `gate_stagnation` event emitted |
 
-Detector exception in any cell: warn + force-pass (matches the row "triggered=no").
+Detector exception in any cell: warn + force-pass (matches the row "triggered=no"). Note: column "env any-invalid = yes" implies `cfg.enabled = false` by I-3, so it can never coexist with `triggered = yes`.
 
 ## Configuration surface (final)
 
@@ -248,7 +250,7 @@ HARNESS_GATE_STAGNATION_WINDOW      2    (=== 2 in v1)
    - last `RUN` pairs all ≥ threshold: `triggered = true`
    - last `RUN` pairs include one < threshold: `triggered = false`
    - any pair returns null similarity: `triggered = false`
-4. `loadStagnationConfig` — defaults respect `autoMode`; invalid values warn-once + fall back; valid values parsed correctly.
+4. `loadStagnationConfig` — defaults respect `autoMode`; **any invalid env value forces `enabled = false` and warns at most once per misconfigured key per process** (regardless of which key was malformed); all-valid input returns parsed values with `enabled` driven by `HARNESS_GATE_STAGNATION` only.
 
 ### Unit — `src/phases/runner.test.ts` additions
 
@@ -257,6 +259,7 @@ HARNESS_GATE_STAGNATION_WINDOW      2    (=== 2 in v1)
 7. Manual mode + 3 stagnant rejects → existing escalation path with reason `'gate-retry-limit'` (regression guard).
 8. `HARNESS_GATE_STAGNATION=off` in auto-mode + 3 stagnant rejects → `forcePassGate` called (regression guard).
 9. Detector throws inside `shouldEscalate` → fall back to `forcePassGate`, single warn, no `gate_stagnation` event.
+9a. **Env misconfiguration (any one of THRESHOLD/RUN/WINDOW invalid, e.g., `HARNESS_GATE_STAGNATION_THRESHOLD=not-a-number`) in auto-mode + 3 stagnant rejects → `forcePassGate` called, `gate_stagnation` not emitted, exactly one warn for the offending key.** This pins the unified-fail-open rule.
 
 ### Integration — `tests/integration/gate-stagnation.test.ts`
 
@@ -281,15 +284,15 @@ A change is *complete* when **all** of the following are true:
 5. **Backward compat:** a freshly built `dist/` produces an `events.jsonl` whose `force_pass`, `gate_retry`, and `escalation` event shapes are byte-identical to a baseline captured before the change for non-stagnant runs. Verifiable by: integration test 11 listed above (existing suite passes unchanged).
 6. **No new dependency:** `package.json` `dependencies` and `devDependencies` are unchanged. Verifiable by: `git diff main -- package.json` shows zero diff in these blocks.
 7. **Documentation sync (CLAUDE.md mandate):** `README.md`, `README.ko.md`, `docs/HOW-IT-WORKS.md`, `docs/HOW-IT-WORKS.ko.md` each contain the string `HARNESS_GATE_STAGNATION` at least once. Verifiable by: `grep -l "HARNESS_GATE_STAGNATION" README.md README.ko.md docs/HOW-IT-WORKS.md docs/HOW-IT-WORKS.ko.md` lists all four files.
-8. **Fail-open under env misconfiguration:** with `HARNESS_GATE_STAGNATION_THRESHOLD=not-a-number` and a 3-stagnant-reject auto-mode run, the result is `forcePassGate` (i.e., the single warn does not block force-pass). Verifiable by integration test variant of test 9.
+8. **Fail-open under env misconfiguration:** with `HARNESS_GATE_STAGNATION_THRESHOLD=not-a-number` (or any other invalid value of any of the four env vars) and a 3-stagnant-reject auto-mode run, the result is `forcePassGate(by='auto')`, `gate_stagnation` is NOT emitted, and exactly one stderr `console.warn` is produced for the offending key. Verifiable by test 9a in the test plan above.
 
 ## Invariants
 
 The implementation MUST preserve the following at all times:
 
-- **I-1 (no-regress):** When `cfg.enabled === false` OR detector returns `triggered === false`, the runtime path through `handleGateReject` is byte-identical to the pre-change path. No new state mutation, no new event, no new file IO.
-- **I-2 (auto-mode-only by default):** In manual mode (`state.autoMode === false`) and with no env override, `loadStagnationConfig(false).enabled === false`. The detector may be constructed and recorded into, but `shouldEscalate` is never consulted on the manual-mode branch.
-- **I-3 (fail-open):** Any thrown exception from `tokenJaccard`, `record`, `shouldEscalate`, or `loadStagnationConfig` is caught at the call site in `handleGateReject` and routed to the existing `forcePassGate` path. Stagnation MUST NOT introduce a new way to crash the harness.
+- **I-1 (no-regress):** When `cfg.enabled === false` (manual mode, env-off, or env-misconfigured) OR `triggered === false` from `shouldEscalate()`, the runtime path through `handleGateReject` is byte-identical to the pre-change path with respect to *persisted* state (`state.json`, sentinels, files), *emitted events*, and *file IO*. The only deltas vs main are: (a) the pure `process.env` read inside `loadStagnationConfig` (which has no side effects beyond an at-most-once-per-key deduped `console.warn`), and (b) when `cfg.enabled === true`, an in-memory ring-buffer push inside the detector — both confined to the running process and never serialised.
+- **I-2 (auto-mode-only by default):** In manual mode (`state.autoMode === false`) and with no env override, `loadStagnationConfig(false).enabled === false`. **When `cfg.enabled === false`, the detector is neither constructed nor consulted** — `getOrCreateDetector` is not called and `record`/`shouldEscalate` are never invoked. The whole stagnation code path collapses to the single `loadStagnationConfig` call.
+- **I-3 (fail-open):** Any thrown exception from `loadStagnationConfig`, `tokenJaccard`, `record`, or `shouldEscalate` is caught at the call site in `handleGateReject` and routed to the existing `forcePassGate` path with one `console.warn`. Additionally, *any* invalid env value forces `cfg.enabled = false` for the rest of the process (one warn per misconfigured key, see I-8). Stagnation MUST NOT introduce a new way to crash the harness, and it MUST NOT make stricter decisions (escalate where the old code force-passed) under malformed configuration.
 - **I-4 (event additivity):** Existing `LogEvent` variant fields remain unchanged in name, type, and presence. The only schema deltas are: (a) a new top-level variant `gate_stagnation`; (b) an enum extension on `escalation.reason`. Verifiable by: `grep -nE "event: 'gate_retry'\|event: 'force_pass'\|event: 'escalation'" src/types.ts` shows the same line shapes (modulo the enum widening) as on `main`.
 - **I-5 (in-memory only):** `state.json` and `meta.json` schemas gain no new fields. The detector buffer is never serialised. Verifiable by: `grep -n "stagnation\|Stagnation" src/state.ts src/types.ts` returns hits ONLY in the LogEvent area, NOT in `HarnessState` / `SessionMeta` interfaces.
 - **I-6 (no new dependency):** `package.json` is unchanged in `dependencies` and `devDependencies`.

--- a/docs/specs/2026-05-06-phase-harness-gate-retry-8ea9-design.md
+++ b/docs/specs/2026-05-06-phase-harness-gate-retry-8ea9-design.md
@@ -38,7 +38,7 @@ Medium — single new module (`src/phases/stagnation.ts`, ~150 LoC) plus one bra
 1. In auto-mode, replace the *unconditional* "rejected `retryLimit` times → force-pass" rule with: *"rejected `retryLimit` times AND the last two reject pairs were stagnant → escalate to user; else force-pass as before"*.
 2. The escalation surface is the existing `handleGateEscalation` prompt (C / S / Q) — no new UI, no new sentinel/reopen logic.
 3. Stagnation detection is deterministic, dependency-free, O(text length) per gate retry, and never blocks a converging gate from reaching force-pass.
-4. The user can disable detection or tune its threshold/run/window via environment variables without rebuilding.
+4. The user can disable detection or tune its **threshold and run** via environment variables without rebuilding. The pair-size parameter (`window`) is *not* user-tunable in v1 — it is fixed at `2` (adjacent-pair comparison). The env var `HARNESS_GATE_STAGNATION_WINDOW` is accepted but treated as a no-op for forward-compatibility (see Configuration loader).
 5. The events.jsonl schema gains exactly one new optional event variant and one enum addition; no existing event field is renamed, removed, or retyped.
 6. On any internal failure (token parse error, ring buffer corruption, malformed env), behaviour falls back to the existing 3-strike force-pass with at most one stderr warn per key — *never* harder than today. Specifically: malformed env values force `cfg.enabled = false` for the entire process (unified rule — see Configuration loader and I-3); detector exceptions are caught and routed to force-pass at the call site.
 
@@ -97,7 +97,7 @@ class StagnationDetector {
 }
 ```
 
-The buffer holds the last `RUN + (WINDOW − 1)` feedback strings — at default `RUN=2, WINDOW=2` this is **3 strings** (s₀, s₁, s₂), enough to form the two adjacent pairs `(s₀,s₁)` and `(s₁,s₂)` required for trigger. Older entries roll off FIFO. `record` is total (no throws on empty/huge inputs); `shouldEscalate` is total (returns `{triggered: false, similarities: []}` when buffer too small).
+The constructor accepts `window` for forward-compat parameterisation (and so unit tests can probe the buffer formula against multiple values), but in v1 `loadStagnationConfig` always passes `window: 2`. The buffer holds the last `RUN + (WINDOW − 1)` feedback strings — at the v1 fixed values `RUN=2, WINDOW=2` this is **3 strings** (s₀, s₁, s₂), enough to form the two adjacent pairs `(s₀,s₁)` and `(s₁,s₂)` required for trigger. Older entries roll off FIFO. `record` is total (no throws on empty/huge inputs); `shouldEscalate` is total (returns `{triggered: false, similarities: []}` when buffer too small).
 
 ### Configuration loader
 
@@ -107,16 +107,16 @@ function loadStagnationConfig(autoMode: boolean): {
 }
 ```
 
-Reads `process.env`. Each env var is parsed once per phase loop iteration entry (cheap). **Any invalid env value forces `enabled = false` for the entire process** (i.e., the feature self-disables on misconfiguration), and emits *one* `console.warn` per misconfigured key per process (deduped via a module-private `Set`). This unified rule guarantees that the runtime path on misconfig is byte-identical to today's 3-strike force-pass behaviour (Goal #6).
+Reads `process.env`. Each env var is parsed once per phase loop iteration entry (cheap). **Any invalid value of a *validated* env (`HARNESS_GATE_STAGNATION`, `_THRESHOLD`, `_RUN`) forces `enabled = false` for the entire process** (i.e., the feature self-disables on misconfiguration), and emits *one* `console.warn` per misconfigured key per process (deduped via a module-private `Set`). This unified rule guarantees that the runtime path on misconfig is byte-identical to today's 3-strike force-pass behaviour (Goal #6). `HARNESS_GATE_STAGNATION_WINDOW` is **not** validated in v1 — it is a *reserved* env name accepted as a no-op and never participates in the misconfig disable rule.
 
 | Env | Default | Parse rule | On invalid |
 |---|---|---|---|
 | `HARNESS_GATE_STAGNATION` | `'on'` if `autoMode` else `'off'` | `'on'`/`'off'` exact (case-insensitive) | warn + force `enabled = false` |
 | `HARNESS_GATE_STAGNATION_THRESHOLD` | `0.70` | `parseFloat`, must be in `[0, 1]` | warn + force `enabled = false` |
 | `HARNESS_GATE_STAGNATION_RUN` | `2` | `parseInt(base 10)`, must be `>= 2` | warn + force `enabled = false` |
-| `HARNESS_GATE_STAGNATION_WINDOW` | `2` | `parseInt(base 10)`, must equal `2` | warn + force `enabled = false` |
+| `HARNESS_GATE_STAGNATION_WINDOW` | `2` (fixed) | **no validation** — value is read but ignored; `window` returned by loader is always `2` in v1 | n/a (no value can be "invalid") |
 
-When valid, `threshold/run/window` are returned as their parsed values; when invalid, the loader returns `{ enabled: false, threshold: 0.70, run: 2, window: 2 }` (the defaults are still populated as inert placeholders, but `enabled: false` short-circuits all downstream consumers — see Integration point below).
+When the three validated envs are valid, `loadStagnationConfig` returns parsed values for `threshold` and `run` and the constant `2` for `window`; when any validated env is invalid, the loader returns `{ enabled: false, threshold: 0.70, run: 2, window: 2 }` (the defaults are still populated as inert placeholders, but `enabled: false` short-circuits all downstream consumers — see Integration point below). Setting `HARNESS_GATE_STAGNATION_WINDOW` to any value (`2`, `5`, `not-a-number`, empty, etc.) does NOT change the returned config and does NOT emit a warn.
 
 ### Integration point in `runner.ts`
 
@@ -219,7 +219,7 @@ All existing readers that pattern-match the four prior values continue to work; 
 
 Truth table for the new branch in `handleGateReject`:
 
-| `retryCount >= retryLimit` | `state.autoMode` | env any-invalid | `cfg.enabled` | Detector `triggered` | Result |
+| `retryCount >= retryLimit` | `state.autoMode` | any *validated* env invalid | `cfg.enabled` | Detector `triggered` | Result |
 |---|---|---|---|---|---|
 | no | * | * | * | * | (unchanged) save feedback, reopen interactive phase |
 | yes | no | * | * | * | (unchanged) `handleGateEscalation` (reason: `'gate-retry-limit'`) |
@@ -228,16 +228,18 @@ Truth table for the new branch in `handleGateReject`:
 | yes | yes | no | yes | no | (unchanged) `forcePassGate(by='auto')` |
 | yes | yes | no | yes | yes | **new** `handleGateEscalation` (reason: `'gate-stagnation'`); `gate_stagnation` event emitted |
 
-Detector exception in any cell: warn + force-pass (matches the row "triggered=no"). Note: column "env any-invalid = yes" implies `cfg.enabled = false` by I-3, so it can never coexist with `triggered = yes`.
+Detector exception in any cell: warn + force-pass (matches the row "triggered=no"). Notes: (1) column "any validated env invalid = yes" implies `cfg.enabled = false` by I-3, so it can never coexist with `triggered = yes`. (2) Setting `HARNESS_GATE_STAGNATION_WINDOW` to any value (including non-`2`) does **not** flip this column — `WINDOW` is not validated in v1 (see Configuration loader).
 
 ## Configuration surface (final)
 
 ```
-HARNESS_GATE_STAGNATION             on (auto) | off (manual; or override)
-HARNESS_GATE_STAGNATION_THRESHOLD   0.70 (range [0, 1])
-HARNESS_GATE_STAGNATION_RUN         2    (>= 2)
-HARNESS_GATE_STAGNATION_WINDOW      2    (=== 2 in v1)
+HARNESS_GATE_STAGNATION             on (auto) | off (manual; or override) | invalid → warn + disable feature
+HARNESS_GATE_STAGNATION_THRESHOLD   0.70  (validated range [0, 1]; invalid → warn + disable feature)
+HARNESS_GATE_STAGNATION_RUN         2     (validated range [2, ∞); invalid → warn + disable feature)
+HARNESS_GATE_STAGNATION_WINDOW      2     (RESERVED in v1 — not validated, accepted as no-op for forward-compat; v1 always uses pair size 2)
 ```
+
+Only the first three envs are honoured for behaviour. `WINDOW` is exposed as a documented placeholder so that future versions can give it semantics without breaking operators who set it today.
 
 ## Test plan
 
@@ -250,7 +252,11 @@ HARNESS_GATE_STAGNATION_WINDOW      2    (=== 2 in v1)
    - last `RUN` pairs all ≥ threshold: `triggered = true`
    - last `RUN` pairs include one < threshold: `triggered = false`
    - any pair returns null similarity: `triggered = false`
-4. `loadStagnationConfig` — defaults respect `autoMode`; **any invalid env value forces `enabled = false` and warns at most once per misconfigured key per process** (regardless of which key was malformed); all-valid input returns parsed values with `enabled` driven by `HARNESS_GATE_STAGNATION` only.
+4. `loadStagnationConfig` —
+   - Defaults respect `autoMode` (manual → `enabled: false`, auto → `enabled: true` baseline).
+   - Any invalid value of a validated key (`HARNESS_GATE_STAGNATION`, `_THRESHOLD`, `_RUN`) forces `enabled = false` and warns at most once per misconfigured key per process.
+   - `HARNESS_GATE_STAGNATION_WINDOW` is treated as no-op: setting it to `'2'`, `'5'`, `'-1'`, `'not-a-number'`, or empty string MUST all return `window: 2` and MUST NOT cause `enabled` to become `false` and MUST NOT emit a warn.
+   - All-valid input returns parsed `threshold`/`run` and the constant `window: 2`, with `enabled` driven by `HARNESS_GATE_STAGNATION` only.
 
 ### Unit — `src/phases/runner.test.ts` additions
 
@@ -259,7 +265,8 @@ HARNESS_GATE_STAGNATION_WINDOW      2    (=== 2 in v1)
 7. Manual mode + 3 stagnant rejects → existing escalation path with reason `'gate-retry-limit'` (regression guard).
 8. `HARNESS_GATE_STAGNATION=off` in auto-mode + 3 stagnant rejects → `forcePassGate` called (regression guard).
 9. Detector throws inside `shouldEscalate` → fall back to `forcePassGate`, single warn, no `gate_stagnation` event.
-9a. **Env misconfiguration (any one of THRESHOLD/RUN/WINDOW invalid, e.g., `HARNESS_GATE_STAGNATION_THRESHOLD=not-a-number`) in auto-mode + 3 stagnant rejects → `forcePassGate` called, `gate_stagnation` not emitted, exactly one warn for the offending key.** This pins the unified-fail-open rule.
+9a. **Env misconfiguration of a *validated* key (any one of `HARNESS_GATE_STAGNATION` / `_THRESHOLD` / `_RUN` invalid, e.g., `HARNESS_GATE_STAGNATION_THRESHOLD=not-a-number`) in auto-mode + 3 stagnant rejects → `forcePassGate` called, `gate_stagnation` not emitted, exactly one warn for the offending key.** This pins the unified-fail-open rule.
+9b. **`HARNESS_GATE_STAGNATION_WINDOW` set to a non-`2` value** (e.g., `5`, `not-a-number`, empty) in auto-mode + 3 stagnant rejects → `handleGateEscalation` called with `reason: 'gate-stagnation'` (i.e., feature stays enabled, WINDOW is ignored), `gate_stagnation` event emitted, NO warn for the WINDOW key. This pins the WINDOW-as-no-op semantics required by Goal #4.
 
 ### Integration — `tests/integration/gate-stagnation.test.ts`
 
@@ -284,7 +291,7 @@ A change is *complete* when **all** of the following are true:
 5. **Backward compat:** a freshly built `dist/` produces an `events.jsonl` whose `force_pass`, `gate_retry`, and `escalation` event shapes are byte-identical to a baseline captured before the change for non-stagnant runs. Verifiable by: integration test 11 listed above (existing suite passes unchanged).
 6. **No new dependency:** `package.json` `dependencies` and `devDependencies` are unchanged. Verifiable by: `git diff main -- package.json` shows zero diff in these blocks.
 7. **Documentation sync (CLAUDE.md mandate):** `README.md`, `README.ko.md`, `docs/HOW-IT-WORKS.md`, `docs/HOW-IT-WORKS.ko.md` each contain the string `HARNESS_GATE_STAGNATION` at least once. Verifiable by: `grep -l "HARNESS_GATE_STAGNATION" README.md README.ko.md docs/HOW-IT-WORKS.md docs/HOW-IT-WORKS.ko.md` lists all four files.
-8. **Fail-open under env misconfiguration:** with `HARNESS_GATE_STAGNATION_THRESHOLD=not-a-number` (or any other invalid value of any of the four env vars) and a 3-stagnant-reject auto-mode run, the result is `forcePassGate(by='auto')`, `gate_stagnation` is NOT emitted, and exactly one stderr `console.warn` is produced for the offending key. Verifiable by test 9a in the test plan above.
+8. **Fail-open under env misconfiguration:** with any invalid value of a *validated* env (`HARNESS_GATE_STAGNATION`, `_THRESHOLD`, or `_RUN` — e.g., `HARNESS_GATE_STAGNATION_THRESHOLD=not-a-number`) and a 3-stagnant-reject auto-mode run, the result is `forcePassGate(by='auto')`, `gate_stagnation` is NOT emitted, and exactly one stderr `console.warn` is produced for the offending key. `HARNESS_GATE_STAGNATION_WINDOW` is *not* a validated env in v1: setting it to any value MUST NOT trigger this path (see test 9b). Verifiable by tests 9a and 9b in the test plan above.
 
 ## Invariants
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -180,7 +180,7 @@ export class FileSessionLogger implements SessionLogger {
       const phases: Record<string, any> = {};
       const seenVerdictKeys = new Set<string>();
       const seenErrorPhases = new Set<number>();
-      let gateTokens = 0, gateRejects = 0, gateErrors = 0, escalations = 0, verifyFailures = 0, forcePasses = 0;
+      let gateTokens = 0, gateRejects = 0, gateErrors = 0, escalations = 0, verifyFailures = 0, forcePasses = 0, stagnationEscalations = 0;
 
       // First pass: collect authoritative event keys
       for (const e of events) {
@@ -226,6 +226,8 @@ export class FileSessionLogger implements SessionLogger {
           escalations++;
         } else if (e.event === 'force_pass') {
           forcePasses++;
+        } else if (e.event === 'gate_stagnation' && (e as any).action === 'escalate') {
+          stagnationEscalations++;
         } else if (e.event === 'verify_result' && !e.passed) {
           verifyFailures++;
         }
@@ -241,7 +243,7 @@ export class FileSessionLogger implements SessionLogger {
         status,
         autoMode: state.autoMode,
         phases,
-        totals: { gateTokens, gateRejects, gateErrors, escalations, verifyFailures, forcePasses },
+        totals: { gateTokens, gateRejects, gateErrors, escalations, verifyFailures, forcePasses, stagnationEscalations },
       };
 
       const tmpPath = this.summaryPath + '.tmp';

--- a/src/phases/runner.ts
+++ b/src/phases/runner.ts
@@ -18,6 +18,7 @@ import { commitEvalReport, normalizeArtifactCommit, resolveArtifact } from '../a
 import { runInteractivePhase } from './interactive.js';
 import { runGatePhase } from './gate.js';
 import { runVerifyPhase } from './verify.js';
+import { StagnationDetector, loadStagnationConfig } from './stagnation.js';
 import { readClaudeSessionUsage, claudeSessionJsonlExists } from '../runners/claude-usage.js';
 import {
   promptChoice,
@@ -28,6 +29,25 @@ import {
   printSuccess,
   printInfo,
 } from '../ui.js';
+
+// ─── Stagnation detector map ──────────────────────────────────────────────────
+// In-memory only; never serialised. Keyed by gate phase number.
+const detectorMap = new Map<string, StagnationDetector>();
+
+function getOrCreateDetector(phase: number, cfg: { threshold: number; run: number; window: number }): StagnationDetector {
+  const key = String(phase);
+  if (!detectorMap.has(key)) detectorMap.set(key, new StagnationDetector(cfg));
+  return detectorMap.get(key)!;
+}
+
+function dropDetector(phase: number): void {
+  detectorMap.delete(String(phase));
+}
+
+// Test hook — reset all detector state between test cases.
+export function __resetDetectors(): void {
+  detectorMap.clear();
+}
 
 // ─── Phase type dispatch helpers ──────────────────────────────────────────────
 
@@ -612,6 +632,7 @@ export async function handleGatePhase(
       });
 
       state.phases[String(phase)] = 'completed';
+      dropDetector(phase);
 
       // Post-success sidecar cleanup
       deleteGateSidecars(runDir, phase);
@@ -706,6 +727,20 @@ export async function handleGateReject(
 ): Promise<void> {
   state.phases[String(phase)] = 'pending';
 
+  // Stagnation setup — fail-open: any exception skips detection for this call.
+  let cfg: { enabled: boolean; threshold: number; run: number; window: number } | undefined;
+  let detector: StagnationDetector | undefined;
+  try {
+    cfg = loadStagnationConfig(state.autoMode);
+    if (cfg.enabled) {
+      const det = getOrCreateDetector(phase, cfg);
+      det.record(comments);
+      detector = det;
+    }
+  } catch (err) {
+    console.warn(`[stagnation] setup error: ${(err as Error).message} — detection skipped`);
+  }
+
   // Increment retry counter AFTER capturing retryIndex (pre-mutation)
   state.gateRetries[String(phase)] = retryIndex + 1;
 
@@ -725,6 +760,33 @@ export async function handleGateReject(
 
   if (retryCount < retryLimit || state.autoMode) {
     if (retryCount >= retryLimit && state.autoMode) {
+      if (cfg?.enabled && detector !== undefined) {
+        let triggered = false;
+        let similarities: number[] = [];
+        try {
+          const r = detector.shouldEscalate();
+          triggered = r.triggered;
+          similarities = r.similarities;
+        } catch (err) {
+          console.warn(`[stagnation] detector error: ${(err as Error).message} — falling back to force-pass`);
+        }
+        if (triggered) {
+          logger.logEvent({
+            event: 'gate_stagnation',
+            phase, retryIndex,
+            similarities,
+            threshold: cfg.threshold,
+            run: cfg.run,
+            action: 'escalate',
+          });
+          await handleGateEscalation(
+            phase, comments, scope, retryIndex,
+            state, runDir, cwd, inputManager, logger,
+            { reason: 'gate-stagnation' },
+          );
+          return;
+        }
+      }
       // Auto-mode force pass (no gate_retry event — force_pass covers this path)
       await forcePassGate(phase, state, runDir, cwd, 'auto', logger);
       return;
@@ -805,6 +867,7 @@ export async function handleGateEscalation(
   cwd: string,
   inputManager: InputManager,
   logger: SessionLogger,
+  opts?: { reason?: 'gate-retry-limit' | 'gate-stagnation' },
 ): Promise<void> {
   const retryLimit = getGateRetryLimit(state.flow, phase);
   printWarning(`Gate ${phase} retry limit reached (${retryLimit})`);
@@ -823,7 +886,7 @@ export async function handleGateEscalation(
   logger.logEvent({
     event: 'escalation',
     phase,
-    reason: 'gate-retry-limit',
+    reason: opts?.reason ?? 'gate-retry-limit',
     userChoice: choice as 'C' | 'S' | 'Q',
   });
 
@@ -847,6 +910,7 @@ export async function handleGateEscalation(
 
     state.gateEscalationCycles = state.gateEscalationCycles ?? {};
     state.gateEscalationCycles[key] = (state.gateEscalationCycles[key] ?? 0) + 1;
+    dropDetector(phase);
 
     if (state.flow === 'light' && phase === 7) {
       state.carryoverFeedback = {
@@ -909,6 +973,7 @@ export async function forcePassGate(
 
   // Emit force_pass as the sole terminal event for this path
   logger.logEvent({ event: 'force_pass', phase, by });
+  dropDetector(phase);
 
   // Side effects: cleanup, advance
   deleteGateSidecars(runDir, phase);

--- a/src/phases/stagnation.ts
+++ b/src/phases/stagnation.ts
@@ -1,0 +1,118 @@
+function tokenize(text: string): string[] {
+  return Array.from(
+    text.normalize('NFKC').toLowerCase().matchAll(/[\p{L}\p{N}_]+/gu),
+    m => m[0],
+  );
+}
+
+export function tokenJaccard(a: string, b: string): number | null {
+  const A = new Set(tokenize(a));
+  const B = new Set(tokenize(b));
+  if (A.size === 0 || B.size === 0) return null;
+  let inter = 0;
+  for (const x of A) { if (B.has(x)) inter++; }
+  const union = A.size + B.size - inter;
+  if (union === 0) return null;
+  return inter / union;
+}
+
+export class StagnationDetector {
+  private buf: string[] = [];
+  private readonly capacity: number;
+
+  constructor(private readonly cfg: { threshold: number; run: number; window: number }) {
+    this.capacity = cfg.run + (cfg.window - 1);
+  }
+
+  record(comments: string): void {
+    this.buf.push(comments);
+    if (this.buf.length > this.capacity) this.buf.shift();
+  }
+
+  shouldEscalate(): { triggered: boolean; similarities: number[] } {
+    const { run, threshold } = this.cfg;
+    if (this.buf.length < run + 1) return { triggered: false, similarities: [] };
+    const similarities: number[] = [];
+    for (let i = this.buf.length - run - 1; i < this.buf.length - 1; i++) {
+      const sim = tokenJaccard(this.buf[i], this.buf[i + 1]);
+      if (sim === null || sim < threshold) return { triggered: false, similarities: [] };
+      similarities.push(sim);
+    }
+    return { triggered: true, similarities };
+  }
+}
+
+const warnedKeys = new Set<string>();
+let featureDisabledForProcess = false;
+
+export function loadStagnationConfig(autoMode: boolean): {
+  enabled: boolean; threshold: number; run: number; window: number;
+} {
+  const base = { threshold: 0.70, run: 2, window: 2 };
+
+  if (featureDisabledForProcess) return { enabled: false, ...base };
+
+  const envMain      = process.env['HARNESS_GATE_STAGNATION'];
+  const envThreshold = process.env['HARNESS_GATE_STAGNATION_THRESHOLD'];
+  const envRun       = process.env['HARNESS_GATE_STAGNATION_RUN'];
+  // HARNESS_GATE_STAGNATION_WINDOW is reserved/no-op in v1 — intentionally not read
+
+  let anyInvalid = false;
+  let enabled   = autoMode;
+  let threshold = base.threshold;
+  let run       = base.run;
+
+  if (envMain !== undefined) {
+    const lower = envMain.toLowerCase();
+    if (lower === 'on') {
+      enabled = true;
+    } else if (lower === 'off') {
+      enabled = false;
+    } else {
+      if (!warnedKeys.has('HARNESS_GATE_STAGNATION')) {
+        console.warn(`[stagnation] invalid HARNESS_GATE_STAGNATION="${envMain}" — feature disabled`);
+        warnedKeys.add('HARNESS_GATE_STAGNATION');
+      }
+      anyInvalid = true;
+    }
+  }
+
+  if (envThreshold !== undefined) {
+    const parsed = parseFloat(envThreshold);
+    if (Number.isNaN(parsed) || parsed < 0 || parsed > 1) {
+      if (!warnedKeys.has('HARNESS_GATE_STAGNATION_THRESHOLD')) {
+        console.warn(`[stagnation] invalid HARNESS_GATE_STAGNATION_THRESHOLD="${envThreshold}" — feature disabled`);
+        warnedKeys.add('HARNESS_GATE_STAGNATION_THRESHOLD');
+      }
+      anyInvalid = true;
+    } else {
+      threshold = parsed;
+    }
+  }
+
+  if (envRun !== undefined) {
+    const parsed = parseInt(envRun, 10);
+    if (Number.isNaN(parsed) || parsed < 2) {
+      if (!warnedKeys.has('HARNESS_GATE_STAGNATION_RUN')) {
+        console.warn(`[stagnation] invalid HARNESS_GATE_STAGNATION_RUN="${envRun}" — feature disabled`);
+        warnedKeys.add('HARNESS_GATE_STAGNATION_RUN');
+      }
+      anyInvalid = true;
+    } else {
+      run = parsed;
+    }
+  }
+
+  if (anyInvalid) {
+    featureDisabledForProcess = true;
+    return { enabled: false, ...base };
+  }
+
+  return { enabled, threshold, run, window: 2 };
+}
+
+// Test hook — resets warn dedup set and process-level disabled latch.
+export function __resetWarnCache(): void {
+  warnedKeys.clear();
+  featureDisabledForProcess = false;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -273,7 +273,16 @@ export type LogEvent =
       preset?: { id: string; runner: 'claude' | 'codex'; model: string; effort: string };
     })
   | (LogEventBase & { event: 'gate_retry'; phase: number; retryIndex: number; retryCount: number; retryLimit: number; feedbackPath: string; feedbackBytes: number; feedbackPreview: string })
-  | (LogEventBase & { event: 'escalation'; phase: number; reason: 'gate-retry-limit' | 'gate-error' | 'verify-limit' | 'verify-error'; userChoice?: 'C' | 'S' | 'Q' | 'R' })
+  | (LogEventBase & {
+      event: 'gate_stagnation';
+      phase: number;
+      retryIndex: number;
+      similarities: number[];
+      threshold: number;
+      run: number;
+      action: 'escalate';
+    })
+  | (LogEventBase & { event: 'escalation'; phase: number; reason: 'gate-retry-limit' | 'gate-error' | 'verify-limit' | 'verify-error' | 'gate-stagnation'; userChoice?: 'C' | 'S' | 'Q' | 'R' })
   | (LogEventBase & { event: 'force_pass'; phase: number; by: 'auto' | 'user' })
   | (LogEventBase & { event: 'verify_result'; passed: boolean; retryIndex: number; durationMs: number; failedChecks?: string[] })
   | (LogEventBase & { event: 'phase_end'; phase: number; attemptId?: string | null; status: 'completed' | 'failed'; durationMs: number; details?: { reason: string; error?: string }; claudeTokens?: ClaudeTokens | null; codexTokens?: ClaudeTokens | null; uncommittedRepos?: Array<{ path: string; count: number }> })

--- a/tests/integration/gate-stagnation.test.ts
+++ b/tests/integration/gate-stagnation.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { HarnessState } from '../../src/types.js';
+import { createInitialState } from '../../src/state.js';
+import { getGateRetryLimit } from '../../src/config.js';
+import { FileSessionLogger, computeRepoKey } from '../../src/logger.js';
+import { __resetWarnCache } from '../../src/phases/stagnation.js';
+
+vi.mock('../../src/phases/interactive.js', () => ({
+  runInteractivePhase: vi.fn(),
+  preparePhase: vi.fn(),
+  checkSentinelFreshness: vi.fn(),
+  validatePhaseArtifacts: vi.fn(),
+}));
+
+vi.mock('../../src/phases/gate.js', () => ({
+  runGatePhase: vi.fn(),
+  checkGateSidecars: vi.fn(),
+  buildGateResult: vi.fn(),
+  parseVerdict: vi.fn(),
+}));
+
+vi.mock('../../src/phases/verify.js', () => ({
+  runVerifyPhase: vi.fn(),
+  readVerifyResult: vi.fn(),
+  isEvalReportValid: vi.fn(),
+}));
+
+vi.mock('../../src/ui.js', () => ({
+  promptChoice: vi.fn(),
+  printPhaseTransition: vi.fn(),
+  renderControlPanel: vi.fn(),
+  printWarning: vi.fn(),
+  printError: vi.fn(),
+  printSuccess: vi.fn(),
+  printInfo: vi.fn(),
+}));
+
+vi.mock('../../src/artifact.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/artifact.js')>();
+  return { ...actual, commitEvalReport: vi.fn().mockReturnValue('committed'), normalizeArtifactCommit: vi.fn().mockReturnValue(true), runPhase6Preconditions: vi.fn() };
+});
+
+vi.mock('../../src/git.js', () => ({
+  getHead: vi.fn().mockReturnValue('mock-sha'),
+  getGitRoot: vi.fn(),
+  isAncestor: vi.fn(),
+  isWorkingTreeClean: vi.fn(),
+  hasStagedChanges: vi.fn(),
+  getStagedFiles: vi.fn(),
+  getFileStatus: vi.fn(),
+  generateRunId: vi.fn(),
+  detectExternalCommits: vi.fn(),
+  isPathGitignored: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../../src/state.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/state.js')>();
+  return { ...actual, writeState: vi.fn() };
+});
+
+import { handleGateReject, __resetDetectors } from '../../src/phases/runner.js';
+import { promptChoice } from '../../src/ui.js';
+import { InputManager } from '../../src/input.js';
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+  __resetDetectors();
+  __resetWarnCache();
+  for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true });
+  tmpDirs.length = 0;
+});
+
+function makeTmpDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'stagnation-int-'));
+  tmpDirs.push(d);
+  return d;
+}
+
+function makeTestLogger(runId: string): { logger: FileSessionLogger; eventsPath: string; cleanup: () => void } {
+  const harnessDir = makeTmpDir();
+  const sessionsRoot = path.join(harnessDir, 'sessions');
+  const logger = new FileSessionLogger(runId, harnessDir, { sessionsRoot });
+  logger.writeMeta({ task: 't' });
+  const eventsPath = path.join(sessionsRoot, computeRepoKey(harnessDir), runId, 'events.jsonl');
+  return { logger, eventsPath, cleanup: () => {} };
+}
+
+function readEvents(eventsPath: string): any[] {
+  if (!fs.existsSync(eventsPath)) return [];
+  return fs.readFileSync(eventsPath, 'utf-8').trim().split('\n').filter(Boolean).map(l => JSON.parse(l));
+}
+
+function makeState(overrides: Partial<HarnessState> = {}): HarnessState {
+  return { ...createInitialState('int-run', '/task.md', 'sha', false), ...overrides };
+}
+
+const HDIR = '/tmp/harness-dir';
+const CWD = '/tmp/cwd';
+const FULL_LIMIT = getGateRetryLimit('full');
+const STAGNANT = 'plan does not cover spec requirements; tests are missing; edge cases unhandled';
+
+// ─── Test 10: Integration — 3 stagnant rejects → event ordering ──────────────
+
+describe('Integration Test 10: 3 stagnant auto-mode rejects → gate_retry×2, gate_stagnation, escalation(gate-stagnation), no force_pass', () => {
+  it('events appear in correct order with no force_pass', async () => {
+    const runDir = makeTmpDir();
+    const state = makeState({ autoMode: true, currentPhase: 2 });
+    const { logger, eventsPath } = makeTestLogger(state.runId);
+
+    vi.mocked(promptChoice).mockResolvedValueOnce('Q');
+
+    // 3 rejects with identical feedback
+    await handleGateReject(2, STAGNANT, undefined, 0, state, HDIR, runDir, CWD, new InputManager(), logger);
+    await handleGateReject(2, STAGNANT, undefined, 1, state, HDIR, runDir, CWD, new InputManager(), logger);
+    await handleGateReject(2, STAGNANT, undefined, 2, state, HDIR, runDir, CWD, new InputManager(), logger);
+
+    const events = readEvents(eventsPath);
+
+    // gate_retry × 2 (retryIndex 0 and 1 only; retryIndex 2 goes to stagnation)
+    const gateRetries = events.filter((e: any) => e.event === 'gate_retry');
+    expect(gateRetries).toHaveLength(2);
+    expect(gateRetries[0].retryIndex).toBe(0);
+    expect(gateRetries[1].retryIndex).toBe(1);
+
+    // gate_stagnation × 1
+    const stagnations = events.filter((e: any) => e.event === 'gate_stagnation');
+    expect(stagnations).toHaveLength(1);
+    expect(stagnations[0].phase).toBe(2);
+    expect(stagnations[0].action).toBe('escalate');
+    expect(stagnations[0].threshold).toBe(0.70);
+
+    // escalation × 1 with reason gate-stagnation
+    const escalations = events.filter((e: any) => e.event === 'escalation');
+    expect(escalations).toHaveLength(1);
+    expect(escalations[0].reason).toBe('gate-stagnation');
+    expect(escalations[0].phase).toBe(2);
+
+    // NO force_pass
+    expect(events.filter((e: any) => e.event === 'force_pass')).toHaveLength(0);
+
+    // Order: last gate_retry < gate_stagnation < escalation
+    const lastRetryIdx  = events.map((e: any, i: number) => e.event === 'gate_retry'      ? i : -1).filter(i => i >= 0).pop()!;
+    const stagnationIdx = events.findIndex((e: any) => e.event === 'gate_stagnation');
+    const escalationIdx = events.findIndex((e: any) => e.event === 'escalation');
+    expect(lastRetryIdx).toBeLessThan(stagnationIdx);
+    expect(stagnationIdx).toBeLessThan(escalationIdx);
+  });
+});
+
+// ─── Test 11: Regression — pre-existing event shapes are unchanged ─────────────
+
+describe('Integration Test 11: regression — force_pass and escalation event shapes unchanged for non-stagnant runs', () => {
+  it('non-stagnant auto-mode run produces force_pass with by=auto, no gate_stagnation', async () => {
+    const runDir = makeTmpDir();
+    const state = makeState({ autoMode: true, currentPhase: 2 });
+    const { logger, eventsPath } = makeTestLogger(state.runId);
+
+    const feedback = ['the type signatures are wrong', 'missing null check in handler', 'lint errors in new file'];
+    for (let i = 0; i < FULL_LIMIT; i++) {
+      await handleGateReject(2, feedback[i] ?? `distinct feedback ${i}`, undefined, i, state, HDIR, runDir, CWD, new InputManager(), logger);
+    }
+
+    const events = readEvents(eventsPath);
+    const forcePass = events.find((e: any) => e.event === 'force_pass');
+    expect(forcePass).toBeDefined();
+    expect(forcePass.by).toBe('auto');
+    expect(forcePass.phase).toBe(2);
+    expect(events.find((e: any) => e.event === 'gate_stagnation')).toBeUndefined();
+  });
+});

--- a/tests/phases/runner.test.ts
+++ b/tests/phases/runner.test.ts
@@ -86,7 +86,9 @@ import {
   handleVerifyFail,
   handleVerifyEscalation,
   handleVerifyError,
+  __resetDetectors,
 } from '../../src/phases/runner.js';
+import { __resetWarnCache } from '../../src/phases/stagnation.js';
 import { runInteractivePhase } from '../../src/phases/interactive.js';
 import { runGatePhase } from '../../src/phases/gate.js';
 import { runVerifyPhase } from '../../src/phases/verify.js';
@@ -103,6 +105,9 @@ const tmpDirs: string[] = [];
 
 afterEach(() => {
   vi.clearAllMocks();
+  vi.unstubAllEnvs();
+  __resetDetectors();
+  __resetWarnCache();
   for (const dir of tmpDirs) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -2004,5 +2009,225 @@ describe('light flow — runPhaseLoop (spec §4 + ADR-1/ADR-4/ADR-14)', () => {
     expect(state.phaseCodexSessions['7']).toBeNull();
     expect(fs.existsSync(path.join(runDir, 'gate-7-raw.txt'))).toBe(false);
     expect(fs.existsSync(path.join(runDir, 'gate-7-result.json'))).toBe(false);
+  });
+});
+
+// ─── Stagnation detection in handleGateReject ─────────────────────────────────
+
+const STAGNANT = 'plan does not cover spec requirements; tests are missing; docs incomplete';
+const DIVERSE_A = 'the implementation is mostly correct but tests need edge case coverage';
+const DIVERSE_B = 'formatting issues found; please fix indentation and remove dead code';
+const DIVERSE_C = 'critical bug in error handler path; stack overflow under high load';
+
+describe('Stagnation — Test 5: auto-mode + 3 stagnant rejects → gate_stagnation + handleGateEscalation', () => {
+  it('emits gate_stagnation and calls handleGateEscalation with reason gate-stagnation', async () => {
+    __resetDetectors();
+    const runDir = makeTmpDir();
+    const state = makeState({ autoMode: true, currentPhase: 2 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    vi.mocked(promptChoice).mockResolvedValueOnce('Q');
+
+    try {
+      // 3 rejects, same text — buffer fills with 3 identical entries
+      await handleGateReject(2, STAGNANT, undefined, 0, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+      await handleGateReject(2, STAGNANT, undefined, 1, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+      // 3rd reject: retryCount = 3 = retryLimit → stagnation fires
+      await handleGateReject(2, STAGNANT, undefined, 2, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+
+      const events = readEvents(eventsPath);
+      const stagnation = events.find((e: any) => e.event === 'gate_stagnation');
+      expect(stagnation).toBeDefined();
+      expect(stagnation.phase).toBe(2);
+      expect(stagnation.action).toBe('escalate');
+      expect(Array.isArray(stagnation.similarities)).toBe(true);
+      expect(stagnation.similarities.length).toBeGreaterThanOrEqual(1);
+
+      const escalation = events.find((e: any) => e.event === 'escalation');
+      expect(escalation).toBeDefined();
+      expect(escalation.reason).toBe('gate-stagnation');
+
+      const forcePassEvents = events.filter((e: any) => e.event === 'force_pass');
+      expect(forcePassEvents).toHaveLength(0);
+
+      // forcePassGate must NOT have been called
+      expect(vi.mocked(promptChoice)).toHaveBeenCalledTimes(1);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('Stagnation — Test 6: auto-mode + 3 diverse rejects → forcePassGate, no gate_stagnation', () => {
+  it('calls forcePassGate and does NOT emit gate_stagnation', async () => {
+    __resetDetectors();
+    const runDir = makeTmpDir();
+    const state = makeState({ autoMode: true, currentPhase: 2 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    try {
+      await handleGateReject(2, DIVERSE_A, undefined, 0, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+      await handleGateReject(2, DIVERSE_B, undefined, 1, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+      await handleGateReject(2, DIVERSE_C, undefined, 2, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+
+      const events = readEvents(eventsPath);
+      expect(events.find((e: any) => e.event === 'gate_stagnation')).toBeUndefined();
+      expect(events.find((e: any) => e.event === 'force_pass')).toBeDefined();
+
+      const writes = vi.mocked(writeState).mock.calls.map(([, s]) => s);
+      const forcePassState = writes.find(s => s.phases['2'] === 'completed');
+      expect(forcePassState).toBeDefined();
+
+      expect(vi.mocked(promptChoice)).not.toHaveBeenCalled();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('Stagnation — Test 7: manual mode + 3 stagnant rejects → escalation reason=gate-retry-limit (no change)', () => {
+  it('preserves existing manual-mode escalation path', async () => {
+    __resetDetectors();
+    const runDir = makeTmpDir();
+    const state = makeState({ autoMode: false, currentPhase: 2,
+      gateRetries: { '2': FULL_GATE_RETRY_LIMIT, '4': 0, '7': 0 } });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    vi.mocked(promptChoice).mockResolvedValueOnce('Q');
+
+    try {
+      await handleGateReject(2, STAGNANT, undefined, FULL_GATE_RETRY_LIMIT, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+
+      const events = readEvents(eventsPath);
+      const escalation = events.find((e: any) => e.event === 'escalation');
+      expect(escalation).toBeDefined();
+      expect(escalation.reason).toBe('gate-retry-limit');
+      expect(events.find((e: any) => e.event === 'gate_stagnation')).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('Stagnation — Test 8: HARNESS_GATE_STAGNATION=off in auto-mode → forcePassGate', () => {
+  it('disables stagnation via env; falls back to force-pass', async () => {
+    __resetDetectors();
+    __resetWarnCache();
+    vi.stubEnv('HARNESS_GATE_STAGNATION', 'off');
+
+    const runDir = makeTmpDir();
+    const state = makeState({ autoMode: true, currentPhase: 2 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    try {
+      await handleGateReject(2, STAGNANT, undefined, 0, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+      await handleGateReject(2, STAGNANT, undefined, 1, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+      await handleGateReject(2, STAGNANT, undefined, 2, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+
+      const events = readEvents(eventsPath);
+      expect(events.find((e: any) => e.event === 'gate_stagnation')).toBeUndefined();
+      expect(events.find((e: any) => e.event === 'force_pass')).toBeDefined();
+      expect(vi.mocked(promptChoice)).not.toHaveBeenCalled();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('Stagnation — Test 9: detector throws → forcePassGate, single warn, no gate_stagnation', () => {
+  it('catches detector exception and falls back to force-pass', async () => {
+    __resetDetectors();
+    const runDir = makeTmpDir();
+    const state = makeState({ autoMode: true, currentPhase: 2 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    // Populate buffer so stagnation would normally trigger
+    await handleGateReject(2, STAGNANT, undefined, 0, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+    await handleGateReject(2, STAGNANT, undefined, 1, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+
+    // Make shouldEscalate throw on the 3rd call
+    const { StagnationDetector: SD } = await import('../../src/phases/stagnation.js');
+    const origShouldEscalate = SD.prototype.shouldEscalate;
+    SD.prototype.shouldEscalate = function() { throw new Error('detector exploded'); };
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await handleGateReject(2, STAGNANT, undefined, 2, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+
+      const events = readEvents(eventsPath);
+      expect(events.find((e: any) => e.event === 'gate_stagnation')).toBeUndefined();
+      expect(events.find((e: any) => e.event === 'force_pass')).toBeDefined();
+
+      const stagnationWarns = warnSpy.mock.calls.filter(args => String(args[0]).includes('detector error'));
+      expect(stagnationWarns).toHaveLength(1);
+
+      expect(vi.mocked(promptChoice)).not.toHaveBeenCalled();
+    } finally {
+      SD.prototype.shouldEscalate = origShouldEscalate;
+      cleanup();
+    }
+  });
+});
+
+describe('Stagnation — Test 9a: invalid THRESHOLD env in auto-mode → forcePassGate, one warn', () => {
+  it('unified fail-open: invalid validated env disables feature', async () => {
+    __resetDetectors();
+    __resetWarnCache();
+    vi.stubEnv('HARNESS_GATE_STAGNATION_THRESHOLD', 'not-a-number');
+
+    const runDir = makeTmpDir();
+    const state = makeState({ autoMode: true, currentPhase: 2 });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await handleGateReject(2, STAGNANT, undefined, 0, state, HDIR, runDir, CWD, createNoOpInputManager(), new NoopLogger());
+      await handleGateReject(2, STAGNANT, undefined, 1, state, HDIR, runDir, CWD, createNoOpInputManager(), new NoopLogger());
+      await handleGateReject(2, STAGNANT, undefined, 2, state, HDIR, runDir, CWD, createNoOpInputManager(), new NoopLogger());
+
+      expect(vi.mocked(promptChoice)).not.toHaveBeenCalled();
+
+      const writes = vi.mocked(writeState).mock.calls.map(([, s]) => s);
+      const forcePassState = writes.find(s => s.phases['2'] === 'completed');
+      expect(forcePassState).toBeDefined();
+
+      const warns = warnSpy.mock.calls.filter(args => String(args[0]).includes('HARNESS_GATE_STAGNATION_THRESHOLD'));
+      expect(warns).toHaveLength(1);
+    } finally {
+      // no cleanup needed (NoopLogger)
+    }
+  });
+});
+
+describe('Stagnation — Test 9b: WINDOW env set to non-2 value → stagnation still fires, no warn', () => {
+  it('WINDOW is a no-op; feature remains enabled when only WINDOW is set', async () => {
+    __resetDetectors();
+    __resetWarnCache();
+    vi.stubEnv('HARNESS_GATE_STAGNATION_WINDOW', '5');
+
+    const runDir = makeTmpDir();
+    const state = makeState({ autoMode: true, currentPhase: 2 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    vi.mocked(promptChoice).mockResolvedValueOnce('Q');
+
+    try {
+      await handleGateReject(2, STAGNANT, undefined, 0, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+      await handleGateReject(2, STAGNANT, undefined, 1, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+      await handleGateReject(2, STAGNANT, undefined, 2, state, HDIR, runDir, CWD, createNoOpInputManager(), logger);
+
+      const events = readEvents(eventsPath);
+      const stagnation = events.find((e: any) => e.event === 'gate_stagnation');
+      expect(stagnation).toBeDefined();
+
+      const escalation = events.find((e: any) => e.event === 'escalation');
+      expect(escalation?.reason).toBe('gate-stagnation');
+
+      const windowWarns = warnSpy.mock.calls.filter(args => String(args[0]).includes('HARNESS_GATE_STAGNATION_WINDOW'));
+      expect(windowWarns).toHaveLength(0);
+    } finally {
+      cleanup();
+    }
   });
 });

--- a/tests/phases/stagnation.test.ts
+++ b/tests/phases/stagnation.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { tokenJaccard, StagnationDetector, loadStagnationConfig, __resetWarnCache } from '../../src/phases/stagnation.js';
+
+beforeEach(() => {
+  __resetWarnCache();
+  vi.unstubAllEnvs();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  __resetWarnCache();
+});
+
+// ─── tokenJaccard ────────────────────────────────────────────────────────────
+
+describe('tokenJaccard', () => {
+  it('identical strings return 1', () => {
+    expect(tokenJaccard('the quick brown fox', 'the quick brown fox')).toBe(1);
+  });
+
+  it('disjoint strings return 0', () => {
+    expect(tokenJaccard('alpha beta', 'gamma delta')).toBe(0);
+  });
+
+  it('one-side empty returns null', () => {
+    expect(tokenJaccard('', 'hello world')).toBeNull();
+    expect(tokenJaccard('hello world', '')).toBeNull();
+  });
+
+  it('both empty returns null', () => {
+    expect(tokenJaccard('', '')).toBeNull();
+  });
+
+  it('NFKC normalisation: ½ tokenises the same as 1 2', () => {
+    // '½' normalises to '1/2' under NFKC → tokens ['1', '2']
+    const sim = tokenJaccard('½ cup', '1 2 cup');
+    expect(sim).not.toBeNull();
+    expect(sim!).toBeGreaterThan(0.5);
+  });
+
+  it('case insensitive', () => {
+    expect(tokenJaccard('Hello World', 'hello world')).toBe(1);
+  });
+
+  it('mixed Korean and English', () => {
+    const sim = tokenJaccard('플랜이 누락됨 plan missing', '플랜이 누락됨 plan missing');
+    expect(sim).toBe(1);
+  });
+
+  it('partial overlap returns value in (0, 1)', () => {
+    const sim = tokenJaccard('plan is missing tests', 'plan needs tests and docs');
+    expect(sim).not.toBeNull();
+    expect(sim!).toBeGreaterThan(0);
+    expect(sim!).toBeLessThan(1);
+  });
+
+  it('very long strings produce a finite result (length-stable)', () => {
+    const long = 'word '.repeat(10_000).trim();
+    const sim = tokenJaccard(long, long);
+    expect(sim).toBe(1);
+  });
+});
+
+// ─── StagnationDetector.record ────────────────────────────────────────────────
+
+describe('StagnationDetector.record — FIFO buffer', () => {
+  it('drops oldest entry when buffer exceeds RUN + WINDOW - 1 = 3', () => {
+    const d = new StagnationDetector({ threshold: 0.70, run: 2, window: 2 });
+    // push 4 items — capacity is 3
+    d.record('a');
+    d.record('b');
+    d.record('c');
+    d.record('d'); // 'a' should be evicted
+
+    // Only last 3 entries matter; verify by checking shouldEscalate doesn't see 'a'
+    // (if 'a' were still in buffer, we'd have 4 entries, but capacity is 3)
+    // We check indirectly: 'a','b','c' → diverse; 'b','c','d' → b/c differ from d
+    const { triggered } = d.shouldEscalate();
+    // 'b' vs 'c' and 'c' vs 'd' — all distinct — should not trigger
+    expect(triggered).toBe(false);
+  });
+
+  it('accepts RUN=3 and capacity is RUN + WINDOW - 1 = 4', () => {
+    const d = new StagnationDetector({ threshold: 0.70, run: 3, window: 2 });
+    const same = 'plan is missing tests and docs and coverage';
+    d.record(same);
+    d.record(same);
+    d.record(same);
+    d.record(same); // 4 entries, 3 adjacent pairs all sim=1.0
+    const { triggered, similarities } = d.shouldEscalate();
+    expect(triggered).toBe(true);
+    expect(similarities).toHaveLength(3);
+  });
+});
+
+// ─── StagnationDetector.shouldEscalate ────────────────────────────────────────
+
+describe('StagnationDetector.shouldEscalate', () => {
+  const SAME = 'plan does not cover spec requirements; tests are missing; docs incomplete';
+  const DIFF = 'implementation looks correct but formatting needs work';
+
+  it('buffer < RUN+1 entries → triggered false', () => {
+    const d = new StagnationDetector({ threshold: 0.70, run: 2, window: 2 });
+    d.record(SAME); // 1 entry, need ≥3
+    d.record(SAME); // 2 entries, need ≥3
+    expect(d.shouldEscalate().triggered).toBe(false);
+  });
+
+  it('last RUN pairs all ≥ threshold → triggered true', () => {
+    const d = new StagnationDetector({ threshold: 0.70, run: 2, window: 2 });
+    d.record(SAME);
+    d.record(SAME);
+    d.record(SAME);
+    const { triggered, similarities } = d.shouldEscalate();
+    expect(triggered).toBe(true);
+    expect(similarities).toHaveLength(2);
+    similarities.forEach(s => expect(s).toBeGreaterThanOrEqual(0.70));
+  });
+
+  it('one pair below threshold → triggered false', () => {
+    const d = new StagnationDetector({ threshold: 0.70, run: 2, window: 2 });
+    d.record(SAME);
+    d.record(DIFF); // this pair will be < threshold
+    d.record(SAME);
+    expect(d.shouldEscalate().triggered).toBe(false);
+  });
+
+  it('pair where one side tokenizes to empty → triggered false (null similarity)', () => {
+    const d = new StagnationDetector({ threshold: 0.70, run: 2, window: 2 });
+    d.record(SAME);
+    d.record(''); // empty → null similarity
+    d.record(SAME);
+    expect(d.shouldEscalate().triggered).toBe(false);
+  });
+
+  it('threshold 0 → always triggers when buffer is full', () => {
+    const d = new StagnationDetector({ threshold: 0, run: 2, window: 2 });
+    d.record('alpha');
+    d.record('beta');
+    d.record('gamma'); // all disjoint but sim ≥ 0
+    const { triggered } = d.shouldEscalate();
+    expect(triggered).toBe(true);
+  });
+});
+
+// ─── loadStagnationConfig ─────────────────────────────────────────────────────
+
+describe('loadStagnationConfig', () => {
+  it('manual mode default: enabled=false', () => {
+    const cfg = loadStagnationConfig(false);
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.threshold).toBe(0.70);
+    expect(cfg.run).toBe(2);
+    expect(cfg.window).toBe(2);
+  });
+
+  it('auto mode default: enabled=true', () => {
+    const cfg = loadStagnationConfig(true);
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.threshold).toBe(0.70);
+    expect(cfg.run).toBe(2);
+    expect(cfg.window).toBe(2);
+  });
+
+  it('HARNESS_GATE_STAGNATION=off overrides auto-mode default', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION', 'off');
+    expect(loadStagnationConfig(true).enabled).toBe(false);
+  });
+
+  it('HARNESS_GATE_STAGNATION=on overrides manual-mode default', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION', 'on');
+    expect(loadStagnationConfig(false).enabled).toBe(true);
+  });
+
+  it('HARNESS_GATE_STAGNATION=ON (uppercase) is accepted', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION', 'ON');
+    expect(loadStagnationConfig(true).enabled).toBe(true);
+  });
+
+  it('invalid HARNESS_GATE_STAGNATION → enabled=false + exactly one warn', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION', 'maybe');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    loadStagnationConfig(true);
+    loadStagnationConfig(true); // second call — warn must NOT fire again
+    const stagnationWarns = warnSpy.mock.calls.filter(args => String(args[0]).includes('HARNESS_GATE_STAGNATION'));
+    expect(stagnationWarns).toHaveLength(1);
+    expect(loadStagnationConfig(true).enabled).toBe(false);
+  });
+
+  it('valid HARNESS_GATE_STAGNATION_THRESHOLD is parsed', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION_THRESHOLD', '0.85');
+    const cfg = loadStagnationConfig(true);
+    expect(cfg.threshold).toBe(0.85);
+    expect(cfg.enabled).toBe(true);
+  });
+
+  it('invalid HARNESS_GATE_STAGNATION_THRESHOLD → enabled=false + one warn for that key', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION_THRESHOLD', 'not-a-number');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    loadStagnationConfig(true);
+    loadStagnationConfig(true);
+    const warns = warnSpy.mock.calls.filter(args => String(args[0]).includes('HARNESS_GATE_STAGNATION_THRESHOLD'));
+    expect(warns).toHaveLength(1);
+  });
+
+  it('HARNESS_GATE_STAGNATION_THRESHOLD out of [0,1] range → enabled=false', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION_THRESHOLD', '1.5');
+    expect(loadStagnationConfig(true).enabled).toBe(false);
+    __resetWarnCache();
+    vi.stubEnv('HARNESS_GATE_STAGNATION_THRESHOLD', '-0.1');
+    expect(loadStagnationConfig(true).enabled).toBe(false);
+  });
+
+  it('valid HARNESS_GATE_STAGNATION_RUN is parsed', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION_RUN', '3');
+    const cfg = loadStagnationConfig(true);
+    expect(cfg.run).toBe(3);
+    expect(cfg.enabled).toBe(true);
+  });
+
+  it('invalid HARNESS_GATE_STAGNATION_RUN → enabled=false + one warn', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION_RUN', 'bad');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    loadStagnationConfig(true);
+    loadStagnationConfig(true);
+    const warns = warnSpy.mock.calls.filter(args => String(args[0]).includes('HARNESS_GATE_STAGNATION_RUN'));
+    expect(warns).toHaveLength(1);
+  });
+
+  it('HARNESS_GATE_STAGNATION_RUN < 2 → enabled=false', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION_RUN', '1');
+    expect(loadStagnationConfig(true).enabled).toBe(false);
+  });
+
+  it('HARNESS_GATE_STAGNATION_WINDOW set to any value → window=2, no warn, enabled unaffected', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    for (const val of ['5', '-1', 'not-a-number', '']) {
+      __resetWarnCache();
+      vi.stubEnv('HARNESS_GATE_STAGNATION_WINDOW', val);
+      const cfg = loadStagnationConfig(true);
+      expect(cfg.window).toBe(2);
+      expect(cfg.enabled).toBe(true);
+      const windowWarns = warnSpy.mock.calls.filter(args => String(args[0]).includes('HARNESS_GATE_STAGNATION_WINDOW'));
+      expect(windowWarns).toHaveLength(0);
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('all-valid envs return parsed values with enabled=true in auto-mode', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION', 'on');
+    vi.stubEnv('HARNESS_GATE_STAGNATION_THRESHOLD', '0.80');
+    vi.stubEnv('HARNESS_GATE_STAGNATION_RUN', '3');
+    vi.stubEnv('HARNESS_GATE_STAGNATION_WINDOW', '5'); // no-op
+    const cfg = loadStagnationConfig(true);
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.threshold).toBe(0.80);
+    expect(cfg.run).toBe(3);
+    expect(cfg.window).toBe(2);
+  });
+
+  it('two invalid validated envs → both keys warned once each, feature disabled', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION', 'maybe');      // invalid
+    vi.stubEnv('HARNESS_GATE_STAGNATION_THRESHOLD', '999'); // invalid
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    loadStagnationConfig(true);
+    loadStagnationConfig(true); // second call — neither key warns again
+    const mainWarns = warnSpy.mock.calls.filter(args => String(args[0]).includes('HARNESS_GATE_STAGNATION='));
+    const threshWarns = warnSpy.mock.calls.filter(args => String(args[0]).includes('HARNESS_GATE_STAGNATION_THRESHOLD'));
+    expect(mainWarns).toHaveLength(1);
+    expect(threshWarns).toHaveLength(1);
+    expect(loadStagnationConfig(true).enabled).toBe(false);
+  });
+
+  it('process latch: once any key is invalid, enabled=false survives env correction until __resetWarnCache', () => {
+    vi.stubEnv('HARNESS_GATE_STAGNATION', 'maybe'); // invalid → sets latch
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    loadStagnationConfig(true); // latch engaged
+    vi.unstubAllEnvs();          // env is now "corrected" (no bad values)
+    // Latch still set → must stay disabled
+    expect(loadStagnationConfig(true).enabled).toBe(false);
+    // Reset latch → re-enabled
+    __resetWarnCache();
+    expect(loadStagnationConfig(true).enabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Auto-mode force-pass (4th attempt after 3 Codex rejects) currently fires regardless of *why* retries failed — it can't distinguish genuine progress from oscillation. When all rejects share a root cause, force-pass blasts through and the next phase explodes anyway.

This PR adds a deterministic stagnation detector that intercepts force-pass when the last two adjacent retry-feedback pairs are highly similar, and escalates to the user instead.

- New `src/phases/stagnation.ts` (118 LoC) — `tokenJaccard` (NFKC + lowercase + Unicode-letter/number tokens), `StagnationDetector` (in-memory ring buffer, no state.json schema change), `loadStagnationConfig` (env validation with fail-open warns).
- `src/phases/runner.ts` (+67 LoC) — intercepts `forcePassGate` in `handleGateReject` only when stagnation is triggered; otherwise byte-identical to the previous path.
- New event `gate_stagnation` (variant added to `LogEvent`); `escalation.reason` enum extended with `'gate-stagnation'`. Both additive — backward-compatible.
- Manual mode default OFF, auto-mode default ON. Disable via `HARNESS_GATE_STAGNATION=off`.
- 4 env vars (threshold, run length, window, master switch) — all invalid values fall back to defaults with deduped stderr warns.
- Tests: 285L unit (token Jaccard / detector / config) + 225L runner integration (auto-mode, manual, env-off, fail-open) + 176L event-ordering integration. 8/8 auto-verify pass.
- README* + HOW-IT-WORKS* (KO/EN) synced.

Inspired by [Q00/ouroboros](https://github.com/Q00/ouroboros)'s stagnation detection (oscillation pattern, ~70% feedback overlap), but scoped to the auto-mode failure mode harness-cli actually has — single signal, deterministic, no LLM.

Dogfooded: this PR was produced by phase-harness itself (run `2026-05-06-phase-harness-gate-retry-8ea9`, ~106 min, P7 APPROVE with one P3 comment, no P0/P1).

### Deferred

- **P3 (src/phases/stagnation.ts:53)** — process-wide disable latch returns before re-inspecting env vars on later calls; a second misconfigured key wouldn't get its dedup warn. Doesn't affect fail-open or escalation correctness. TODO for follow-up.

## Test plan

- [x] `pnpm tsc --noEmit` (clean)
- [x] `pnpm vitest run` (all suites incl. new stagnation + integration)
- [x] Auto-verify report 8/8 pass (`docs/process/evals/2026-05-06-phase-harness-gate-retry-8ea9-eval.md`)
- [ ] Manually verify auto-mode behavior on a synthetic stagnant gate (next dogfood iteration)
- [ ] Confirm `HARNESS_GATE_STAGNATION=off` reproduces pre-PR behavior on a real auto-mode run