### PR TITLE
feat(gate): add quantitative ambiguity score to P2 spec gate (full-flow only)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -49,6 +49,8 @@ P1 spec → P2 spec gate → P3 plan → P4 plan gate → P5 implement → P6 ve
 
 마이그레이션, API/contract 변경, 보안 민감 작업처럼 **구현 전에 독립 리뷰가 중요한 경우** full flow가 적합합니다.
 
+Spec gate (P2)는 Codex의 `## Clarity Scores` 출력에서 가중 모호성 점수를 추가로 계산하며, `ambiguity > HARNESS_GATE_AMBIGUITY_THRESHOLD`(기본값 0.2)인 경우 APPROVE를 REJECT로 재작성합니다.
+
 ### Light flow (`phase-harness start --light "task"`)
 
 ```text
@@ -236,6 +238,7 @@ phase-harness start --root /tmp/demo "task"
 | `HARNESS_GATE_STAGNATION_THRESHOLD` | `0.70` | Jaccard 유사도 임계값 [0, 1]; 높을수록 엄격 |
 | `HARNESS_GATE_STAGNATION_RUN` | `2` | 에스컬레이션 전 연속 정체 쌍 수 (최소 2) |
 | `HARNESS_GATE_STAGNATION_WINDOW` | `2` | 향후 사용 예약; 현재 2로 고정 (쌍 비교) |
+| `HARNESS_GATE_AMBIGUITY_THRESHOLD` | `0.2` | P2 spec gate 모호성 거부권 임계값 [0, 1]. `off`로 비활성화(점수는 여전히 로깅). 유효하지 않은 값 → 거부권 비활성화 + stderr 경고 1회. |
 
 처음 세 변수에 잘못된 값이 있으면 해당 프로세스에서 기능이 비활성화되고 stderr에 경고 하나가 출력됩니다. 수동 모드에서는 항상 비활성화됩니다.
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ P1 spec → P2 spec gate → P3 plan → P4 plan gate → P5 implement → P6 ve
 
 Use the full flow when independent pre-implementation review matters: migrations, API/contract work, security-sensitive changes, or anything where the extra gate cost is worth it.
 
+Spec gate (P2) additionally computes a weighted ambiguity score from Codex's `## Clarity Scores` output and vetoes APPROVE→REJECT when `ambiguity > HARNESS_GATE_AMBIGUITY_THRESHOLD` (default 0.2).
+
 ### Light flow (`phase-harness start --light "task"`)
 
 ```text
@@ -236,6 +238,7 @@ When running with `--auto`, harness detects *stagnant* gate retry cycles — whe
 | `HARNESS_GATE_STAGNATION_THRESHOLD` | `0.70` | Jaccard similarity threshold [0, 1]; higher = stricter |
 | `HARNESS_GATE_STAGNATION_RUN` | `2` | Consecutive stagnant pairs required before escalation (min 2) |
 | `HARNESS_GATE_STAGNATION_WINDOW` | `2` | Reserved for future use; currently fixed at 2 (pair comparison) |
+| `HARNESS_GATE_AMBIGUITY_THRESHOLD` | `0.2` | P2 spec gate ambiguity veto threshold [0, 1]. Set to `off` to disable veto (scores still logged). Invalid value → veto disabled + one stderr warning. |
 
 Any invalid value for the first three variables disables the feature for that process and emits one warning to stderr. The feature is always off in manual mode.
 

--- a/docs/HOW-IT-WORKS.ko.md
+++ b/docs/HOW-IT-WORKS.ko.md
@@ -89,6 +89,7 @@ light flow 특이사항:
 - `HARNESS_GATE_STAGNATION_THRESHOLD=0.70`
 - `HARNESS_GATE_STAGNATION_RUN=2` (연속 정체 쌍 2개 필요)
 - `HARNESS_GATE_STAGNATION_WINDOW=2` (예약됨; v1에서는 no-op)
+- `HARNESS_GATE_AMBIGUITY_THRESHOLD=0.2` — P2 spec gate 모호성 거부권 임계값 [0, 1]. `=off`로 비활성화(점수는 여전히 로깅). 유효하지 않은 값 → 거부권 비활성화 + stderr 경고 1회.
 
 처음 세 변수의 잘못된 값은 기능을 fail-open으로 비활성화합니다 (프로세스당 키당 최대 1회 stderr 경고). 감지기 버퍼는 메모리 내에만 존재하며, 일시정지된 실행을 재개하면 빈 상태로 시작됩니다.
 
@@ -164,6 +165,10 @@ outer cwd가 git 레포가 아니어도 codex가 trust 프롬프트나 git-repo 
 - interactive: 30분
 - gate: 6분
 - verify: 5분
+
+### 명확성 점수 & 모호성 거부권 (P2 전체 플로우 전용)
+
+전체 플로우 P2 spec gate에서 Codex는 `## Clarity Scores` 블록(4개 축: goal, constraint, success, context, 각 [0.0, 1.0])을 출력하도록 지시받습니다. 하네스는 `ambiguity = 1 − Σ(score × weight)` (가중치: goal 0.35, constraint 0.25, success 0.30, context 0.10)를 계산합니다. `ambiguity > HARNESS_GATE_AMBIGUITY_THRESHOLD` (기본값 `0.2`)이고 정성 판단이 APPROVE였다면, 하네스는 REJECT로 재작성하며 점수가 가장 낮은 두 축을 명시하는 P1 합성 코멘트를 생성합니다. 환경 변수를 `off`로 설정하면 거부권이 비활성화되지만 점수는 여전히 파싱·로깅됩니다. 파싱 실패는 fail-open 처리됩니다. 이 기능은 full-flow P2 전용입니다; light-flow P2는 변경되지 않습니다.
 
 ---
 
@@ -324,7 +329,7 @@ light flow에서는 skipped phase로 jump할 수 없습니다.
   summary.json
 ```
 
-주요 이벤트는 `phase_start`, `phase_end`, `gate_verdict`, `gate_error`, `gate_retry`, `gate_stagnation`, `verify_result`, `ui_render`, `terminal_action`, `session_end` 등입니다. `gate_stagnation` 이벤트는 `phase`, `retryIndex`, `similarities` (number[]), `threshold`, `run`, `action: 'escalate'` 필드를 포함합니다.
+주요 이벤트는 `phase_start`, `phase_end`, `gate_verdict`, `gate_error`, `gate_retry`, `gate_stagnation`, `verify_result`, `ui_render`, `terminal_action`, `session_end` 등입니다. `gate_stagnation` 이벤트는 `phase`, `retryIndex`, `similarities` (number[]), `threshold`, `run`, `action: 'escalate'` 필드를 포함합니다. Phase 2의 `gate_verdict` 이벤트에는 모호성 게이트 실행 시 다음 5개의 선택적 필드가 추가됩니다: `clarityScores`, `ambiguity`, `ambiguityThreshold`, `ambiguityVetoed`, `clarityParseError`. 이 필드들은 P4/P7 이벤트에는 포함되지 않습니다.
 control pane footer는 이 로그를 바탕으로 경과 시간과 Claude/gate 토큰 합계를 집계합니다.
 
 ---

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -89,6 +89,7 @@ In auto-mode, when a gate phase is rejected `retryLimit` times in a row, harness
 - `HARNESS_GATE_STAGNATION_THRESHOLD=0.70`
 - `HARNESS_GATE_STAGNATION_RUN=2` (two consecutive stagnant pairs required)
 - `HARNESS_GATE_STAGNATION_WINDOW=2` (reserved; no-op in v1)
+- `HARNESS_GATE_AMBIGUITY_THRESHOLD=0.2` — P2 spec gate ambiguity veto threshold [0, 1]. `=off` to disable veto (scores still logged). Invalid value → veto disabled + one stderr warning.
 
 Invalid values for the first three vars disable the feature fail-open (one stderr warn per key per process). The detector buffer is in-memory only; resuming a paused run starts empty.
 
@@ -164,6 +165,10 @@ Current timeout constants (`src/config.ts`):
 - interactive phases: 30 minutes
 - gate phases: 6 minutes
 - verify: 5 minutes
+
+### Clarity Scores & Ambiguity Veto (P2 full flow only)
+
+When running the spec gate (full flow P2), Codex is instructed to emit a `## Clarity Scores` block with four axis scores (goal, constraint, success, context), each in [0.0, 1.0]. Harness computes `ambiguity = 1 − Σ(score × weight)` with weights `{goal: 0.35, constraint: 0.25, success: 0.30, context: 0.10}`. If `ambiguity > HARNESS_GATE_AMBIGUITY_THRESHOLD` (default `0.2`) and the qualitative verdict was APPROVE, harness rewrites it to REJECT with a synthetic P1 comment naming the lowest-scoring axes and appends `Scope: design` to route the retry back to Phase 1. Setting the env var to `off` disables the veto while still parsing and logging scores. Parse failure is fail-open — the qualitative verdict stands and `clarityParseError: true` is attached to the event. This feature applies to full-flow P2 only; light-flow P2 (`FIVE_AXIS_DESIGN_GATE_LIGHT`) is unchanged.
 
 ---
 
@@ -343,7 +348,7 @@ When enabled, harness writes under:
   summary.json
 ```
 
-Important logged events include `phase_start`, `phase_end`, `gate_verdict`, `gate_error`, `gate_retry`, `gate_stagnation`, `verify_result`, `ui_render`, `terminal_action`, and `session_end`. The `gate_stagnation` event carries fields `phase`, `retryIndex`, `similarities` (number[]), `threshold`, `run`, `action: 'escalate'`.
+Important logged events include `phase_start`, `phase_end`, `gate_verdict`, `gate_error`, `gate_retry`, `gate_stagnation`, `verify_result`, `ui_render`, `terminal_action`, and `session_end`. The `gate_stagnation` event carries fields `phase`, `retryIndex`, `similarities` (number[]), `threshold`, `run`, `action: 'escalate'`. The `gate_verdict` event for Phase 2 additionally carries five optional fields when the ambiguity gate ran: `clarityScores` (object with goal/constraint/success/context), `ambiguity` (weighted score), `ambiguityThreshold` (threshold in effect), `ambiguityVetoed` (true if APPROVE was rewritten to REJECT), `clarityParseError` (true if score parsing failed). These fields are absent on P4/P7 events.
 The control-pane footer aggregates elapsed time plus Claude/gate token totals from those logs.
 
 ---

--- a/docs/plans/2026-05-06-p2-spec-gate-ambiguity-9fa2.md
+++ b/docs/plans/2026-05-06-p2-spec-gate-ambiguity-9fa2.md
@@ -1265,3 +1265,7 @@ pnpm tsc --noEmit   # typecheck
 pnpm vitest run     # full test suite
 pnpm build          # tsc + copy-assets
 ```
+
+## Deferred
+
+- Persist ambiguity fields (`clarityScores`, `ambiguity`, `ambiguityThreshold`, `ambiguityVetoed`) in `gate-N-result.json` via `_persistSidecars` and hydrate them in `checkGateSidecars`, so sidecar-replay `gate_verdict` events include the post-hoc score data required by spec §28/§349. Requires extending `GateResult` type and both sidecar functions. (gate-7 P2 feedback rev 2)

--- a/docs/plans/2026-05-06-p2-spec-gate-ambiguity-9fa2.md
+++ b/docs/plans/2026-05-06-p2-spec-gate-ambiguity-9fa2.md
@@ -1268,4 +1268,5 @@ pnpm build          # tsc + copy-assets
 
 ## Deferred
 
-- Persist ambiguity fields (`clarityScores`, `ambiguity`, `ambiguityThreshold`, `ambiguityVetoed`) in `gate-N-result.json` via `_persistSidecars` and hydrate them in `checkGateSidecars`, so sidecar-replay `gate_verdict` events include the post-hoc score data required by spec §28/§349. Requires extending `GateResult` type and both sidecar functions. (gate-7 P2 feedback rev 2)
+(none — gate-7 P2 sidecar persistence and light-flow P2 resume gating
+were addressed before merge as follow-up commits.)

--- a/docs/plans/2026-05-06-p2-spec-gate-ambiguity-9fa2.md
+++ b/docs/plans/2026-05-06-p2-spec-gate-ambiguity-9fa2.md
@@ -1,0 +1,1267 @@
+# P2 Spec Gate Quantitative Ambiguity Score Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a quantitative ambiguity score to the P2 spec gate — Codex emits a `## Clarity Scores` block with 4 axes, harness computes weighted ambiguity, and vetoes APPROVE→REJECT when `ambiguity > HARNESS_GATE_AMBIGUITY_THRESHOLD` (default 0.2).
+
+**Architecture:** Five touch-points in dependency order: (1) pure parser/types in `verdict.ts`, (2) new `ambiguity.ts` module mirroring `stagnation.ts`, (3) `assembler.ts` Codex contract injection, (4) `types.ts` schema extension, (5) `gate.ts` + `runner.ts` wiring. All logic is stateless per gate attempt; `state.json`, P4/P7 gate paths, light-flow phase 2, and the sidecar-replay branch are unchanged.
+
+**Tech Stack:** TypeScript 5, Vitest, Node.js ESM. No new dependencies.
+
+Related artifacts:
+- Spec: `docs/specs/2026-05-06-p2-spec-gate-ambiguity-9fa2-design.md`
+- Decisions log: `.harness/2026-05-06-p2-spec-gate-ambiguity-9fa2/decisions.md`
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `src/phases/ambiguity.ts` | `loadAmbiguityThreshold`, `applyAmbiguityGate`, `__resetAmbiguityWarning` |
+| Create | `tests/phases/ambiguity.test.ts` | Unit tests for ambiguity module |
+| Modify | `src/phases/verdict.ts` | Add `AMBIGUITY_AXES`, `CLARITY_WEIGHTS`, `ClarityScores`, `parseClarityScores`, `computeWeightedAmbiguity` |
+| Modify | `src/types.ts` | Add 5 optional fields to `GateOutcome`, `GateError`, `gate_verdict` LogEvent; type-only import of `ClarityScores` |
+| Modify | `src/context/assembler.ts` | Append `CLARITY_SCORES_PROTOCOL` to `FIVE_AXIS_SPEC_GATE`; phase-aware `structuredOutputReminder` |
+| Modify | `src/phases/gate.ts` | Call `applyAmbiguityGate` for `phase === 2`, both Claude and Codex paths, before `_persistSidecars` |
+| Modify | `src/phases/runner.ts` | Pass 5 new optional fields through both `gate_verdict` emission sites, guarded by `phase === 2` |
+| Modify | `tests/phases/verdict.test.ts` | Tests for `parseClarityScores` and `computeWeightedAmbiguity` |
+| Modify | `tests/context/assembler.test.ts` | Assert `## Clarity Scores` in P2 prompt; absent in P4/P7; 4-bullet resume reminder in P2 |
+| Modify | `tests/phases/gate.test.ts` | Integration tests: P2 veto fires; P4 clean |
+| Modify | `docs/HOW-IT-WORKS.md` | Phase 2 gate section + `gate_verdict` event table |
+| Modify | `docs/HOW-IT-WORKS.ko.md` | Same, Korean |
+| Modify | `README.md` | Env var row + one-line spec gate note |
+| Modify | `README.ko.md` | Same, Korean |
+
+---
+
+## Task 1: `verdict.ts` — pure types and functions + `types.ts` extensions
+
+**Files:**
+- Modify: `src/phases/verdict.ts`
+- Modify: `src/types.ts`
+- Modify: `tests/phases/verdict.test.ts`
+
+- [ ] **Step 1.1: Write failing tests for `parseClarityScores`**
+
+Add to `tests/phases/verdict.test.ts`:
+
+```typescript
+import {
+  parseClarityScores,
+  computeWeightedAmbiguity,
+  AMBIGUITY_AXES,
+  CLARITY_WEIGHTS,
+} from '../../src/phases/verdict.js';
+
+describe('parseClarityScores', () => {
+  const good = [
+    '## Verdict', 'APPROVE',
+    '## Comments', '- looks good',
+    '## Summary', 'All clear.',
+    '## Clarity Scores',
+    '- goal: 0.85',
+    '- constraint: 0.70',
+    '- success: 0.90',
+    '- context: 0.60',
+  ].join('\n');
+
+  it('parses a well-formed block', () => {
+    const scores = parseClarityScores(good);
+    expect(scores).toEqual({ goal: 0.85, constraint: 0.70, success: 0.90, context: 0.60 });
+  });
+
+  it('returns null when ## Clarity Scores header is absent', () => {
+    expect(parseClarityScores('## Verdict\nAPPROVE\n## Summary\nOK.')).toBeNull();
+  });
+
+  it('returns null when any axis is missing', () => {
+    const partial = '## Clarity Scores\n- goal: 0.9\n- constraint: 0.8\n- success: 0.7\n';
+    expect(parseClarityScores(partial)).toBeNull();
+  });
+
+  it('returns null when any value is outside [0, 1]', () => {
+    const neg = '## Clarity Scores\n- goal: -0.1\n- constraint: 0.8\n- success: 0.7\n- context: 0.5\n';
+    const big = '## Clarity Scores\n- goal: 1.1\n- constraint: 0.8\n- success: 0.7\n- context: 0.5\n';
+    expect(parseClarityScores(neg)).toBeNull();
+    expect(parseClarityScores(big)).toBeNull();
+  });
+
+  it('accepts integer values (goal: 1 treated as 1.0)', () => {
+    const intVals = '## Clarity Scores\n- goal: 1\n- constraint: 0\n- success: 1\n- context: 0\n';
+    const scores = parseClarityScores(intVals);
+    expect(scores).toEqual({ goal: 1, constraint: 0, success: 1, context: 0 });
+  });
+
+  it('is case-insensitive on header and axis names', () => {
+    const mixed = '## clarity scores\n- Goal: 0.9\n- CONSTRAINT: 0.8\n- Success: 0.7\n- Context: 0.6\n';
+    expect(parseClarityScores(mixed)).toEqual({ goal: 0.9, constraint: 0.8, success: 0.7, context: 0.6 });
+  });
+
+  it('first duplicate axis wins, others ignored', () => {
+    const dup = '## Clarity Scores\n- goal: 0.9\n- goal: 0.1\n- constraint: 0.8\n- success: 0.7\n- context: 0.6\n';
+    const scores = parseClarityScores(dup);
+    expect(scores?.goal).toBe(0.9);
+  });
+
+  it('stops scanning at next ## header', () => {
+    const stop = '## Clarity Scores\n- goal: 0.9\n- constraint: 0.8\n## Other\n- success: 0.7\n- context: 0.6\n';
+    expect(parseClarityScores(stop)).toBeNull(); // success and context after ##, so missing
+  });
+
+  it('tolerates extra whitespace around separator', () => {
+    const spacy = '## Clarity Scores\n  -  goal :  0.85  \n- constraint: 0.70\n- success: 0.90\n- context: 0.60\n';
+    expect(parseClarityScores(spacy)).toEqual({ goal: 0.85, constraint: 0.70, success: 0.90, context: 0.60 });
+  });
+});
+
+describe('computeWeightedAmbiguity', () => {
+  it('all 1.0 scores → ambiguity 0.0', () => {
+    expect(computeWeightedAmbiguity({ goal: 1, constraint: 1, success: 1, context: 1 })).toBe(0);
+  });
+
+  it('all 0.0 scores → ambiguity 1.0', () => {
+    expect(computeWeightedAmbiguity({ goal: 0, constraint: 0, success: 0, context: 0 })).toBe(1);
+  });
+
+  it('weights sum to 1.0 (invariant)', () => {
+    const sum = Object.values(CLARITY_WEIGHTS).reduce((a, b) => a + b, 0);
+    expect(sum).toBeCloseTo(1.0, 10);
+  });
+
+  it('matches manual calculation', () => {
+    // goal=0.45 *0.35 + constraint=0.60 *0.25 + success=0.85 *0.30 + context=0.90 *0.10
+    // = 0.1575 + 0.15 + 0.255 + 0.09 = 0.6525 → ambiguity = 1 - 0.6525 = 0.3475
+    const scores = { goal: 0.45, constraint: 0.60, success: 0.85, context: 0.90 };
+    expect(computeWeightedAmbiguity(scores)).toBeCloseTo(0.3475, 6);
+  });
+
+  it('result is clamped to [0, 1]', () => {
+    const result = computeWeightedAmbiguity({ goal: 1, constraint: 1, success: 1, context: 1 });
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(1);
+  });
+
+  it('AMBIGUITY_AXES contains exactly goal, constraint, success, context', () => {
+    expect([...AMBIGUITY_AXES].sort()).toEqual(['constraint', 'context', 'goal', 'success']);
+  });
+});
+```
+
+- [ ] **Step 1.2: Run tests to verify they fail**
+
+```bash
+cd /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/ambiguity-gate
+pnpm vitest run tests/phases/verdict.test.ts
+```
+
+Expected: FAIL — `parseClarityScores`, `computeWeightedAmbiguity`, `AMBIGUITY_AXES`, `CLARITY_WEIGHTS` are not exported.
+
+- [ ] **Step 1.3: Add types and functions to `src/phases/verdict.ts`**
+
+Add the following at the end of `src/phases/verdict.ts` (before the final `}`):
+
+```typescript
+// ─── Ambiguity scoring ────────────────────────────────────────────────────────
+
+export const AMBIGUITY_AXES = ['goal', 'constraint', 'success', 'context'] as const;
+export type AmbiguityAxis = typeof AMBIGUITY_AXES[number];
+
+export const CLARITY_WEIGHTS: Readonly<Record<AmbiguityAxis, number>> = Object.freeze({
+  goal: 0.35,
+  constraint: 0.25,
+  success: 0.30,
+  context: 0.10,
+});
+
+export type ClarityScores = Record<AmbiguityAxis, number>;
+
+/**
+ * Parse the `## Clarity Scores` block from a Codex gate output.
+ * Returns null on missing header, missing axis, or out-of-range value.
+ * Pure function — no I/O, no exceptions.
+ */
+export function parseClarityScores(rawOutput: string): ClarityScores | null {
+  const lines = rawOutput.split('\n');
+  const headerIdx = lines.findIndex(
+    (l) => l.trim().toLowerCase() === '## clarity scores',
+  );
+  if (headerIdx === -1) return null;
+
+  const found: Partial<Record<AmbiguityAxis, number>> = {};
+  for (let i = headerIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^\s*##\s/.test(line)) break;
+    const m = line.match(/^\s*-\s*(goal|constraint|success|context)\s*:\s*(\d+(?:\.\d+)?)\s*$/i);
+    if (!m) continue;
+    const axis = m[1].toLowerCase() as AmbiguityAxis;
+    if (axis in found) continue; // first wins
+    const value = parseFloat(m[2]);
+    if (value < 0 || value > 1) return null;
+    found[axis] = value;
+  }
+
+  for (const axis of AMBIGUITY_AXES) {
+    if (!(axis in found)) return null;
+  }
+  return found as ClarityScores;
+}
+
+/**
+ * Compute weighted ambiguity score: 1 − Σ(score × weight).
+ * Result clamped to [0, 1] to absorb floating-point drift.
+ * Pure function — no I/O, no exceptions.
+ */
+export function computeWeightedAmbiguity(scores: ClarityScores): number {
+  let clarity = 0;
+  for (const axis of AMBIGUITY_AXES) {
+    clarity += scores[axis] * CLARITY_WEIGHTS[axis];
+  }
+  const ambiguity = 1 - clarity;
+  return Math.min(1, Math.max(0, ambiguity));
+}
+```
+
+- [ ] **Step 1.4: Extend `src/types.ts` with 5 optional fields**
+
+Add a type-only import at the top of `src/types.ts` (after the existing empty imports, before the first `export`):
+
+```typescript
+import type { ClarityScores } from './phases/verdict.js';
+```
+
+Then extend `GateOutcome` (add after the `resumeFallback?` line):
+
+```typescript
+  // Ambiguity gate fields (Phase 2 only)
+  clarityScores?: ClarityScores;
+  ambiguity?: number;
+  ambiguityThreshold?: number;
+  ambiguityVetoed?: boolean;
+  clarityParseError?: boolean;
+```
+
+Extend `GateError` (add after the `resumeFallback?` line):
+
+```typescript
+  // Ambiguity gate fields (Phase 2 only)
+  clarityScores?: ClarityScores;
+  ambiguity?: number;
+  ambiguityThreshold?: number;
+  ambiguityVetoed?: boolean;
+  clarityParseError?: boolean;
+```
+
+Extend the `gate_verdict` variant of `LogEvent` (add the 5 fields after the `preset?` line):
+
+```typescript
+      // New (Phase 2 only):
+      clarityScores?: ClarityScores;
+      ambiguity?: number;
+      ambiguityThreshold?: number;
+      ambiguityVetoed?: boolean;
+      clarityParseError?: boolean;
+```
+
+- [ ] **Step 1.5: Run tests to verify they pass**
+
+```bash
+pnpm vitest run tests/phases/verdict.test.ts
+```
+
+Expected: PASS for all `parseClarityScores` and `computeWeightedAmbiguity` tests.
+
+- [ ] **Step 1.6: Typecheck**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: zero errors.
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git add src/phases/verdict.ts src/types.ts tests/phases/verdict.test.ts
+git commit -m "feat(ambiguity): add parseClarityScores, computeWeightedAmbiguity, and types"
+```
+
+---
+
+## Task 2: `src/phases/ambiguity.ts` — new module + tests
+
+**Files:**
+- Create: `src/phases/ambiguity.ts`
+- Create: `tests/phases/ambiguity.test.ts`
+
+- [ ] **Step 2.1: Write failing tests**
+
+Create `tests/phases/ambiguity.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { loadAmbiguityThreshold, applyAmbiguityGate, __resetAmbiguityWarning } from '../../src/phases/ambiguity.js';
+import type { GatePhaseResult } from '../../src/types.js';
+
+function makeApprove(rawOutput: string): GatePhaseResult {
+  return {
+    type: 'verdict',
+    verdict: 'APPROVE',
+    comments: '',
+    rawOutput,
+    runner: 'codex',
+  };
+}
+
+function makeReject(rawOutput: string): GatePhaseResult {
+  return {
+    type: 'verdict',
+    verdict: 'REJECT',
+    comments: 'some finding',
+    rawOutput,
+    runner: 'codex',
+  };
+}
+
+function makeError(): GatePhaseResult {
+  return { type: 'error', error: 'subprocess failed', rawOutput: '' };
+}
+
+const highAmbiguityOutput = [
+  '## Verdict', 'APPROVE',
+  '## Summary', 'Spec looks decent.',
+  '## Clarity Scores',
+  '- goal: 0.45',
+  '- constraint: 0.60',
+  '- success: 0.85',
+  '- context: 0.90',
+].join('\n');
+// ambiguity = 1 - (0.45*0.35 + 0.60*0.25 + 0.85*0.30 + 0.90*0.10)
+//           = 1 - (0.1575 + 0.15 + 0.255 + 0.09) = 1 - 0.6525 = 0.3475 > 0.2
+
+const lowAmbiguityOutput = [
+  '## Clarity Scores',
+  '- goal: 0.90',
+  '- constraint: 0.85',
+  '- success: 0.95',
+  '- context: 0.80',
+].join('\n');
+// ambiguity = 1 - (0.90*0.35 + 0.85*0.25 + 0.95*0.30 + 0.80*0.10)
+//           = 1 - (0.315 + 0.2125 + 0.285 + 0.08) = 1 - 0.8925 = 0.1075 < 0.2
+
+const exactThresholdOutput = [
+  '## Clarity Scores',
+  '- goal: 0.8',
+  '- constraint: 0.8',
+  '- success: 0.8',
+  '- context: 0.8',
+].join('\n');
+// ambiguity = 1 - 0.8 = 0.2 (exactly at threshold, should NOT veto)
+
+beforeEach(() => {
+  __resetAmbiguityWarning();
+  vi.unstubAllEnvs();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  __resetAmbiguityWarning();
+});
+
+// ─── loadAmbiguityThreshold ──────────────────────────────────────────────────
+
+describe('loadAmbiguityThreshold', () => {
+  it('returns 0.2 when env var is unset', () => {
+    delete process.env['HARNESS_GATE_AMBIGUITY_THRESHOLD'];
+    expect(loadAmbiguityThreshold()).toBe(0.2);
+  });
+
+  it('returns 0.2 when env var is empty string', () => {
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', '');
+    expect(loadAmbiguityThreshold()).toBe(0.2);
+  });
+
+  it('returns null for "off" (case-insensitive, trimmed)', () => {
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', 'off');
+    expect(loadAmbiguityThreshold()).toBeNull();
+    __resetAmbiguityWarning();
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', 'OFF');
+    expect(loadAmbiguityThreshold()).toBeNull();
+    __resetAmbiguityWarning();
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', '  Off  ');
+    expect(loadAmbiguityThreshold()).toBeNull();
+  });
+
+  it('returns 0.0 for "0.0"', () => {
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', '0.0');
+    expect(loadAmbiguityThreshold()).toBe(0.0);
+  });
+
+  it('returns 1.0 for "1.0"', () => {
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', '1.0');
+    expect(loadAmbiguityThreshold()).toBe(1.0);
+  });
+
+  it('returns null + warn for value > 1', () => {
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', '1.5');
+    expect(loadAmbiguityThreshold()).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it('returns null + warn for value < 0', () => {
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', '-0.1');
+    expect(loadAmbiguityThreshold()).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it('returns null + warn for non-numeric', () => {
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', 'abc');
+    expect(loadAmbiguityThreshold()).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it('warned-once: second invalid load produces no extra warning', () => {
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', 'bad');
+    loadAmbiguityThreshold();
+    loadAmbiguityThreshold();
+    loadAmbiguityThreshold();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it('__resetAmbiguityWarning clears the warned-once state', () => {
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', 'bad');
+    loadAmbiguityThreshold();
+    __resetAmbiguityWarning();
+    loadAmbiguityThreshold();
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    warnSpy.mockRestore();
+  });
+});
+
+// ─── applyAmbiguityGate ──────────────────────────────────────────────────────
+
+describe('applyAmbiguityGate', () => {
+  it('APPROVE + ambiguity > threshold → REJECT with ambiguityVetoed', () => {
+    const result = applyAmbiguityGate(makeApprove(highAmbiguityOutput), highAmbiguityOutput, 0.2);
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.verdict).toBe('REJECT');
+      expect(result.ambiguityVetoed).toBe(true);
+      expect(result.ambiguity).toBeCloseTo(0.3475, 4);
+      expect(result.ambiguityThreshold).toBe(0.2);
+      expect(result.clarityScores).toEqual({ goal: 0.45, constraint: 0.60, success: 0.85, context: 0.90 });
+      expect(result.comments).toMatch(/\[P1\]/);
+      expect(result.comments).toMatch(/Scope: design/);
+    }
+  });
+
+  it('APPROVE + ambiguity = threshold → unchanged (boundary inclusive on pass side)', () => {
+    const result = applyAmbiguityGate(makeApprove(exactThresholdOutput), exactThresholdOutput, 0.2);
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.verdict).toBe('APPROVE');
+      expect(result.ambiguityVetoed).toBeUndefined();
+    }
+  });
+
+  it('APPROVE + ambiguity < threshold → unchanged, scores attached', () => {
+    const result = applyAmbiguityGate(makeApprove(lowAmbiguityOutput), lowAmbiguityOutput, 0.2);
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.verdict).toBe('APPROVE');
+      expect(result.ambiguityVetoed).toBeUndefined();
+      expect(result.clarityScores).toBeDefined();
+      expect(result.ambiguity).toBeDefined();
+    }
+  });
+
+  it('REJECT + any ambiguity → verdict stays REJECT, scores attached', () => {
+    const result = applyAmbiguityGate(makeReject(highAmbiguityOutput), highAmbiguityOutput, 0.2);
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.verdict).toBe('REJECT');
+      expect(result.ambiguityVetoed).toBeUndefined();
+      expect(result.clarityScores).toBeDefined();
+    }
+  });
+
+  it('threshold null (off) → no veto even at ambiguity=1.0, scores still attached', () => {
+    const allZero = [
+      '## Clarity Scores',
+      '- goal: 0.0', '- constraint: 0.0', '- success: 0.0', '- context: 0.0',
+    ].join('\n');
+    const result = applyAmbiguityGate(makeApprove(allZero), allZero, null);
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.verdict).toBe('APPROVE');
+      expect(result.ambiguityVetoed).toBeUndefined();
+      expect(result.ambiguityThreshold).toBeUndefined();
+      expect(result.clarityScores).toBeDefined();
+      expect(result.ambiguity).toBe(1.0);
+    }
+  });
+
+  it('error result → returned unchanged', () => {
+    const err = makeError();
+    const result = applyAmbiguityGate(err, '', 0.2);
+    expect(result).toBe(err);
+  });
+
+  it('parse failure → clarityParseError true, verdict unchanged, ambiguityThreshold attached', () => {
+    const noScores = '## Verdict\nAPPROVE\n## Summary\nLooks fine.';
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const result = applyAmbiguityGate(makeApprove(noScores), noScores, 0.2);
+    expect(result.clarityParseError).toBe(true);
+    expect(result.ambiguityThreshold).toBe(0.2);
+    if (result.type === 'verdict') {
+      expect(result.verdict).toBe('APPROVE');
+    }
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    // Second call: warned-once → no extra warning
+    applyAmbiguityGate(makeApprove(noScores), noScores, 0.2);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it('synthetic P1 comment names the two lowest-scoring axes', () => {
+    const result = applyAmbiguityGate(makeApprove(highAmbiguityOutput), highAmbiguityOutput, 0.2);
+    if (result.type === 'verdict') {
+      // goal=0.45 and constraint=0.60 are the two lowest
+      expect(result.comments).toMatch(/goal/);
+      expect(result.comments).toMatch(/constraint/);
+    }
+  });
+
+  it('regression: legacy output without ## Clarity Scores → fail-open, verdict unchanged', () => {
+    const legacy = '## Verdict\nAPPROVE\n## Comments\n- All good.\n## Summary\nSpec is clear.';
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const result = applyAmbiguityGate(makeApprove(legacy), legacy, 0.2);
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.verdict).toBe('APPROVE');
+    }
+    expect(result.clarityParseError).toBe(true);
+    warnSpy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2.2: Run tests to verify they fail**
+
+```bash
+pnpm vitest run tests/phases/ambiguity.test.ts
+```
+
+Expected: FAIL — module `src/phases/ambiguity.ts` does not exist.
+
+- [ ] **Step 2.3: Create `src/phases/ambiguity.ts`**
+
+```typescript
+import type { GatePhaseResult } from '../types.js';
+import { parseClarityScores, computeWeightedAmbiguity, AMBIGUITY_AXES } from './verdict.js';
+import type { ClarityScores } from './verdict.js';
+
+const warnedKeys = new Set<string>();
+
+export function __resetAmbiguityWarning(): void {
+  warnedKeys.clear();
+}
+
+/**
+ * Load the ambiguity veto threshold from the environment.
+ * - Unset / empty → 0.2 (default)
+ * - "off" (case-insensitive, trimmed) → null (veto disabled, scores still parsed)
+ * - Numeric in [0.0, 1.0] → that value
+ * - Anything else → null + one stderr warning (warned-once)
+ */
+export function loadAmbiguityThreshold(): number | null {
+  const raw = process.env['HARNESS_GATE_AMBIGUITY_THRESHOLD'];
+  if (raw === undefined || raw === '') return 0.2;
+
+  const trimmed = raw.trim();
+  if (trimmed.toLowerCase() === 'off') return null;
+
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    if (!warnedKeys.has('HARNESS_GATE_AMBIGUITY_THRESHOLD')) {
+      process.stderr.write(
+        `[ambiguity] invalid HARNESS_GATE_AMBIGUITY_THRESHOLD="${raw}" — veto disabled for this run\n`,
+      );
+      warnedKeys.add('HARNESS_GATE_AMBIGUITY_THRESHOLD');
+    }
+    return null;
+  }
+  return parsed;
+}
+
+/**
+ * Apply the ambiguity veto gate to a GatePhaseResult.
+ * - Errors pass through unchanged.
+ * - Parse failure: sets clarityParseError, emits one warning, leaves verdict untouched.
+ * - Scores parsed: attaches clarityScores and ambiguity.
+ * - If threshold not null and APPROVE and ambiguity > threshold: rewrites to REJECT.
+ */
+export function applyAmbiguityGate(
+  result: GatePhaseResult,
+  rawOutput: string,
+  threshold: number | null,
+): GatePhaseResult {
+  if (result.type === 'error') return result;
+
+  const scores = parseClarityScores(rawOutput);
+
+  if (scores === null) {
+    if (!warnedKeys.has('clarity-parse')) {
+      process.stderr.write(
+        '[ambiguity] ## Clarity Scores section missing or malformed — fail-open, verdict unchanged\n',
+      );
+      warnedKeys.add('clarity-parse');
+    }
+    return {
+      ...result,
+      clarityParseError: true,
+      ...(threshold !== null ? { ambiguityThreshold: threshold } : {}),
+    };
+  }
+
+  const ambiguity = computeWeightedAmbiguity(scores);
+  const withScores: GatePhaseResult = {
+    ...result,
+    clarityScores: scores,
+    ambiguity,
+    ...(threshold !== null ? { ambiguityThreshold: threshold } : {}),
+  };
+
+  if (threshold !== null && result.verdict === 'APPROVE' && ambiguity > threshold) {
+    const sorted = ([...AMBIGUITY_AXES] as string[]).sort(
+      (a, b) => (scores as ClarityScores)[a as keyof ClarityScores] - (scores as ClarityScores)[b as keyof ClarityScores],
+    );
+    const lowestTwo = sorted.slice(0, 2);
+    const lowestDesc = lowestTwo
+      .map((ax) => `${ax}=${(scores as ClarityScores)[ax as keyof ClarityScores].toFixed(2)}`)
+      .join(', ');
+    const scoresJson = Object.entries(scores)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join(', ');
+
+    const syntheticComment =
+      `- **[P1]** — Location: spec (overall)\n` +
+      `  Issue: Spec ambiguity ${ambiguity.toFixed(2)} exceeds threshold ${threshold.toFixed(2)} (weighted across goal/constraint/success/context).\n` +
+      `  Suggestion: Tighten the lowest-scoring axes — ${lowestDesc}. Restate goals as measurable outcomes and enumerate forbidden behaviors / boundary conditions.\n` +
+      `  Evidence: clarityScores = { ${scoresJson} } → weighted ambiguity ${ambiguity.toFixed(2)} > ${threshold.toFixed(2)}.`;
+
+    const existingComments = (result.comments ?? '').replace(/\n?Scope:\s*(design|impl|mixed)\b[^\n]*/i, '');
+    const newComments = (existingComments.trim()
+      ? syntheticComment + '\n' + existingComments.trim()
+      : syntheticComment) + '\nScope: design';
+
+    return {
+      ...withScores,
+      verdict: 'REJECT',
+      comments: newComments,
+      ambiguityVetoed: true,
+      scope: 'design',
+    };
+  }
+
+  return withScores;
+}
+```
+
+- [ ] **Step 2.4: Run tests to verify they pass**
+
+```bash
+pnpm vitest run tests/phases/ambiguity.test.ts
+```
+
+Expected: PASS for all tests.
+
+- [ ] **Step 2.5: Typecheck**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: zero errors.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add src/phases/ambiguity.ts tests/phases/ambiguity.test.ts
+git commit -m "feat(ambiguity): add loadAmbiguityThreshold and applyAmbiguityGate module"
+```
+
+---
+
+## Task 3: `assembler.ts` — Codex contract injection + phase-aware resume reminder
+
+**Files:**
+- Modify: `src/context/assembler.ts`
+- Modify: `tests/context/assembler.test.ts`
+
+- [ ] **Step 3.1: Write failing tests**
+
+Add to `tests/context/assembler.test.ts` (after the existing `describe` blocks):
+
+```typescript
+describe('assembler — Clarity Scores protocol (Phase 2 only)', () => {
+  it('phase-2 fresh prompt contains ## Clarity Scores instruction', () => {
+    const dir = makeTmpDir();
+    const state = makeState({ runId: 'test-run' });
+    // Write spec fixture
+    fs.mkdirSync(path.join(dir, 'docs/specs'), { recursive: true });
+    const specPath = path.join(dir, 'docs/specs/test-run-design.md');
+    fs.writeFileSync(specPath, '# spec\nsome spec content');
+    state.artifacts.spec = specPath;
+
+    const prompt = assembleGatePrompt(2, state, dir, dir);
+    expect(typeof prompt).toBe('string');
+    expect(prompt as string).toContain('## Clarity Scores');
+  });
+
+  it('phase-4 fresh prompt does NOT contain ## Clarity Scores instruction', () => {
+    const dir = makeTmpDir();
+    const state = makeState({ runId: 'test-run' });
+    fs.mkdirSync(path.join(dir, 'docs/specs'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'docs/plans'), { recursive: true });
+    const specPath = path.join(dir, 'docs/specs/test-run-design.md');
+    const planPath = path.join(dir, 'docs/plans/test-run.md');
+    fs.writeFileSync(specPath, '# spec');
+    fs.writeFileSync(planPath, '# plan');
+    state.artifacts.spec = specPath;
+    state.artifacts.plan = planPath;
+
+    const prompt = assembleGatePrompt(4, state, dir, dir);
+    expect(typeof prompt).toBe('string');
+    expect(prompt as string).not.toContain('## Clarity Scores');
+  });
+
+  it('phase-2 resume prompt structured-output reminder contains 4-bullet form', () => {
+    const dir = makeTmpDir();
+    const state = makeState({ runId: 'test-run' });
+    fs.mkdirSync(path.join(dir, 'docs/specs'), { recursive: true });
+    const specPath = path.join(dir, 'docs/specs/test-run-design.md');
+    fs.writeFileSync(specPath, '# spec');
+    state.artifacts.spec = specPath;
+
+    const prompt = assembleGateResumePrompt(2, state, dir, 'approve', '', dir);
+    expect(typeof prompt).toBe('string');
+    expect(prompt as string).toContain('## Clarity Scores');
+  });
+
+  it('phase-4 resume prompt structured-output reminder contains only 3 bullets (no Clarity Scores)', () => {
+    const dir = makeTmpDir();
+    const state = makeState({ runId: 'test-run' });
+    fs.mkdirSync(path.join(dir, 'docs/specs'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'docs/plans'), { recursive: true });
+    const specPath = path.join(dir, 'docs/specs/test-run-design.md');
+    const planPath = path.join(dir, 'docs/plans/test-run.md');
+    fs.writeFileSync(specPath, '# spec');
+    fs.writeFileSync(planPath, '# plan');
+    state.artifacts.spec = specPath;
+    state.artifacts.plan = planPath;
+
+    const prompt = assembleGateResumePrompt(4, state, dir, 'approve', '', dir);
+    expect(typeof prompt).toBe('string');
+    expect(prompt as string).not.toContain('## Clarity Scores');
+  });
+});
+```
+
+- [ ] **Step 3.2: Run tests to verify they fail**
+
+```bash
+pnpm vitest run tests/context/assembler.test.ts
+```
+
+Expected: FAIL — `## Clarity Scores` is not in the P2 prompt yet.
+
+- [ ] **Step 3.3: Update `src/context/assembler.ts`**
+
+**3.3a — Append `CLARITY_SCORES_PROTOCOL` to `FIVE_AXIS_SPEC_GATE`.**
+
+Locate the `FIVE_AXIS_SPEC_GATE` constant (around line 50). Replace it with:
+
+```typescript
+const CLARITY_SCORES_PROTOCOL = `
+## Clarity Scores (REQUIRED — Phase 2 only)
+After \`## Summary\`, append a section titled exactly \`## Clarity Scores\`
+with one line per axis, in this exact order:
+
+  - goal: <0.0–1.0>
+  - constraint: <0.0–1.0>
+  - success: <0.0–1.0>
+  - context: <0.0–1.0>
+
+Each score is your assessment of how clear/unambiguous that aspect of the
+spec is — independent of whether you ultimately APPROVE or REJECT:
+  - goal       — Is the desired outcome stated unambiguously?
+  - constraint — Are non-requirements / forbidden behaviors / boundary conditions explicit?
+  - success    — Are success criteria measurable and concrete?
+  - context    — Are assumptions, inputs, and prior decisions captured?
+
+Use 1.0 for "fully clear, no reviewer-to-reviewer drift expected" and 0.0 for
+"so vague that two reviewers would reasonably reach different conclusions".
+Emit numbers, not adjectives. Do not omit axes.
+`;
+
+const FIVE_AXIS_SPEC_GATE = `
+## Five-Axis Evaluation (Phase 2 — spec gate)
+평가 대상은 spec 문서다. 다음 축만 적용:
+1. Correctness — 요구사항/비요구사항/경계조건/성공기준이 명시되었는가?
+2. Readability — 섹션 구성이 명확하고 모호 표현이 없는가?
+3. Scope — 단일 구현 plan으로 분해 가능한 크기인가? 여러 독립 프로젝트 섞이지 않음?
+
+Note: Phase 1 resolves design ambiguities live with the developer. Do not penalize for missing "Open Questions" / "TODO" / deferred-items sections — those are intentionally absent.
+` + CLARITY_SCORES_PROTOCOL;
+```
+
+**3.3b — Make `structuredOutputReminder` phase-aware in `assembleGateResumePrompt`.**
+
+Locate the `structuredOutputReminder` const (around line 767). Replace it with:
+
+```typescript
+  const clarityScoresBullet = phase === 2
+    ? '- `## Clarity Scores` (4 lines: goal/constraint/success/context, each 0.0–1.0)\n'
+    : '';
+  const structuredOutputReminder =
+    'Respond with the same structured sections as before:\n' +
+    '- `## Verdict` (exactly `APPROVE` or `REJECT`)\n' +
+    '- `## Comments` (each finding labeled `[P0|P1|P2|P3]`, with Location/Issue/Suggestion/Evidence)\n' +
+    '- `## Summary` (1–2 sentences)\n' +
+    clarityScoresBullet +
+    'Approval rule: `APPROVE` only if there are zero P0 and zero P1 findings.\n';
+```
+
+- [ ] **Step 3.4: Run tests to verify they pass**
+
+```bash
+pnpm vitest run tests/context/assembler.test.ts
+```
+
+Expected: PASS for all tests including the new Clarity Scores assertions.
+
+- [ ] **Step 3.5: Typecheck**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: zero errors.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add src/context/assembler.ts tests/context/assembler.test.ts
+git commit -m "feat(assembler): inject CLARITY_SCORES_PROTOCOL into P2 gate prompt and resume reminder"
+```
+
+---
+
+## Task 4: `gate.ts` + `runner.ts` wiring + integration tests
+
+**Files:**
+- Modify: `src/phases/gate.ts`
+- Modify: `src/phases/runner.ts`
+- Modify: `tests/phases/gate.test.ts`
+
+- [ ] **Step 4.1: Write failing integration tests**
+
+Add to `tests/phases/gate.test.ts` (at the end of the file):
+
+```typescript
+import { loadAmbiguityThreshold } from '../../src/phases/ambiguity.js';
+
+// ─── ambiguity gate integration ──────────────────────────────────────────────
+
+describe('runGatePhaseInteractive — ambiguity gate (phase 2)', () => {
+  it('phase-2 with low clarity scores → result has ambiguityVetoed and REJECT verdict', async () => {
+    const dir = makeTmpDir();
+    const runDir = dir;
+
+    // Write verdict file with low goal/constraint scores (ambiguity > 0.2)
+    const verdictContent = [
+      '## Verdict', 'APPROVE',
+      '## Comments', '- looks fine',
+      '## Summary', 'OK.',
+      '## Clarity Scores',
+      '- goal: 0.45', '- constraint: 0.60', '- success: 0.85', '- context: 0.90',
+    ].join('\n');
+    fs.writeFileSync(path.join(runDir, 'gate-2-verdict.md'), verdictContent);
+
+    const { assembleGatePrompt: asmMock } = await import('../../src/context/assembler.js');
+    vi.mocked(asmMock).mockReturnValue('mocked prompt');
+
+    const { waitForPhaseCompletion } = await import('../../src/phases/interactive.js');
+    vi.mocked(waitForPhaseCompletion).mockResolvedValue({ status: 'completed' });
+
+    const { createInitialState } = await import('../../src/state.js');
+    const state = createInitialState('test-run', '/task.md', 'abc123', false);
+    state.phasePresets['2'] = 'codex-high';
+    state.tmuxSession = 'mock-session';
+    state.tmuxWorkspacePane = 'mock-pane';
+
+    const result = await runGatePhase(2, state, dir, runDir, dir);
+
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.verdict).toBe('REJECT');
+      expect(result.ambiguityVetoed).toBe(true);
+      expect(result.clarityScores).toBeDefined();
+      expect(result.ambiguity).toBeGreaterThan(0.2);
+    }
+  });
+
+  it('phase-4 result does NOT have clarityScores or ambiguity', async () => {
+    const dir = makeTmpDir();
+
+    const verdictContent = [
+      '## Verdict', 'APPROVE',
+      '## Summary', 'Plan is solid.',
+      '## Clarity Scores',
+      '- goal: 0.90', '- constraint: 0.85', '- success: 0.95', '- context: 0.80',
+    ].join('\n');
+    fs.writeFileSync(path.join(dir, 'gate-4-verdict.md'), verdictContent);
+
+    const { assembleGatePrompt: asmMock } = await import('../../src/context/assembler.js');
+    vi.mocked(asmMock).mockReturnValue('mocked prompt');
+
+    const { waitForPhaseCompletion } = await import('../../src/phases/interactive.js');
+    vi.mocked(waitForPhaseCompletion).mockResolvedValue({ status: 'completed' });
+
+    const { createInitialState } = await import('../../src/state.js');
+    const state = createInitialState('test-run-4', '/task.md', 'abc123', false);
+    state.phasePresets['4'] = 'codex-high';
+    state.tmuxSession = 'mock-session';
+    state.tmuxWorkspacePane = 'mock-pane';
+
+    const result = await runGatePhase(4, state, dir, dir, dir);
+
+    expect(result.type).toBe('verdict');
+    expect(result.clarityScores).toBeUndefined();
+    expect(result.ambiguity).toBeUndefined();
+    expect(result.ambiguityVetoed).toBeUndefined();
+  });
+
+  it('sidecar replay of legacy gate-2-result.json (no scores) returns verdict unchanged, no warning', async () => {
+    const dir = makeTmpDir();
+    const legacyRaw = '## Verdict\nAPPROVE\n## Summary\nOK.';
+    const legacyResult = { exitCode: 0, timestamp: Date.now(), runner: 'codex' };
+    writeSidecars(dir, 2, legacyRaw, legacyResult as GateResult);
+
+    const { createInitialState } = await import('../../src/state.js');
+    const state = createInitialState('legacy-run', '/task.md', 'abc123', false);
+    state.phasePresets['2'] = 'codex-high';
+
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const result = await runGatePhase(2, state, dir, dir, dir, { value: true });
+    warnSpy.mockRestore();
+
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.verdict).toBe('APPROVE');
+    }
+    expect(result.clarityScores).toBeUndefined();
+    expect(result.ambiguityVetoed).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 4.2: Run tests to verify they fail**
+
+```bash
+pnpm vitest run tests/phases/gate.test.ts
+```
+
+Expected: FAIL — `applyAmbiguityGate` not yet called from `gate.ts`.
+
+- [ ] **Step 4.3: Wire `applyAmbiguityGate` into `src/phases/gate.ts`**
+
+**4.3a — Add import** at the top of `src/phases/gate.ts`, after the existing `./verdict.js` import:
+
+```typescript
+import { loadAmbiguityThreshold, applyAmbiguityGate } from './ambiguity.js';
+```
+
+**4.3b — Claude path** (inside the `if (runner === 'claude')` block, around line 318). Change:
+
+```typescript
+    const result: GatePhaseResult = { ...rawResult, runner, promptBytes, durationMs };
+    if (state.currentPhase !== phase) return result;
+    await _persistSidecars(result, runDir, phase, runner, promptBytes, durationMs, preset);
+    return result;
+```
+
+to:
+
+```typescript
+    let result: GatePhaseResult = { ...rawResult, runner, promptBytes, durationMs };
+    if (phase === 2) {
+      const threshold = loadAmbiguityThreshold();
+      result = applyAmbiguityGate(result, result.rawOutput ?? '', threshold);
+    }
+    if (state.currentPhase !== phase) return result;
+    await _persistSidecars(result, runDir, phase, runner, promptBytes, durationMs, preset);
+    return result;
+```
+
+**4.3c — Codex path** (after Step 10 in the Codex path, before Step 11 codexTokens block). Locate `// Step 11: Collect codexTokens` and insert before it:
+
+```typescript
+  // Apply ambiguity gate for phase 2 (after verdict is built, before sidecars)
+  if (phase === 2) {
+    const threshold = loadAmbiguityThreshold();
+    gateResult = applyAmbiguityGate(gateResult, gateResult.rawOutput ?? '', threshold);
+  }
+```
+
+- [ ] **Step 4.4: Wire new fields into `src/phases/runner.ts`**
+
+Locate the APPROVE branch `gate_verdict` emission (around line 611) and the REJECT branch (around line 663). In **both** emission sites, add the 5 new optional fields after the existing `preset:` line:
+
+```typescript
+          ...(phase === 2 && result.clarityScores !== undefined ? { clarityScores: result.clarityScores } : {}),
+          ...(phase === 2 && result.ambiguity !== undefined ? { ambiguity: result.ambiguity } : {}),
+          ...(phase === 2 && result.ambiguityThreshold !== undefined ? { ambiguityThreshold: result.ambiguityThreshold } : {}),
+          ...(phase === 2 && result.ambiguityVetoed !== undefined ? { ambiguityVetoed: result.ambiguityVetoed } : {}),
+          ...(phase === 2 && result.clarityParseError !== undefined ? { clarityParseError: result.clarityParseError } : {}),
+```
+
+Also update the import at the top of `runner.ts` to include `ClarityScores` (for TypeScript to resolve the spread types — it does this automatically through `GatePhaseResult`, but if TypeScript needs an explicit import add `import type { ClarityScores } from '../types.js';`).
+
+- [ ] **Step 4.5: Run the gate tests**
+
+```bash
+pnpm vitest run tests/phases/gate.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4.6: Run the full test suite**
+
+```bash
+pnpm vitest run
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4.7: Typecheck**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: zero errors.
+
+- [ ] **Step 4.8: Add runner-level gate_verdict emission tests** (SC7)
+
+Add to `tests/phases/runner.test.ts` inside the existing `describe('handleGatePhase — gate_verdict emission (APPROVE)', ...)` block:
+
+```typescript
+  it('emits gate_verdict with clarityScores/ambiguity/ambiguityVetoed on phase-2 APPROVE (vetoed to REJECT)', async () => {
+    const runDir = makeTmpDir();
+    const state = makeState({ currentPhase: 2 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    vi.mocked(runGatePhase).mockResolvedValueOnce({
+      type: 'verdict',
+      verdict: 'REJECT',
+      comments: '- **[P1]** synthetic veto\nScope: design',
+      rawOutput: '',
+      runner: 'codex',
+      promptBytes: 1000,
+      durationMs: 5000,
+      clarityScores: { goal: 0.45, constraint: 0.60, success: 0.85, context: 0.90 },
+      ambiguity: 0.3475,
+      ambiguityThreshold: 0.2,
+      ambiguityVetoed: true,
+    } as any);
+
+    try {
+      await handleGatePhase(2, state, HDIR, runDir, CWD, createNoOpInputManager(), logger, { value: false });
+      const events = readEvents(eventsPath);
+      const verdict = events.find((e: any) => e.event === 'gate_verdict');
+      expect(verdict).toBeDefined();
+      expect(verdict.phase).toBe(2);
+      expect(verdict.clarityScores).toEqual({ goal: 0.45, constraint: 0.60, success: 0.85, context: 0.90 });
+      expect(verdict.ambiguity).toBeCloseTo(0.3475, 4);
+      expect(verdict.ambiguityThreshold).toBe(0.2);
+      expect(verdict.ambiguityVetoed).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('does NOT emit clarityScores/ambiguity fields on phase-4 gate_verdict', async () => {
+    const runDir = makeTmpDir();
+    const state = makeState({ currentPhase: 4 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    vi.mocked(runGatePhase).mockResolvedValueOnce({
+      type: 'verdict',
+      verdict: 'APPROVE',
+      comments: '',
+      rawOutput: '',
+      runner: 'codex',
+      promptBytes: 1000,
+      durationMs: 5000,
+      // No clarity fields — should NOT appear in event
+    } as any);
+
+    try {
+      await handleGatePhase(4, state, HDIR, runDir, CWD, createNoOpInputManager(), logger, { value: false });
+      const events = readEvents(eventsPath);
+      const verdict = events.find((e: any) => e.event === 'gate_verdict');
+      expect(verdict).toBeDefined();
+      expect(verdict.phase).toBe(4);
+      expect(verdict.clarityScores).toBeUndefined();
+      expect(verdict.ambiguity).toBeUndefined();
+      expect(verdict.ambiguityVetoed).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+```
+
+- [ ] **Step 4.9: Run full test suite after runner tests**
+
+```bash
+pnpm vitest run tests/phases/runner.test.ts
+```
+
+Expected: PASS including the two new gate_verdict emission tests.
+
+- [ ] **Step 4.10: Commit**
+
+```bash
+git add src/phases/gate.ts src/phases/runner.ts tests/phases/gate.test.ts tests/phases/runner.test.ts
+git commit -m "feat(gate): wire applyAmbiguityGate at P2 and pass clarity fields through gate_verdict"
+```
+
+---
+
+## Task 5: Documentation
+
+**Files:**
+- Modify: `docs/HOW-IT-WORKS.md`
+- Modify: `docs/HOW-IT-WORKS.ko.md`
+- Modify: `README.md`
+- Modify: `README.ko.md`
+
+- [ ] **Step 5.1: Update `docs/HOW-IT-WORKS.md`**
+
+In the **Phase 2 spec gate** section (near line 156), add a paragraph after the existing P2 Spec Gate description:
+
+```markdown
+**Clarity Scores & Ambiguity Veto (P2 only).** When running the spec gate (full flow P2), Codex is instructed to emit a `## Clarity Scores` block with four axis scores (goal, constraint, success, context), each in [0.0, 1.0]. Harness computes `ambiguity = 1 − Σ(score × weight)` with weights `{goal: 0.35, constraint: 0.25, success: 0.30, context: 0.10}`. If `ambiguity > HARNESS_GATE_AMBIGUITY_THRESHOLD` (default `0.2`) and the qualitative verdict was APPROVE, harness rewrites it to REJECT with a synthetic P1 comment naming the lowest-scoring axes and appends `Scope: design` to route the retry back to Phase 1. Setting the env var to `off` disables the veto while still parsing and logging scores. Parse failure is fail-open — the qualitative verdict stands and `clarityParseError: true` is attached to the event. This feature applies to full-flow P2 only; light-flow P2 (`FIVE_AXIS_DESIGN_GATE_LIGHT`) is unchanged.
+```
+
+In the **events.jsonl** section's `gate_verdict` row description (near line 346), extend it to mention the new fields:
+
+```markdown
+The `gate_verdict` event for Phase 2 additionally carries five optional fields when the ambiguity gate ran: `clarityScores` (object with goal/constraint/success/context), `ambiguity` (weighted score), `ambiguityThreshold` (threshold in effect), `ambiguityVetoed` (true if APPROVE was rewritten), `clarityParseError` (true if score parsing failed). These fields are absent on P4/P7 events.
+```
+
+In the **env-var table** (near line 88 in HOW-IT-WORKS), add a new row:
+
+```markdown
+- `HARNESS_GATE_AMBIGUITY_THRESHOLD=0.2` — P2 spec gate ambiguity veto threshold [0, 1]. `=off` to disable veto (scores still logged). Invalid value → veto disabled + one stderr warning.
+```
+
+- [ ] **Step 5.2: Update `docs/HOW-IT-WORKS.ko.md`**
+
+Apply the equivalent changes in Korean:
+
+**Phase 2 spec gate 섹션** 추가 단락:
+
+```markdown
+**명확성 점수 & 모호성 거부권 (P2 전용).** 전체 플로우 P2 spec gate에서 Codex는 `## Clarity Scores` 블록(4개 축: goal, constraint, success, context, 각 [0.0, 1.0])을 출력하도록 지시받습니다. 하네스는 `ambiguity = 1 − Σ(score × weight)` (가중치: goal 0.35, constraint 0.25, success 0.30, context 0.10)를 계산합니다. `ambiguity > HARNESS_GATE_AMBIGUITY_THRESHOLD` (기본값 `0.2`)이고 정성 판단이 APPROVE였다면, 하네스는 REJECT로 재작성하며 점수가 가장 낮은 두 축을 명시하는 P1 합성 코멘트를 생성합니다. 환경 변수를 `off`로 설정하면 거부권이 비활성화되지만 점수는 여전히 파싱·로깅됩니다. 파싱 실패는 fail-open 처리됩니다. 이 기능은 full-flow P2 전용입니다; light-flow P2는 변경되지 않습니다.
+```
+
+**events.jsonl gate_verdict 이벤트** 설명 업데이트:
+
+```markdown
+Phase 2의 `gate_verdict` 이벤트에는 모호성 게이트 실행 시 다음 5개의 선택적 필드가 추가됩니다: `clarityScores`, `ambiguity`, `ambiguityThreshold`, `ambiguityVetoed`, `clarityParseError`. 이 필드들은 P4/P7 이벤트에는 포함되지 않습니다.
+```
+
+**env var 목록** 추가:
+
+```markdown
+- `HARNESS_GATE_AMBIGUITY_THRESHOLD=0.2` — P2 spec gate 모호성 거부권 임계값 [0, 1]. `=off`로 비활성화(점수는 여전히 로깅). 유효하지 않은 값 → 거부권 비활성화 + stderr 경고 1회.
+```
+
+- [ ] **Step 5.3: Update `README.md`**
+
+In the **stagnation env-var table** section (around line 231), add a new row to the table:
+
+```markdown
+| `HARNESS_GATE_AMBIGUITY_THRESHOLD` | `0.2` | P2 spec gate ambiguity veto threshold [0, 1]. Set to `off` to disable veto (scores still logged). Invalid value → veto disabled + one stderr warning. |
+```
+
+In the description of the spec gate (wherever Phase 2 is described in the flow section), add a one-liner:
+
+```markdown
+Spec gate (P2) additionally computes a weighted ambiguity score from Codex's `## Clarity Scores` output and vetoes APPROVE→REJECT when `ambiguity > HARNESS_GATE_AMBIGUITY_THRESHOLD` (default 0.2).
+```
+
+- [ ] **Step 5.4: Update `README.ko.md`**
+
+Same changes, Korean translation:
+
+Table row:
+
+```markdown
+| `HARNESS_GATE_AMBIGUITY_THRESHOLD` | `0.2` | P2 spec gate 모호성 거부권 임계값 [0, 1]. `off`로 비활성화(점수는 여전히 로깅). 유효하지 않은 값 → 거부권 비활성화 + stderr 경고 1회. |
+```
+
+Spec gate note:
+
+```markdown
+Spec gate (P2)는 Codex의 `## Clarity Scores` 출력에서 가중 모호성 점수를 추가로 계산하며, `ambiguity > HARNESS_GATE_AMBIGUITY_THRESHOLD`(기본값 0.2)인 경우 APPROVE를 REJECT로 재작성합니다.
+```
+
+- [ ] **Step 5.5: Run the full test suite one final time**
+
+```bash
+pnpm vitest run
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5.6: Typecheck and build**
+
+```bash
+pnpm tsc --noEmit && pnpm build
+```
+
+Expected: zero errors, build succeeds.
+
+- [ ] **Step 5.7: Commit**
+
+```bash
+git add docs/HOW-IT-WORKS.md docs/HOW-IT-WORKS.ko.md README.md README.ko.md
+git commit -m "docs: document P2 ambiguity gate, env var, and gate_verdict new fields"
+```
+
+---
+
+## Eval Checklist
+
+The machine-readable checklist is at `.harness/2026-05-06-p2-spec-gate-ambiguity-9fa2/checklist.json`.
+
+Verification commands:
+```bash
+pnpm tsc --noEmit   # typecheck
+pnpm vitest run     # full test suite
+pnpm build          # tsc + copy-assets
+```

--- a/docs/process/evals/2026-05-06-p2-spec-gate-ambiguity-9fa2-eval.md
+++ b/docs/process/evals/2026-05-06-p2-spec-gate-ambiguity-9fa2-eval.md
@@ -50,103 +50,103 @@
 
  RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/ambiguity-gate
 
- ✓ tests/state.test.ts (53 tests) 45ms
- ✓ tests/context/skills-rendering.test.ts (45 tests) 71ms
- ✓ tests/logger.test.ts (32 tests) 91ms
- ✓ tests/phases/gate.test.ts (35 tests) 149ms
- ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 36ms
- ✓ tests/phases/gate-resume.test.ts (12 tests) 120ms
- ✓ tests/signal.test.ts (17 tests) 395ms
- ✓ tests/runners/claude-usage.test.ts (17 tests) 94ms
- ✓ tests/commands/inner.test.ts (25 tests) 202ms
- ✓ tests/phases/runner.test.ts (85 tests) 612ms
- ✓ tests/integration/logging.test.ts (15 tests) 251ms
- ✓ tests/phases/terminal-ui.test.ts (18 tests) 112ms
- ✓ tests/lock.test.ts (20 tests) 203ms
- ✓ tests/commands/footer-ticker.test.ts (10 tests) 61ms
- ✓ tests/phases/stagnation.test.ts (32 tests) 12ms
- ✓ tests/phases/runner-token-capture.test.ts (8 tests) 19ms
- ✓ tests/phases/verify.test.ts (15 tests) 26ms
- ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 6ms
- ✓ tests/orphan-cleanup.test.ts (20 tests) 75ms
- ✓ tests/integration/codex-session-resume.test.ts (6 tests) 106ms
- ✓ tests/preflight.test.ts (27 tests | 1 skipped) 156ms
- ✓ tests/runners/codex.test.ts (21 tests) 1587ms
-   ✓ spawnCodexInteractiveInPane — pane injection > sends a top-level `codex` TUI command (not `codex exec`) with prompt arg, sandbox, CODEX_HOME 304ms
-   ✓ spawnCodexInteractiveInPane — pane injection > uses --dangerously-bypass-approvals-and-sandbox for phase 5 312ms
-   ✓ spawnCodexInPane — fresh > sends fresh top-level `codex` TUI command with prompt as cat-substitution arg 303ms
-   ✓ spawnCodexInPane — fresh in non-git cwd > does NOT add --skip-git-repo-check even when cwd is non-git (trust-entry handles it) 302ms
-   ✓ spawnCodexInPane — resume > sends top-level `codex resume <sessionId>` TUI command with prompt arg 303ms
- ✓ tests/integration/light-flow.test.ts (4 tests) 256ms
- ✓ tests/context/assembler.test.ts (82 tests) 1673ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 360ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 515ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 603ms
+ ✓ tests/state.test.ts (53 tests) 50ms
+ ✓ tests/logger.test.ts (32 tests) 85ms
+ ✓ tests/context/skills-rendering.test.ts (45 tests) 78ms
+ ✓ tests/phases/gate.test.ts (36 tests) 152ms
+ ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 44ms
+ ✓ tests/phases/gate-resume.test.ts (12 tests) 156ms
+ ✓ tests/runners/claude-usage.test.ts (17 tests) 90ms
+ ✓ tests/signal.test.ts (17 tests) 411ms
+ ✓ tests/phases/runner.test.ts (85 tests) 640ms
+ ✓ tests/phases/terminal-ui.test.ts (18 tests) 145ms
+ ✓ tests/commands/inner.test.ts (25 tests) 289ms
+ ✓ tests/integration/logging.test.ts (15 tests) 305ms
+ ✓ tests/commands/footer-ticker.test.ts (10 tests) 97ms
+ ✓ tests/lock.test.ts (20 tests) 248ms
+ ✓ tests/phases/stagnation.test.ts (32 tests) 18ms
+ ✓ tests/phases/verify.test.ts (15 tests) 29ms
+ ✓ tests/runners/codex.test.ts (21 tests) 1617ms
+   ✓ spawnCodexInteractiveInPane — pane injection > sends a top-level `codex` TUI command (not `codex exec`) with prompt arg, sandbox, CODEX_HOME 308ms
+   ✓ spawnCodexInteractiveInPane — pane injection > uses --dangerously-bypass-approvals-and-sandbox for phase 5 310ms
+   ✓ spawnCodexInPane — fresh > sends fresh top-level `codex` TUI command with prompt as cat-substitution arg 305ms
+   ✓ spawnCodexInPane — fresh in non-git cwd > does NOT add --skip-git-repo-check even when cwd is non-git (trust-entry handles it) 309ms
+   ✓ spawnCodexInPane — resume > sends top-level `codex resume <sessionId>` TUI command with prompt arg 309ms
+ ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 11ms
+ ✓ tests/phases/runner-token-capture.test.ts (8 tests) 16ms
+ ✓ tests/integration/codex-session-resume.test.ts (6 tests) 76ms
+ ✓ tests/orphan-cleanup.test.ts (20 tests) 21ms
  ✓ tests/phases/ambiguity.test.ts (19 tests) 5ms
- ✓ tests/phases/verdict.test.ts (31 tests) 5ms
- ✓ tests/resume-light.test.ts (10 tests) 14ms
- ✓ tests/tmux.test.ts (34 tests) 814ms
-   ✓ pollForPidFile > returns null on timeout when file never appears 402ms
-   ✓ pollForPidFile > returns null when file contains non-numeric content 406ms
- ✓ tests/runners/codex-resume.test.ts (8 tests) 60ms
- ✓ tests/context/assembler-resume.test.ts (10 tests) 59ms
- ✓ tests/commands/inner-footer.test.ts (2 tests) 11ms
- ✓ tests/runners/codex-isolation.test.ts (10 tests) 21ms
- ✓ tests/integration/gate-stagnation.test.ts (2 tests) 12ms
- ✓ tests/commands/resume-cmd.test.ts (12 tests) 2188ms
-   ✓ resumeCommand > Case 2 stale pane (reused-mode): outer session stays alive, recursion creates new control window 325ms
- ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 5ms
- ✓ tests/state-invalidation.test.ts (5 tests) 13ms
- ✓ tests/runners/claude.test.ts (4 tests) 5ms
- ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 69ms
- ✓ tests/phases/gate-resume-escalation.test.ts (2 tests) 33ms
- ✓ tests/resume.test.ts (11 tests) 2777ms
-   ✓ resumeRun > errors when phase 5 completed but all trackedRepos implHead are null (state anomaly) 341ms
-   ✓ resumeRun > skip_phase Phase 6 with gitignored eval report: skips commit and leaves evalCommit null 302ms
- ✓ tests/runners/codex-usage.test.ts (6 tests) 311ms
-   ✓ readCodexSessionUsage — pinned sessionId > returns null when file missing 304ms
- ✓ tests/root.test.ts (10 tests) 154ms
- ✓ tests/commands/status-list.test.ts (7 tests) 597ms
- ✓ tests/context/reviewer-contract.test.ts (4 tests) 59ms
- ✓ tests/ink/components/CurrentPhase.test.tsx (10 tests) 20ms
+ ✓ tests/preflight.test.ts (27 tests | 1 skipped) 222ms
+ ✓ tests/context/assembler.test.ts (82 tests) 2333ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 463ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 1009ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 661ms
+ ✓ tests/integration/light-flow.test.ts (4 tests) 305ms
+ ✓ tests/phases/verdict.test.ts (31 tests) 4ms
+ ✓ tests/resume-light.test.ts (10 tests) 26ms
+ ✓ tests/runners/codex-resume.test.ts (8 tests) 67ms
+ ✓ tests/tmux.test.ts (34 tests) 821ms
+   ✓ pollForPidFile > returns null on timeout when file never appears 406ms
+   ✓ pollForPidFile > returns null when file contains non-numeric content 407ms
+ ✓ tests/commands/inner-footer.test.ts (2 tests) 9ms
+ ✓ tests/context/assembler-resume.test.ts (10 tests) 72ms
+ ✓ tests/runners/codex-isolation.test.ts (10 tests) 37ms
+ ✓ tests/integration/gate-stagnation.test.ts (2 tests) 23ms
+ ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 7ms
+ ✓ tests/state-invalidation.test.ts (5 tests) 47ms
+ ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 79ms
+ ✓ tests/runners/claude.test.ts (4 tests) 14ms
+ ✓ tests/commands/resume-cmd.test.ts (12 tests) 2194ms
+   ✓ resumeCommand > resumes with implicit current-run (Case 3: no session) 321ms
+ ✓ tests/phases/gate-resume-escalation.test.ts (2 tests) 72ms
+ ✓ tests/resume.test.ts (11 tests) 3379ms
+   ✓ resumeRun > exits with code 1 and non-interactive message on paused run with null pendingAction (D4b) 366ms
+   ✓ resumeRun > clears pendingAction when rerun_gate target already completed 514ms
+   ✓ resumeRun > errors when specCommit is not in git history 342ms
+   ✓ completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8) > returns false when no repo advanced (HEAD === implRetryBase) 368ms
+   ✓ completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8) > skips ancestry check for repos with implHead=null (null-safe FR-8) 336ms
+ ✓ tests/runners/codex-usage.test.ts (6 tests) 326ms
+   ✓ readCodexSessionUsage — pinned sessionId > returns null when file missing 307ms
+ ✓ tests/root.test.ts (10 tests) 186ms
+ ✓ tests/commands/status-list.test.ts (7 tests) 723ms
+ ✓ tests/context/reviewer-contract.test.ts (4 tests) 70ms
+ ✓ tests/git.test.ts (24 tests) 2682ms
+ ✓ tests/commands/jump.test.ts (6 tests) 690ms
+ ✓ tests/ink/components/CurrentPhase.test.tsx (10 tests) 34ms
  ✓ tests/ui-footer.test.ts (9 tests) 4ms
- ✓ tests/commands/jump.test.ts (6 tests) 687ms
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-WXERsW/.claude/skills:
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-F6pptw/.claude/skills:
   phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-UNmrDo/.claude/skills:
-  phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-WXERsW/.claude/skills:
-  phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-bUinqZ/.claude/skills:
-  phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-bUinqZ/.claude/skills:
-  phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-z8c98I/.claude/skills:
-  phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-ZmEPXc/.claude/skills:
-  phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-vJOWjN/.claude/skills:
-  phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-vJOWjN/.claude/skills:
-  phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-GA5kyS/.claude/skills:
-  phase-harness-codex-gate-review
-No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-RfjN6J/.claude/skills. Nothing to uninstall.
- ✓ tests/uninstall-skills.test.ts (6 tests) 20ms
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-fs0w56/.claude/skills:
-  phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-fs0w56/.claude/skills:
-  phase-harness-codex-gate-review
- ✓ tests/install-skills.test.ts (7 tests) 27ms
  ✓ tests/input.test.ts (12 tests) 3ms
- ✓ tests/multi-worktree.test.ts (11 tests) 2852ms
-   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 970ms
-   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 391ms
-   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 385ms
-   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 421ms
-   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 474ms
- ✓ tests/git.test.ts (24 tests) 2554ms
-   ✓ getGitRoot > returns repo root path 306ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-mr6Btu/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-oxVCec/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-zFDRJR/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-J3Yhez/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-Yxmrs6/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-Yxmrs6/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-J3Yhez/.claude/skills:
+  phase-harness-codex-gate-review
+ ✓ tests/install-skills.test.ts (7 tests) 22ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-udr9PQ/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-udr9PQ/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-gZ7tDu/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-gZ7tDu/.claude/skills:
+  phase-harness-codex-gate-review
+No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-68stm4/.claude/skills. Nothing to uninstall.
+ ✓ tests/uninstall-skills.test.ts (6 tests) 18ms
+ ✓ tests/multi-worktree.test.ts (11 tests) 2909ms
+   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 537ms
+   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 579ms
+   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 562ms
 ```
 
 </details>
@@ -157,8 +157,8 @@ Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install
 ```
 ⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
 ⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
-⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-PK2Qk4/phase-5-carryover-missing.md
 ⚠️  claude session resume fallback: no prior attempt id
+⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-vrW8Hf/phase-5-carryover-missing.md
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: jsonl missing
@@ -180,7 +180,6 @@ Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install
 ℹ Received control signal (SIGUSR1). Applying pending action...
 ✓ Applied: skip. Phase loop re-entering.
 ℹ Received control signal (SIGUSR1). Applying pending action...
-fatal: not a git repository (or any of the parent directories): .git
 [harness] phase=5 status=failed
 
 Recent events:
@@ -205,6 +204,7 @@ Recent events:
 (events.jsonl not present — logging disabled)
 
 Working tree:
+(git not available)
 ```
 
 </details>

--- a/docs/process/evals/2026-05-06-p2-spec-gate-ambiguity-9fa2-eval.md
+++ b/docs/process/evals/2026-05-06-p2-spec-gate-ambiguity-9fa2-eval.md
@@ -1,0 +1,240 @@
+# Auto Verification Report
+- Date: 2026-05-06
+- Related Spec: N/A
+- Related Plan: N/A
+
+## Results
+| Check | Status | Detail |
+|-------|--------|--------|
+| typecheck | pass |  |
+| test suite | pass |  |
+| build | pass |  |
+
+## Summary
+- Total: 3 checks
+- Pass: 3
+- Fail: 0
+
+## Raw Output
+
+### typecheck
+**Command:** `pnpm tsc --noEmit`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>
+
+### test suite
+**Command:** `pnpm vitest run`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+ RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/ambiguity-gate
+
+ ✓ tests/state.test.ts (53 tests) 45ms
+ ✓ tests/context/skills-rendering.test.ts (45 tests) 71ms
+ ✓ tests/logger.test.ts (32 tests) 91ms
+ ✓ tests/phases/gate.test.ts (35 tests) 149ms
+ ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 36ms
+ ✓ tests/phases/gate-resume.test.ts (12 tests) 120ms
+ ✓ tests/signal.test.ts (17 tests) 395ms
+ ✓ tests/runners/claude-usage.test.ts (17 tests) 94ms
+ ✓ tests/commands/inner.test.ts (25 tests) 202ms
+ ✓ tests/phases/runner.test.ts (85 tests) 612ms
+ ✓ tests/integration/logging.test.ts (15 tests) 251ms
+ ✓ tests/phases/terminal-ui.test.ts (18 tests) 112ms
+ ✓ tests/lock.test.ts (20 tests) 203ms
+ ✓ tests/commands/footer-ticker.test.ts (10 tests) 61ms
+ ✓ tests/phases/stagnation.test.ts (32 tests) 12ms
+ ✓ tests/phases/runner-token-capture.test.ts (8 tests) 19ms
+ ✓ tests/phases/verify.test.ts (15 tests) 26ms
+ ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 6ms
+ ✓ tests/orphan-cleanup.test.ts (20 tests) 75ms
+ ✓ tests/integration/codex-session-resume.test.ts (6 tests) 106ms
+ ✓ tests/preflight.test.ts (27 tests | 1 skipped) 156ms
+ ✓ tests/runners/codex.test.ts (21 tests) 1587ms
+   ✓ spawnCodexInteractiveInPane — pane injection > sends a top-level `codex` TUI command (not `codex exec`) with prompt arg, sandbox, CODEX_HOME 304ms
+   ✓ spawnCodexInteractiveInPane — pane injection > uses --dangerously-bypass-approvals-and-sandbox for phase 5 312ms
+   ✓ spawnCodexInPane — fresh > sends fresh top-level `codex` TUI command with prompt as cat-substitution arg 303ms
+   ✓ spawnCodexInPane — fresh in non-git cwd > does NOT add --skip-git-repo-check even when cwd is non-git (trust-entry handles it) 302ms
+   ✓ spawnCodexInPane — resume > sends top-level `codex resume <sessionId>` TUI command with prompt arg 303ms
+ ✓ tests/integration/light-flow.test.ts (4 tests) 256ms
+ ✓ tests/context/assembler.test.ts (82 tests) 1673ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 360ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 515ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 603ms
+ ✓ tests/phases/ambiguity.test.ts (19 tests) 5ms
+ ✓ tests/phases/verdict.test.ts (31 tests) 5ms
+ ✓ tests/resume-light.test.ts (10 tests) 14ms
+ ✓ tests/tmux.test.ts (34 tests) 814ms
+   ✓ pollForPidFile > returns null on timeout when file never appears 402ms
+   ✓ pollForPidFile > returns null when file contains non-numeric content 406ms
+ ✓ tests/runners/codex-resume.test.ts (8 tests) 60ms
+ ✓ tests/context/assembler-resume.test.ts (10 tests) 59ms
+ ✓ tests/commands/inner-footer.test.ts (2 tests) 11ms
+ ✓ tests/runners/codex-isolation.test.ts (10 tests) 21ms
+ ✓ tests/integration/gate-stagnation.test.ts (2 tests) 12ms
+ ✓ tests/commands/resume-cmd.test.ts (12 tests) 2188ms
+   ✓ resumeCommand > Case 2 stale pane (reused-mode): outer session stays alive, recursion creates new control window 325ms
+ ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 5ms
+ ✓ tests/state-invalidation.test.ts (5 tests) 13ms
+ ✓ tests/runners/claude.test.ts (4 tests) 5ms
+ ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 69ms
+ ✓ tests/phases/gate-resume-escalation.test.ts (2 tests) 33ms
+ ✓ tests/resume.test.ts (11 tests) 2777ms
+   ✓ resumeRun > errors when phase 5 completed but all trackedRepos implHead are null (state anomaly) 341ms
+   ✓ resumeRun > skip_phase Phase 6 with gitignored eval report: skips commit and leaves evalCommit null 302ms
+ ✓ tests/runners/codex-usage.test.ts (6 tests) 311ms
+   ✓ readCodexSessionUsage — pinned sessionId > returns null when file missing 304ms
+ ✓ tests/root.test.ts (10 tests) 154ms
+ ✓ tests/commands/status-list.test.ts (7 tests) 597ms
+ ✓ tests/context/reviewer-contract.test.ts (4 tests) 59ms
+ ✓ tests/ink/components/CurrentPhase.test.tsx (10 tests) 20ms
+ ✓ tests/ui-footer.test.ts (9 tests) 4ms
+ ✓ tests/commands/jump.test.ts (6 tests) 687ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-WXERsW/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-UNmrDo/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-WXERsW/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-bUinqZ/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-bUinqZ/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-z8c98I/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-ZmEPXc/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-vJOWjN/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-vJOWjN/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-GA5kyS/.claude/skills:
+  phase-harness-codex-gate-review
+No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-RfjN6J/.claude/skills. Nothing to uninstall.
+ ✓ tests/uninstall-skills.test.ts (6 tests) 20ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-fs0w56/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-fs0w56/.claude/skills:
+  phase-harness-codex-gate-review
+ ✓ tests/install-skills.test.ts (7 tests) 27ms
+ ✓ tests/input.test.ts (12 tests) 3ms
+ ✓ tests/multi-worktree.test.ts (11 tests) 2852ms
+   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 970ms
+   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 391ms
+   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 385ms
+   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 421ms
+   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 474ms
+ ✓ tests/git.test.ts (24 tests) 2554ms
+   ✓ getGitRoot > returns repo root path 306ms
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
+⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
+⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-PK2Qk4/phase-5-carryover-missing.md
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+[ambiguity] ## Clarity Scores section missing or malformed — fail-open, verdict unchanged
+⚠️  claude session resume fallback: jsonl missing
+ℹ Received control signal (SIGUSR1). Applying pending action...
+✓ Applied: skip. Phase loop re-entering.
+ℹ Received control signal (SIGUSR1). Applying pending action...
+✓ Applied: jump → phase 3. Phase loop re-entering.
+ℹ Received control signal (SIGUSR1). Applying pending action...
+✓ Applied: skip. Phase loop re-entering.
+ℹ Received control signal (SIGUSR1). Applying pending action...
+fatal: not a git repository (or any of the parent directories): .git
+[harness] phase=5 status=failed
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+[harness] phase=5 status=failed
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+[harness] phase=5 status=completed
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+```
+
+</details>
+
+### build
+**Command:** `pnpm build`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+> phase-harness@1.0.10 build /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/ambiguity-gate
+> tsc -p tsconfig.build.json && node scripts/copy-assets.mjs
+
+[copy-assets] copied src/context/prompts -> dist/src/context/prompts
+[copy-assets] copied src/context/skills -> dist/src/context/skills
+[copy-assets] copied src/context/skills-standalone -> dist/src/context/skills-standalone
+[copy-assets] copied src/context/playbooks -> dist/src/context/playbooks
+[copy-assets] copied scripts/harness-verify.sh -> dist/scripts/harness-verify.sh
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>

--- a/docs/process/evals/2026-05-06-p2-spec-gate-ambiguity-9fa2-eval.md
+++ b/docs/process/evals/2026-05-06-p2-spec-gate-ambiguity-9fa2-eval.md
@@ -50,103 +50,103 @@
 
  RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/ambiguity-gate
 
- ✓ tests/state.test.ts (53 tests) 50ms
+ ✓ tests/state.test.ts (53 tests) 46ms
+ ✓ tests/context/skills-rendering.test.ts (45 tests) 60ms
  ✓ tests/logger.test.ts (32 tests) 85ms
- ✓ tests/context/skills-rendering.test.ts (45 tests) 78ms
- ✓ tests/phases/gate.test.ts (36 tests) 152ms
- ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 44ms
- ✓ tests/phases/gate-resume.test.ts (12 tests) 156ms
- ✓ tests/runners/claude-usage.test.ts (17 tests) 90ms
- ✓ tests/signal.test.ts (17 tests) 411ms
- ✓ tests/phases/runner.test.ts (85 tests) 640ms
- ✓ tests/phases/terminal-ui.test.ts (18 tests) 145ms
- ✓ tests/commands/inner.test.ts (25 tests) 289ms
- ✓ tests/integration/logging.test.ts (15 tests) 305ms
- ✓ tests/commands/footer-ticker.test.ts (10 tests) 97ms
- ✓ tests/lock.test.ts (20 tests) 248ms
- ✓ tests/phases/stagnation.test.ts (32 tests) 18ms
- ✓ tests/phases/verify.test.ts (15 tests) 29ms
- ✓ tests/runners/codex.test.ts (21 tests) 1617ms
-   ✓ spawnCodexInteractiveInPane — pane injection > sends a top-level `codex` TUI command (not `codex exec`) with prompt arg, sandbox, CODEX_HOME 308ms
-   ✓ spawnCodexInteractiveInPane — pane injection > uses --dangerously-bypass-approvals-and-sandbox for phase 5 310ms
-   ✓ spawnCodexInPane — fresh > sends fresh top-level `codex` TUI command with prompt as cat-substitution arg 305ms
-   ✓ spawnCodexInPane — fresh in non-git cwd > does NOT add --skip-git-repo-check even when cwd is non-git (trust-entry handles it) 309ms
-   ✓ spawnCodexInPane — resume > sends top-level `codex resume <sessionId>` TUI command with prompt arg 309ms
- ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 11ms
- ✓ tests/phases/runner-token-capture.test.ts (8 tests) 16ms
- ✓ tests/integration/codex-session-resume.test.ts (6 tests) 76ms
- ✓ tests/orphan-cleanup.test.ts (20 tests) 21ms
- ✓ tests/phases/ambiguity.test.ts (19 tests) 5ms
- ✓ tests/preflight.test.ts (27 tests | 1 skipped) 222ms
- ✓ tests/context/assembler.test.ts (82 tests) 2333ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 463ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 1009ms
-   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 661ms
- ✓ tests/integration/light-flow.test.ts (4 tests) 305ms
+ ✓ tests/phases/gate.test.ts (37 tests) 167ms
+ ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 69ms
+ ✓ tests/phases/gate-resume.test.ts (12 tests) 173ms
+ ✓ tests/signal.test.ts (17 tests) 419ms
+ ✓ tests/runners/claude-usage.test.ts (17 tests) 111ms
+ ✓ tests/commands/inner.test.ts (25 tests) 236ms
+ ✓ tests/phases/runner.test.ts (85 tests) 507ms
+ ✓ tests/integration/logging.test.ts (15 tests) 258ms
+ ✓ tests/phases/terminal-ui.test.ts (18 tests) 99ms
+ ✓ tests/lock.test.ts (20 tests) 194ms
+ ✓ tests/commands/footer-ticker.test.ts (10 tests) 49ms
+ ✓ tests/phases/stagnation.test.ts (32 tests) 20ms
+ ✓ tests/phases/verify.test.ts (15 tests) 21ms
+ ✓ tests/phases/runner-token-capture.test.ts (8 tests) 11ms
+ ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 6ms
+ ✓ tests/integration/codex-session-resume.test.ts (6 tests) 77ms
+ ✓ tests/orphan-cleanup.test.ts (20 tests) 17ms
+ ✓ tests/preflight.test.ts (27 tests | 1 skipped) 156ms
+ ✓ tests/phases/ambiguity.test.ts (19 tests) 4ms
+ ✓ tests/runners/codex.test.ts (21 tests) 1585ms
+   ✓ spawnCodexInteractiveInPane — pane injection > sends a top-level `codex` TUI command (not `codex exec`) with prompt arg, sandbox, CODEX_HOME 310ms
+   ✓ spawnCodexInteractiveInPane — pane injection > uses --dangerously-bypass-approvals-and-sandbox for phase 5 308ms
+   ✓ spawnCodexInPane — fresh > sends fresh top-level `codex` TUI command with prompt as cat-substitution arg 304ms
+   ✓ spawnCodexInPane — fresh in non-git cwd > does NOT add --skip-git-repo-check even when cwd is non-git (trust-entry handles it) 302ms
+   ✓ spawnCodexInPane — resume > sends top-level `codex resume <sessionId>` TUI command with prompt arg 303ms
+ ✓ tests/integration/light-flow.test.ts (4 tests) 225ms
+ ✓ tests/context/assembler.test.ts (82 tests) 1689ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 374ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 571ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 539ms
  ✓ tests/phases/verdict.test.ts (31 tests) 4ms
- ✓ tests/resume-light.test.ts (10 tests) 26ms
- ✓ tests/runners/codex-resume.test.ts (8 tests) 67ms
- ✓ tests/tmux.test.ts (34 tests) 821ms
-   ✓ pollForPidFile > returns null on timeout when file never appears 406ms
-   ✓ pollForPidFile > returns null when file contains non-numeric content 407ms
- ✓ tests/commands/inner-footer.test.ts (2 tests) 9ms
- ✓ tests/context/assembler-resume.test.ts (10 tests) 72ms
- ✓ tests/runners/codex-isolation.test.ts (10 tests) 37ms
- ✓ tests/integration/gate-stagnation.test.ts (2 tests) 23ms
- ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 7ms
- ✓ tests/state-invalidation.test.ts (5 tests) 47ms
- ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 79ms
- ✓ tests/runners/claude.test.ts (4 tests) 14ms
- ✓ tests/commands/resume-cmd.test.ts (12 tests) 2194ms
-   ✓ resumeCommand > resumes with implicit current-run (Case 3: no session) 321ms
- ✓ tests/phases/gate-resume-escalation.test.ts (2 tests) 72ms
- ✓ tests/resume.test.ts (11 tests) 3379ms
-   ✓ resumeRun > exits with code 1 and non-interactive message on paused run with null pendingAction (D4b) 366ms
-   ✓ resumeRun > clears pendingAction when rerun_gate target already completed 514ms
-   ✓ resumeRun > errors when specCommit is not in git history 342ms
-   ✓ completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8) > returns false when no repo advanced (HEAD === implRetryBase) 368ms
-   ✓ completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8) > skips ancestry check for repos with implHead=null (null-safe FR-8) 336ms
- ✓ tests/runners/codex-usage.test.ts (6 tests) 326ms
+ ✓ tests/resume-light.test.ts (10 tests) 21ms
+ ✓ tests/runners/codex-resume.test.ts (8 tests) 61ms
+ ✓ tests/tmux.test.ts (34 tests) 813ms
+   ✓ pollForPidFile > returns null on timeout when file never appears 404ms
+   ✓ pollForPidFile > returns null when file contains non-numeric content 403ms
+ ✓ tests/commands/inner-footer.test.ts (2 tests) 12ms
+ ✓ tests/runners/codex-isolation.test.ts (10 tests) 33ms
+ ✓ tests/context/assembler-resume.test.ts (10 tests) 270ms
+ ✓ tests/integration/gate-stagnation.test.ts (2 tests) 25ms
+ ✓ tests/commands/resume-cmd.test.ts (12 tests) 2354ms
+   ✓ resumeCommand > resumeCommand — loggingEnabled inheritance > resume defaults to false when state has loggingEnabled=false 399ms
+ ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 6ms
+ ✓ tests/state-invalidation.test.ts (5 tests) 6ms
+ ✓ tests/runners/claude.test.ts (4 tests) 17ms
+ ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 67ms
+ ✓ tests/phases/gate-resume-escalation.test.ts (2 tests) 33ms
+ ✓ tests/resume.test.ts (11 tests) 2983ms
+   ✓ resumeRun > skip_phase Phase 6 with gitignored eval report: skips commit and leaves evalCommit null 563ms
+   ✓ completeInteractivePhaseFromFreshSentinel — Phase 5 multi-repo (FR-8) > returns true and sets implHead when any repo advanced 405ms
+ ✓ tests/runners/codex-usage.test.ts (6 tests) 318ms
    ✓ readCodexSessionUsage — pinned sessionId > returns null when file missing 307ms
- ✓ tests/root.test.ts (10 tests) 186ms
- ✓ tests/commands/status-list.test.ts (7 tests) 723ms
- ✓ tests/context/reviewer-contract.test.ts (4 tests) 70ms
- ✓ tests/git.test.ts (24 tests) 2682ms
- ✓ tests/commands/jump.test.ts (6 tests) 690ms
- ✓ tests/ink/components/CurrentPhase.test.tsx (10 tests) 34ms
- ✓ tests/ui-footer.test.ts (9 tests) 4ms
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-F6pptw/.claude/skills:
+ ✓ tests/root.test.ts (10 tests) 173ms
+ ✓ tests/commands/status-list.test.ts (7 tests) 647ms
+ ✓ tests/context/reviewer-contract.test.ts (4 tests) 64ms
+ ✓ tests/ink/components/CurrentPhase.test.tsx (10 tests) 25ms
+ ✓ tests/git.test.ts (24 tests) 2627ms
+   ✓ isAncestor > returns false when not an ancestor 449ms
+ ✓ tests/ui-footer.test.ts (9 tests) 3ms
+ ✓ tests/commands/jump.test.ts (6 tests) 662ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-uzhoXP/.claude/skills:
   phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-UqEKGN/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-uzhoXP/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-jTrocq/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-I2S5rk/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-I2S5rk/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-C2hAPA/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-I5swkw/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-I5swkw/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-3cJyRP/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-vtC76U/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-vtC76U/.claude/skills:
+  phase-harness-codex-gate-review
+No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-2rRFjh/.claude/skills. Nothing to uninstall.
  ✓ tests/input.test.ts (12 tests) 3ms
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-mr6Btu/.claude/skills:
-  phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-oxVCec/.claude/skills:
-  phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-zFDRJR/.claude/skills:
-  phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-J3Yhez/.claude/skills:
-  phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-Yxmrs6/.claude/skills:
-  phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-Yxmrs6/.claude/skills:
-  phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-J3Yhez/.claude/skills:
-  phase-harness-codex-gate-review
- ✓ tests/install-skills.test.ts (7 tests) 22ms
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-udr9PQ/.claude/skills:
-  phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-udr9PQ/.claude/skills:
-  phase-harness-codex-gate-review
-Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-gZ7tDu/.claude/skills:
-  phase-harness-codex-gate-review
-Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-gZ7tDu/.claude/skills:
-  phase-harness-codex-gate-review
-No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-68stm4/.claude/skills. Nothing to uninstall.
- ✓ tests/uninstall-skills.test.ts (6 tests) 18ms
- ✓ tests/multi-worktree.test.ts (11 tests) 2909ms
-   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 537ms
-   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 579ms
-   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 562ms
+ ✓ tests/install-skills.test.ts (7 tests) 16ms
+ ✓ tests/uninstall-skills.test.ts (6 tests) 13ms
+ ✓ tests/multi-worktree.test.ts (11 tests) 2940ms
+   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 535ms
+   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 856ms
+   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 399ms
+   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 439ms
+   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 460ms
 ```
 
 </details>
@@ -156,9 +156,9 @@ No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/un
 
 ```
 ⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
+⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-7tfl1f/phase-5-carryover-missing.md
 ⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
 ⚠️  claude session resume fallback: no prior attempt id
-⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-vrW8Hf/phase-5-carryover-missing.md
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: no prior attempt id
 ⚠️  claude session resume fallback: jsonl missing
@@ -180,6 +180,7 @@ No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/un
 ℹ Received control signal (SIGUSR1). Applying pending action...
 ✓ Applied: skip. Phase loop re-entering.
 ℹ Received control signal (SIGUSR1). Applying pending action...
+fatal: not a git repository (or any of the parent directories): .git
 [harness] phase=5 status=failed
 
 Recent events:
@@ -204,7 +205,6 @@ Recent events:
 (events.jsonl not present — logging disabled)
 
 Working tree:
-(git not available)
 ```
 
 </details>

--- a/docs/specs/2026-05-06-p2-spec-gate-ambiguity-9fa2-design.md
+++ b/docs/specs/2026-05-06-p2-spec-gate-ambiguity-9fa2-design.md
@@ -1,0 +1,374 @@
+# P2 Spec Gate — Quantitative Ambiguity Score
+
+Related artifacts:
+- Task: `.harness/2026-05-06-p2-spec-gate-ambiguity-9fa2/task.md`
+- Decisions log: `.harness/2026-05-06-p2-spec-gate-ambiguity-9fa2/decisions.md`
+- Reference (referenced in task): Q00/ouroboros — Ambiguity score gate (Goal/Constraint/Success/Context weights, threshold ≤0.2)
+
+## Context & Decisions
+
+**Problem**. P2 spec gate today is purely qualitative: Codex emits APPROVE/REJECT under the FIVE_AXIS_SPEC_GATE rubric (Correctness / Readability / Scope), and the harness honors that verdict directly. The first dogfood run on this very task showed the failure mode: identical spec, R1 → REJECT, R2 → APPROVE. Nothing changed in the spec between rounds; verdict drift came from reviewer "condition" alone. The qualitative-only contract has no deterministic floor against this kind of noise.
+
+**Goal**. Add a *quantitative* clarity score emitted by Codex alongside the qualitative verdict, compute a weighted ambiguity, and use it as a deterministic veto floor on top of the existing verdict. When ambiguity exceeds a threshold, harness rewrites APPROVE → REJECT with synthetic feedback that points at the lowest-scoring axes; when it doesn't, the existing qualitative verdict stands. The score is also attached to `gate_verdict` events for post-hoc analysis regardless of whether it triggered a veto. Scope is **P2 only**; P4 and P7 are unchanged in this iteration.
+
+**Decisions made during brainstorming** (each resolved live with the developer; no deferred questions):
+
+1. **Threshold breach semantics — Veto.** When `verdict=APPROVE` and `ambiguity > threshold`, harness rewrites verdict to REJECT with synthetic P1 feedback. The alternatives — observational-only logging, or soft alerts — would not address the noise problem the task identifies, since they don't change behavior on identical specs.
+
+2. **Axis set — 4 axes (Goal / Constraint / Success / Context).** Matches the ouroboros reference. Distinct from FIVE_AXIS_SPEC_GATE's verdict axes (Correctness / Readability / Scope), which remain unchanged. Verdict axes answer "is this acceptable?"; clarity axes answer "is this ambiguous?". Weights baked into the harness, not env-tunable: `goal=0.35, constraint=0.25, success=0.30, context=0.10` (sum 1.0). Goal+Success carry the most weight because that is where ambiguity historically breaks implementation. Context is loosest because partial context is legitimately common in early specs.
+
+3. **Codex output format — line-based markdown.** New `## Clarity Scores` section appended after `## Summary`, one bullet per axis: `- goal: 0.85`. No JSON, no fenced block — keeps token cost negligible (~30 tokens output, ~80 tokens added prompt) and avoids JSON-adherence failure modes. No new dependency.
+
+4. **Env var — `HARNESS_GATE_AMBIGUITY_THRESHOLD`.** Default `0.2`. Direction: `ambiguity > threshold` triggers veto (boundary inclusive on the pass side, matching ouroboros's "≤0.2"). Special value `off` (case-insensitive) disables the veto while still parsing and logging scores. Invalid values (non-numeric, out of `[0, 1]`) emit one stderr warning and disable the veto for the run (fail-open).
+
+5. **Autonomous mode — no flow change.** A veto-rewritten REJECT enters the existing `handleGateReject` path: `gateRetries` increments, retry-limit handling is unchanged, the existing PR #96 retry-oscillation detector still applies, autonomous-mode force-pass at attempt 4 still applies. There is no new force-pass mechanism specific to ambiguity. A veto can be force-passed at attempt 4 in autonomous mode just like any other REJECT — the score remains in events.jsonl for post-hoc accountability.
+
+6. **Veto-rewrite location — `src/phases/gate.ts`, after verdict construction, before sidecar persistence.** Keeps `runner.ts`'s control flow clean (single REJECT branch), and makes the rewritten verdict the canonical persisted result (sidecar replay sees the rewritten verdict, not the pre-rewrite APPROVE).
+
+7. **Sidecar replay — no re-application.** When a sidecar (`gate-2-result.json`) is replayed, the rewritten verdict is read back as-is. `applyAmbiguityGate` is **not** invoked on the replay branch. This is correct because (a) the decision is already baked in at write time, and (b) legacy sidecars predating this feature have no scores and should not be re-evaluated against the new threshold. Live runs after this change persist the post-rewrite result + scores.
+
+8. **Temperature override — deferred.** The ouroboros reference uses temperature 0.1 for reproducibility. Our `runners/codex.ts` does not currently expose a temperature flag, and adding `-c temperature=0.1` would either require per-phase plumbing or change behavior across all phases. High `model_reasoning_effort` already constrains variance; if dogfood data shows score instability, follow up in a separate change.
+
+9. **Scope tag rewrite — `Scope: design`.** When a veto rewrite happens, the synthetic comment block is followed by `Scope: design` so `getGateRejectReopenTarget` routes the retry to P1 (where the spec lives). This matches the existing reject-routing convention.
+
+## Complexity
+
+Medium — new module (`ambiguity.ts`) + parser additions in `verdict.ts` + multi-layer call sites (`assembler.ts`, `gate.ts`, `runner.ts`, `types.ts`). Not a single-file change (rules out Small) and not a subsystem refactor (rules out Large).
+
+## Goals
+
+- G1. P2 spec gate emits a quantitative `## Clarity Scores` block with 4 axes (goal, constraint, success, context), each in `[0.0, 1.0]`.
+- G2. Harness computes weighted ambiguity = `1 − Σ(score_axis × weight_axis)` and attaches it to the in-memory `GatePhaseResult` and to the `gate_verdict` event in `events.jsonl`.
+- G3. When `ambiguity > HARNESS_GATE_AMBIGUITY_THRESHOLD` (default 0.2) and the qualitative verdict was APPROVE, harness rewrites the verdict to REJECT with synthetic P1 feedback that names the lowest-scoring axes. The synthetic feedback flows through the existing `gate-2-feedback.md` → P1 reopen pathway unchanged.
+- G4. Threshold is configurable via env var; setting `HARNESS_GATE_AMBIGUITY_THRESHOLD=off` disables the veto while still parsing and logging scores.
+- G5. Score parse failure (missing section, missing axis, out-of-range axis, malformed line) is fail-open: qualitative verdict stands, `clarityParseError: true` is attached to the event, and exactly one stderr warning is emitted per process (warned-once pattern).
+- G6. Existing `events.jsonl` consumers, sidecar replay paths, and gate flow at P4/P7 are untouched. Legacy sidecars and legacy events.jsonl entries (no score fields) replay correctly.
+- G7. Autonomous mode behavior is unchanged: veto-rewritten REJECT goes through the same retry / stagnation / force-pass machinery as any other REJECT.
+
+## Non-Goals
+
+- NG1. No score emission, parsing, or veto for **P4 (plan gate)** or **P7 (eval gate)**. The Codex contract for those gates is untouched. Their `gate_verdict` events do not gain the new fields.
+- NG2. No introduction of additional axes, weights, or rubrics for the existing verdict axes (Correctness / Readability / Scope). Those remain qualitative.
+- NG3. No temperature override on Codex. Reproducibility is delegated to `model_reasoning_effort=high`.
+- NG4. No new CLI flag. The threshold is env-only.
+- NG5. No persistent state in `state.json`. Score parsing and veto are stateless per gate attempt.
+- NG6. No automatic re-prompting / second Codex pass. The existing retry path (which re-prompts P1, then re-runs gate) is the only retry mechanism.
+- NG7. No change to the verdict file path, sentinel protocol, or pane-injection wiring.
+- NG8. Per-axis env-tunable weights. Weights are constants this iteration; if dogfood data warrants, a follow-up may expose them.
+
+## Architecture
+
+Five touch points, in execution order:
+
+1. **`src/context/assembler.ts`** — append a `CLARITY_SCORES_PROTOCOL` block to `FIVE_AXIS_SPEC_GATE` only. `REVIEWER_CONTRACT_BASE` and the per-gate constants for 4/7 are unchanged. The resume-prompt's `structuredOutputReminder` in `assembleGateResumePrompt` becomes phase-aware and adds a fourth bullet for phase 2.
+
+2. **`src/phases/verdict.ts`** — add `parseClarityScores`, `computeWeightedAmbiguity`, and the constants `AMBIGUITY_AXES` / `CLARITY_WEIGHTS`. Both functions are pure (no I/O, no exceptions). The existing `parseVerdict`, `buildGateResult`, `buildGateResultFromFile` are unchanged in signature and behavior.
+
+3. **`src/phases/ambiguity.ts`** (new file) — exports `loadAmbiguityThreshold(): number | null` and `applyAmbiguityGate(result, rawOutput, threshold): GatePhaseResult`. Mirrors the structure of `src/phases/stagnation.ts` (env loader + pure decision function + warned-once Set).
+
+4. **`src/types.ts`** — extend `GateOutcome`, `GateError`, and the `gate_verdict` variant of `LogEvent` with five optional fields. No `LogEvent.v` bump (additive optional fields, established pattern).
+
+5. **`src/phases/gate.ts`** — call `applyAmbiguityGate` once for `phase === 2`, immediately after the verdict is built (Claude path: after `runClaudeGate`; Codex path: after `buildGateResultFromFile`), and before `_persistSidecars`. The replay branch in `checkGateSidecars` is **not** modified.
+
+6. **`src/phases/runner.ts`** — at the two `gate_verdict` event emission sites (APPROVE branch and REJECT branch), pass through the new optional fields when present. Phase-2-only guard prevents fields from leaking into P4/P7 events.
+
+## Codex Contract
+
+Block to append at the END of `FIVE_AXIS_SPEC_GATE`:
+
+```
+## Clarity Scores (REQUIRED — Phase 2 only)
+After `## Summary`, append a section titled exactly `## Clarity Scores`
+with one line per axis, in this exact order:
+
+  - goal: <0.0–1.0>
+  - constraint: <0.0–1.0>
+  - success: <0.0–1.0>
+  - context: <0.0–1.0>
+
+Each score is your assessment of how clear/unambiguous that aspect of the
+spec is — independent of whether you ultimately APPROVE or REJECT:
+  - goal       — Is the desired outcome stated unambiguously?
+  - constraint — Are non-requirements / forbidden behaviors / boundary conditions explicit?
+  - success    — Are success criteria measurable and concrete?
+  - context    — Are assumptions, inputs, and prior decisions captured?
+
+Use 1.0 for "fully clear, no reviewer-to-reviewer drift expected" and 0.0 for
+"so vague that two reviewers would reasonably reach different conclusions".
+Emit numbers, not adjectives. Do not omit axes.
+```
+
+Resume-prompt update: `structuredOutputReminder` in `assembleGateResumePrompt` gains a phase-2 conditional. The reminder for phase 2 includes a fourth bullet: ``- `## Clarity Scores` (4 lines: goal/constraint/success/context, each 0.0–1.0)``. Phases 4/7 receive the existing 3-bullet reminder unchanged.
+
+Token-cost analysis: prompt addition ≈ 80 tokens (one-time per gate run); response addition ≈ 30 tokens (4 short bullet lines). This satisfies the constraint "Codex 토큰 비용 의미 있게 증가시키지 않을 것".
+
+## Parser & Types
+
+### `src/phases/verdict.ts` additions
+
+```ts
+export const AMBIGUITY_AXES = ['goal', 'constraint', 'success', 'context'] as const;
+export type AmbiguityAxis = typeof AMBIGUITY_AXES[number];
+
+export const CLARITY_WEIGHTS: Readonly<Record<AmbiguityAxis, number>> = Object.freeze({
+  goal: 0.35,
+  constraint: 0.25,
+  success: 0.30,
+  context: 0.10,
+});
+
+export type ClarityScores = Record<AmbiguityAxis, number>;
+
+export function parseClarityScores(rawOutput: string): ClarityScores | null;
+export function computeWeightedAmbiguity(scores: ClarityScores): number;
+```
+
+`parseClarityScores` semantics (binding):
+- Locate the first `## Clarity Scores` header (case-insensitive match on the trimmed line, mirroring the `## Verdict` parser).
+- Return `null` if the header is absent.
+- Scan lines after the header until the next `## ` header or EOF.
+- For each axis, accept the first line matching `/^\s*-\s*(goal|constraint|success|context)\s*:\s*(\d+(?:\.\d+)?)\s*$/i`. Subsequent duplicates are ignored.
+- Return `null` if any axis is missing OR any value is outside `[0.0, 1.0]`.
+- No exceptions thrown. Pure function. No file I/O.
+- Integer values (e.g. `goal: 1`) are accepted and treated as `1.0`.
+
+`computeWeightedAmbiguity` semantics (binding):
+- Returns `1 − Σ(scores[axis] × CLARITY_WEIGHTS[axis])` for `axis ∈ AMBIGUITY_AXES`.
+- Result is clamped to `[0, 1]` to absorb floating-point drift; with valid inputs the math itself cannot leave that range.
+- Pure function. No exceptions.
+
+### `src/types.ts` additions
+
+```ts
+// `ClarityScores` is imported into types.ts via type-only import from
+// ../phases/verdict.js. (Type-only avoids the runtime cycle that would arise
+// from a value import; verdict.js is allowed to depend on types.ts but not
+// the reverse for runtime values.)
+clarityScores?: ClarityScores;
+ambiguity?: number;
+ambiguityThreshold?: number;
+ambiguityVetoed?: boolean;
+clarityParseError?: boolean;
+```
+
+Added to:
+- `GateOutcome` (verdict result)
+- `GateError` (error result; only `clarityParseError` and `ambiguityThreshold` are meaningful here, but keeping the union flat avoids a type fork)
+- `gate_verdict` variant of `LogEvent`
+
+All five fields are optional. Existing readers (typed sums, log-analysis scripts) are unaffected.
+
+## Gate Decision Flow
+
+### `src/phases/ambiguity.ts` (new module)
+
+```ts
+export function loadAmbiguityThreshold(): number | null;
+export function applyAmbiguityGate(
+  result: GatePhaseResult,
+  rawOutput: string,
+  threshold: number | null,
+): GatePhaseResult;
+```
+
+`loadAmbiguityThreshold` (binding):
+- Reads `process.env['HARNESS_GATE_AMBIGUITY_THRESHOLD']`.
+- Unset / empty string → return `0.2`.
+- Value `off` (case-insensitive, after trim) → return `null`. Veto disabled.
+- Numeric value parseable by `Number()` and finite and in `[0.0, 1.0]` → return that value.
+- Anything else → emit one stderr warning (warned-once Set keyed by env-var name), return `null`. Veto disabled, scores still parsed.
+- The warned-once Set is module-scoped, mirroring `stagnation.ts`. Test helper `__resetAmbiguityWarning()` exported for unit tests.
+
+`applyAmbiguityGate` (binding):
+- If `result.type === 'error'`: return `result` unchanged. (Errors don't carry `rawOutput` reliably and have no verdict to rewrite.)
+- Run `parseClarityScores(rawOutput)`.
+- If `null` (no scores): set `clarityParseError: true`; if `threshold !== null` set `ambiguityThreshold: threshold`; emit one stderr warning (warned-once); return result. Verdict untouched.
+- If parsed: compute `ambiguity = computeWeightedAmbiguity(scores)`. Attach `clarityScores`, `ambiguity`. If `threshold !== null` attach `ambiguityThreshold: threshold`.
+- If `threshold !== null` AND `result.verdict === 'APPROVE'` AND `ambiguity > threshold`:
+  - Set `result.verdict = 'REJECT'`.
+  - Set `ambiguityVetoed = true`.
+  - Prepend a synthetic comment block to `result.comments` of the form:
+    ```
+    - **[P1]** — Location: spec (overall)
+      Issue: Spec ambiguity {ambiguity.toFixed(2)} exceeds threshold {threshold.toFixed(2)} (weighted across goal/constraint/success/context).
+      Suggestion: Tighten the lowest-scoring axes — {top-2 lowest axes with values}. Restate goals as measurable outcomes and enumerate forbidden behaviors / boundary conditions.
+      Evidence: clarityScores = { goal: G, constraint: C, success: S, context: X } → weighted ambiguity {ambiguity.toFixed(2)} > {threshold.toFixed(2)}.
+    ```
+    The comment uses the standard `[P0|P1|P2|P3]` format so it flows through `gate-2-feedback.md` and the P1 retry prompt unchanged.
+  - Append `\nScope: design` to `result.comments` (after stripping any existing `Scope:` line — APPROVE verdicts shouldn't have one, but be defensive). This routes the retry to P1 via `getGateRejectReopenTarget`.
+- Return the (possibly mutated) result.
+
+### Wiring in `src/phases/gate.ts`
+
+Single guarded call site, in `runGatePhaseInteractive`, immediately after the verdict is built and before `_persistSidecars`. Both the Claude path (Step 7, after `runClaudeGate`) and the Codex path (Step 10, after `buildGateResultFromFile`) get the same call:
+
+```ts
+if (phase === 2) {
+  const threshold = loadAmbiguityThreshold();
+  gateResult = applyAmbiguityGate(gateResult, rawOutput, threshold);
+}
+```
+
+`rawOutput` is the verdict text already in scope (`result.rawOutput` from the file read or from the Claude runner). The mutation flows naturally into `_persistSidecars`, which writes the post-rewrite verdict to `gate-2-result.json`.
+
+The sidecar-replay branch in `checkGateSidecars` (Step 1) is **not** modified. Replay returns whatever was persisted — for new runs that's already the post-rewrite verdict; for legacy sidecars it's the pre-feature qualitative verdict, which is correct by construction.
+
+### Wiring in `src/phases/runner.ts`
+
+At the two `gate_verdict` emission sites (APPROVE branch, line ~611; REJECT branch, line ~664), include the new optional fields:
+
+```ts
+...(phase === 2 && result.clarityScores !== undefined ? { clarityScores: result.clarityScores } : {}),
+...(phase === 2 && result.ambiguity !== undefined ? { ambiguity: result.ambiguity } : {}),
+...(phase === 2 && result.ambiguityThreshold !== undefined ? { ambiguityThreshold: result.ambiguityThreshold } : {}),
+...(phase === 2 && result.ambiguityVetoed !== undefined ? { ambiguityVetoed: result.ambiguityVetoed } : {}),
+...(phase === 2 && result.clarityParseError !== undefined ? { clarityParseError: result.clarityParseError } : {}),
+```
+
+The `phase === 2` guard ensures fields never leak into P4/P7 events. No new dispatch branches; the rewritten verdict naturally takes the existing REJECT branch.
+
+## Event Schema
+
+`gate_verdict` event variant (additive optional fields, no `LogEvent.v` bump):
+
+```ts
+| (LogEventBase & {
+    event: 'gate_verdict';
+    phase: number;
+    retryIndex: number;
+    runner: 'claude' | 'codex';
+    verdict: GateVerdict;
+    durationMs?: number;
+    tokensTotal?: number;
+    promptBytes?: number;
+    codexSessionId?: string;
+    recoveredFromSidecar?: boolean;
+    resumedFrom?: string | null;
+    resumeFallback?: boolean;
+    preset?: { id: string; runner: 'claude' | 'codex'; model: string; effort: string };
+    // New (Phase 2 only):
+    clarityScores?: ClarityScores;
+    ambiguity?: number;
+    ambiguityThreshold?: number;
+    ambiguityVetoed?: boolean;
+    clarityParseError?: boolean;
+  })
+```
+
+Sample emission — vetoed APPROVE on phase 2:
+```json
+{
+  "event": "gate_verdict", "phase": 2, "retryIndex": 0,
+  "runner": "codex", "verdict": "REJECT",
+  "ambiguity": 0.34, "ambiguityThreshold": 0.2, "ambiguityVetoed": true,
+  "clarityScores": { "goal": 0.45, "constraint": 0.60, "success": 0.85, "context": 0.90 },
+  "promptBytes": 12345, "durationMs": 18234, "tokensTotal": 4500
+}
+```
+
+Sample emission — phase 2 parse failure:
+```json
+{
+  "event": "gate_verdict", "phase": 2, "retryIndex": 0,
+  "runner": "codex", "verdict": "APPROVE",
+  "ambiguityThreshold": 0.2, "clarityParseError": true,
+  "promptBytes": 12345, "durationMs": 18234, "tokensTotal": 4500
+}
+```
+
+Sample emission — phase 4 (unchanged):
+```json
+{
+  "event": "gate_verdict", "phase": 4, "retryIndex": 0,
+  "runner": "codex", "verdict": "APPROVE",
+  "promptBytes": 12345, "durationMs": 18234, "tokensTotal": 4500
+}
+```
+
+## Configuration
+
+| Env var | Default | Type | Effect |
+|---|---|---|---|
+| `HARNESS_GATE_AMBIGUITY_THRESHOLD` | `0.2` | number ∈ `[0.0, 1.0]` or `off` | Veto threshold. `ambiguity > threshold` rewrites APPROVE→REJECT for P2. `off` disables veto; scores are still parsed and logged. Invalid value → veto disabled + one stderr warning. |
+
+No CLI flag, no `state.json` field, no per-run override. Threshold is process-wide; if needed in tests, mutate `process.env` and call `__resetAmbiguityWarning()`.
+
+## Testing
+
+### `tests/phases/verdict.test.ts` additions
+
+- `parseClarityScores`: happy path; missing section → `null`; missing axis → `null`; out-of-range axis (negative, >1) → `null`; duplicate axis (first wins); case-insensitive header (`## clarity scores`); case-insensitive axis names (`Goal: 0.5`); extra whitespace tolerance; integer values (`- goal: 1`) accepted as 1.0; trailing text after section ignored.
+- `computeWeightedAmbiguity`: known-vector check (e.g. all-1.0 → 0.0; all-0.0 → 1.0; ouroboros example with mixed scores → expected weighted result); clamp absorbs floating-point drift; weights-sum-to-1.0 invariant test.
+
+### `tests/phases/ambiguity.test.ts` (new)
+
+- APPROVE + ambiguity > threshold → REJECT; `ambiguityVetoed: true`; synthetic P1 comment present; `Scope: design` appended; `clarityScores` and `ambiguity` attached.
+- APPROVE + ambiguity = threshold → unchanged (boundary inclusive on pass side).
+- APPROVE + ambiguity < threshold → unchanged; scores attached, `ambiguityVetoed` absent.
+- REJECT + any ambiguity → unchanged verdict; scores still attached.
+- Parse failure → unchanged verdict; `clarityParseError: true`; `ambiguityThreshold` attached; no `clarityScores`/`ambiguity`/`ambiguityVetoed`.
+- `threshold === null` (off) → no veto even at ambiguity=1.0; scores still attached; `ambiguityThreshold` omitted.
+- `loadAmbiguityThreshold`: unset → 0.2; `off` (case-insensitive) → null; `0.0` → 0.0; `1.0` → 1.0; `1.5` → null + warning; `-0.1` → null + warning; `abc` → null + warning; warned-once across multiple invalid loads (same key); `__resetAmbiguityWarning` clears the set.
+- **Regression**: legacy verdict-only output (no `## Clarity Scores`) → fail-open; verdict unchanged; existing assertions in `verdict.test.ts` continue to pass with the new code path active.
+
+### `tests/phases/gate.test.ts` (existing) — additions
+
+- One integration test: phase-2 fixture verdict file with low scores → `runGatePhaseInteractive` returns a result with `ambiguityVetoed: true` and rewritten verdict. Phase-4 fixture confirms no fields added.
+
+### `tests/context/assembler.test.ts` (existing) — additions
+
+- Phase-2 prompt contains `## Clarity Scores`. Phase-4 and phase-7 prompts do not. Phase-2 resume-prompt structured-output reminder contains the 4-bullet form. Phase-4/7 resume-prompts contain the 3-bullet form.
+
+### Verification commands
+
+```bash
+pnpm tsc --noEmit
+pnpm vitest run
+pnpm build
+```
+
+(Per CLAUDE.md, `pnpm lint` is an alias of `tsc --noEmit` — only one of the two appears in the verification list.)
+
+## Documentation Impact
+
+Per CLAUDE.md "문서 동기화 의무":
+
+- `docs/HOW-IT-WORKS.md` + `docs/HOW-IT-WORKS.ko.md` — paragraph in the Phase 2 spec gate section explaining clarity scores, the env var, fail-open semantics, and that the feature is P2-only. New row in the events.jsonl table for `gate_verdict` documenting the five new optional fields.
+- `README.md` + `README.ko.md` — brief mention in the env-var section and a one-line note in the spec gate description.
+
+No CLI `--help` change (env-only knob).
+
+## Success Criteria
+
+- SC1. Phase 2 prompt (fresh and resume) contains the `## Clarity Scores` instruction. Phase 4/7 prompts do not. Verified by snapshot/string assertions in `tests/context/assembler.test.ts`.
+- SC2. `parseClarityScores` parses a well-formed Codex output with 4 axes, returns `null` for missing/malformed cases. Verified by `tests/phases/verdict.test.ts`.
+- SC3. `computeWeightedAmbiguity` matches `1 − Σ(score × weight)` for canonical vectors and clamps to `[0, 1]`. Verified by `tests/phases/verdict.test.ts`.
+- SC4. With `HARNESS_GATE_AMBIGUITY_THRESHOLD=0.2` and a Codex APPROVE with weighted ambiguity 0.34, the resulting `GatePhaseResult` has `verdict: 'REJECT'`, `ambiguityVetoed: true`, a P1 synthetic comment, and `Scope: design`. Verified by `tests/phases/ambiguity.test.ts`.
+- SC5. With `HARNESS_GATE_AMBIGUITY_THRESHOLD=off`, no veto occurs even at ambiguity=1.0; scores are still attached. Verified by `tests/phases/ambiguity.test.ts`.
+- SC6. With a phase-2 verdict file containing a `## Verdict` section but no `## Clarity Scores` section, `applyAmbiguityGate` returns the verdict unchanged with `clarityParseError: true` set; no warning is emitted on subsequent invalid invocations within the same process. Verified by `tests/phases/ambiguity.test.ts`.
+- SC7. Phase-4 and phase-7 `gate_verdict` events contain none of the five new fields. Phase-2 `gate_verdict` events contain `ambiguityThreshold` whenever the threshold is not `off`. Verified by `tests/phases/gate.test.ts` and a runner-level emission test.
+- SC8. Sidecar replay of a pre-feature `gate-2-result.json` (no scores) produces a `GatePhaseResult` identical to the persisted one — no re-evaluation, no warning. Verified by an explicit test in `tests/phases/gate.test.ts`.
+- SC9. `pnpm tsc --noEmit` passes. `pnpm vitest run` passes. `pnpm build` succeeds.
+- SC10. Documentation changes land in the same PR as the implementation per CLAUDE.md.
+
+## Invariants
+
+- I1. `REVIEWER_CONTRACT_BASE`, `FIVE_AXIS_PLAN_GATE`, `FIVE_AXIS_EVAL_GATE_FULL`, `FIVE_AXIS_EVAL_GATE_LIGHT`, `FIVE_AXIS_DESIGN_GATE_LIGHT` are unchanged.
+- I2. The `## Clarity Scores` instruction appears **only** in the phase-2 prompt and the phase-2 resume reminder. A `grep "Clarity Scores" src/context/assembler.ts` should match exactly the constants for phase 2 and the resume-reminder branch.
+- I3. The five new fields (`clarityScores`, `ambiguity`, `ambiguityThreshold`, `ambiguityVetoed`, `clarityParseError`) are emitted in `gate_verdict` events **only** when `phase === 2`.
+- I4. `applyAmbiguityGate` is called from exactly one site in `gate.ts`, guarded by `phase === 2`. It is never called from the sidecar replay path.
+- I5. Score parse failure does not throw, does not change the verdict, and does not block the run. It emits exactly one stderr warning per process (warned-once Set in `ambiguity.ts`).
+- I6. Threshold env-var parse failure is also fail-open (warned-once, veto disabled). The run never aborts due to a malformed env var.
+- I7. Weights `CLARITY_WEIGHTS` are frozen (`Object.freeze`) and sum to 1.0 (asserted in tests).
+- I8. `LogEvent.v` is not bumped. Existing log readers continue to work without code changes.
+- I9. `state.json` schema is unchanged. No migration required.
+- I10. Autonomous mode flow is unchanged. A vetoed REJECT goes through `handleGateReject` exactly like any other REJECT, including PR #96 retry-oscillation detection and 4th-attempt force-pass.
+
+## Backward Compatibility / Migration
+
+- B1. **Existing events.jsonl files** remain readable. New optional fields are emitted only on phase-2 events from new runs.
+- B2. **Existing sidecars** (`gate-2-result.json` written by pre-feature runs) replay verbatim. The replay path does not invoke `applyAmbiguityGate`, so legacy sidecars are not retroactively vetoed.
+- B3. **Existing state.json** schema is unchanged. No migrationVersion bump.
+- B4. **Existing CLAUDE / Codex runner code paths** for P4 and P7 are byte-identical (no diff in the prompts those gates receive, no diff in the verdicts they emit).
+- B5. **Verify script** (`scripts/harness-verify.sh`) is untouched.
+- B6. **Light flow**: phase 2 in light flow uses `FIVE_AXIS_DESIGN_GATE_LIGHT`, not `FIVE_AXIS_SPEC_GATE`. The Clarity Scores protocol is **not** added to the light variant in this iteration; light flow's phase-2 ambiguity is handled in a follow-up if needed. The decision rationale: light flow's phase-2 reviews a *combined* design+plan artifact, so the ambiguity model would need re-tuning. Out of scope here.

--- a/src/context/assembler.ts
+++ b/src/context/assembler.ts
@@ -786,7 +786,9 @@ export function assembleGateResumePrompt(
   // and, for Variant A, the "prior concerns addressed" check + "APPROVE only if
   // zero P0/P1 findings" approval rule. REVIEWER_CONTRACT itself is already in the
   // session, so we do not re-include it — only the per-turn instruction tail.
-  const clarityScoresBullet = phase === 2
+  // Light-flow P2 reviews a combined design+plan artifact via FIVE_AXIS_DESIGN_GATE_LIGHT
+  // and is explicitly out of scope for clarity scoring; only full-flow P2 gets the bullet.
+  const clarityScoresBullet = phase === 2 && state.flow !== 'light'
     ? '- `## Clarity Scores` (4 lines: goal/constraint/success/context, each 0.0–1.0)\n'
     : '';
   const structuredOutputReminder =

--- a/src/context/assembler.ts
+++ b/src/context/assembler.ts
@@ -47,6 +47,28 @@ Scope rules:
 - Do NOT flag artifacts that are outside this phase's scope as "missing" — later harness phases produce plan/impl/eval artifacts.
 `;
 
+const CLARITY_SCORES_PROTOCOL = `
+## Clarity Scores (REQUIRED — Phase 2 only)
+After \`## Summary\`, append a section titled exactly \`## Clarity Scores\`
+with one line per axis, in this exact order:
+
+  - goal: <0.0–1.0>
+  - constraint: <0.0–1.0>
+  - success: <0.0–1.0>
+  - context: <0.0–1.0>
+
+Each score is your assessment of how clear/unambiguous that aspect of the
+spec is — independent of whether you ultimately APPROVE or REJECT:
+  - goal       — Is the desired outcome stated unambiguously?
+  - constraint — Are non-requirements / forbidden behaviors / boundary conditions explicit?
+  - success    — Are success criteria measurable and concrete?
+  - context    — Are assumptions, inputs, and prior decisions captured?
+
+Use 1.0 for "fully clear, no reviewer-to-reviewer drift expected" and 0.0 for
+"so vague that two reviewers would reasonably reach different conclusions".
+Emit numbers, not adjectives. Do not omit axes.
+`;
+
 const FIVE_AXIS_SPEC_GATE = `
 ## Five-Axis Evaluation (Phase 2 — spec gate)
 평가 대상은 spec 문서다. 다음 축만 적용:
@@ -55,7 +77,7 @@ const FIVE_AXIS_SPEC_GATE = `
 3. Scope — 단일 구현 plan으로 분해 가능한 크기인가? 여러 독립 프로젝트 섞이지 않음?
 
 Note: Phase 1 resolves design ambiguities live with the developer. Do not penalize for missing "Open Questions" / "TODO" / deferred-items sections — those are intentionally absent.
-`;
+` + CLARITY_SCORES_PROTOCOL;
 
 const FIVE_AXIS_PLAN_GATE = `
 ## Five-Axis Evaluation (Phase 4 — plan gate)
@@ -764,11 +786,15 @@ export function assembleGateResumePrompt(
   // and, for Variant A, the "prior concerns addressed" check + "APPROVE only if
   // zero P0/P1 findings" approval rule. REVIEWER_CONTRACT itself is already in the
   // session, so we do not re-include it — only the per-turn instruction tail.
+  const clarityScoresBullet = phase === 2
+    ? '- `## Clarity Scores` (4 lines: goal/constraint/success/context, each 0.0–1.0)\n'
+    : '';
   const structuredOutputReminder =
     'Respond with the same structured sections as before:\n' +
     '- `## Verdict` (exactly `APPROVE` or `REJECT`)\n' +
     '- `## Comments` (each finding labeled `[P0|P1|P2|P3]`, with Location/Issue/Suggestion/Evidence)\n' +
     '- `## Summary` (1–2 sentences)\n' +
+    clarityScoresBullet +
     'Approval rule: `APPROVE` only if there are zero P0 and zero P1 findings.\n';
 
   let prompt: string;

--- a/src/phases/ambiguity.ts
+++ b/src/phases/ambiguity.ts
@@ -1,0 +1,95 @@
+import type { GatePhaseResult } from '../types.js';
+import { parseClarityScores, computeWeightedAmbiguity, AMBIGUITY_AXES } from './verdict.js';
+import type { ClarityScores } from './verdict.js';
+
+const warnedKeys = new Set<string>();
+
+export function __resetAmbiguityWarning(): void {
+  warnedKeys.clear();
+}
+
+export function loadAmbiguityThreshold(): number | null {
+  const raw = process.env['HARNESS_GATE_AMBIGUITY_THRESHOLD'];
+  if (raw === undefined || raw === '') return 0.2;
+
+  const trimmed = raw.trim();
+  if (trimmed.toLowerCase() === 'off') return null;
+
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    if (!warnedKeys.has('HARNESS_GATE_AMBIGUITY_THRESHOLD')) {
+      process.stderr.write(
+        `[ambiguity] invalid HARNESS_GATE_AMBIGUITY_THRESHOLD="${raw}" — veto disabled for this run\n`,
+      );
+      warnedKeys.add('HARNESS_GATE_AMBIGUITY_THRESHOLD');
+    }
+    return null;
+  }
+  return parsed;
+}
+
+export function applyAmbiguityGate(
+  result: GatePhaseResult,
+  rawOutput: string,
+  threshold: number | null,
+): GatePhaseResult {
+  if (result.type === 'error') return result;
+
+  const scores = parseClarityScores(rawOutput);
+
+  if (scores === null) {
+    if (!warnedKeys.has('clarity-parse')) {
+      process.stderr.write(
+        '[ambiguity] ## Clarity Scores section missing or malformed — fail-open, verdict unchanged\n',
+      );
+      warnedKeys.add('clarity-parse');
+    }
+    return {
+      ...result,
+      clarityParseError: true,
+      ...(threshold !== null ? { ambiguityThreshold: threshold } : {}),
+    };
+  }
+
+  const ambiguity = computeWeightedAmbiguity(scores);
+  const withScores: GatePhaseResult = {
+    ...result,
+    clarityScores: scores,
+    ambiguity,
+    ...(threshold !== null ? { ambiguityThreshold: threshold } : {}),
+  };
+
+  if (threshold !== null && result.verdict === 'APPROVE' && ambiguity > threshold) {
+    const sorted = ([...AMBIGUITY_AXES] as string[]).sort(
+      (a, b) => (scores as ClarityScores)[a as keyof ClarityScores] - (scores as ClarityScores)[b as keyof ClarityScores],
+    );
+    const lowestTwo = sorted.slice(0, 2);
+    const lowestDesc = lowestTwo
+      .map((ax) => `${ax}=${(scores as ClarityScores)[ax as keyof ClarityScores].toFixed(2)}`)
+      .join(', ');
+    const scoresJson = Object.entries(scores)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join(', ');
+
+    const syntheticComment =
+      `- **[P1]** — Location: spec (overall)\n` +
+      `  Issue: Spec ambiguity ${ambiguity.toFixed(2)} exceeds threshold ${threshold.toFixed(2)} (weighted across goal/constraint/success/context).\n` +
+      `  Suggestion: Tighten the lowest-scoring axes — ${lowestDesc}. Restate goals as measurable outcomes and enumerate forbidden behaviors / boundary conditions.\n` +
+      `  Evidence: clarityScores = { ${scoresJson} } → weighted ambiguity ${ambiguity.toFixed(2)} > ${threshold.toFixed(2)}.`;
+
+    const existingComments = (result.comments ?? '').replace(/\n?Scope:\s*(design|impl|mixed)\b[^\n]*/i, '');
+    const newComments = (existingComments.trim()
+      ? syntheticComment + '\n' + existingComments.trim()
+      : syntheticComment) + '\nScope: design';
+
+    return {
+      ...withScores,
+      verdict: 'REJECT',
+      comments: newComments,
+      ambiguityVetoed: true,
+      scope: 'design',
+    };
+  }
+
+  return withScores;
+}

--- a/src/phases/ambiguity.ts
+++ b/src/phases/ambiguity.ts
@@ -82,10 +82,23 @@ export function applyAmbiguityGate(
       ? syntheticComment + '\n' + existingComments.trim()
       : syntheticComment) + '\nScope: design';
 
+    const syntheticRawOutput = [
+      '## Verdict',
+      'REJECT',
+      'Scope: design',
+      '',
+      '## Comments',
+      syntheticComment,
+      '',
+      '## Summary',
+      `Ambiguity veto applied: spec ambiguity ${ambiguity.toFixed(2)} > threshold ${threshold.toFixed(2)}.`,
+    ].join('\n');
+
     return {
       ...withScores,
       verdict: 'REJECT',
       comments: newComments,
+      rawOutput: syntheticRawOutput,
       ambiguityVetoed: true,
       scope: 'design',
     };

--- a/src/phases/ambiguity.ts
+++ b/src/phases/ambiguity.ts
@@ -68,7 +68,7 @@ export function applyAmbiguityGate(
       .map((ax) => `${ax}=${(scores as ClarityScores)[ax as keyof ClarityScores].toFixed(2)}`)
       .join(', ');
     const scoresJson = Object.entries(scores)
-      .map(([k, v]) => `${k}: ${v}`)
+      .map(([k, v]) => `${k}: ${(v as number).toFixed(2)}`)
       .join(', ');
 
     const syntheticComment =

--- a/src/phases/gate.ts
+++ b/src/phases/gate.ts
@@ -318,7 +318,7 @@ export async function runGatePhaseInteractive(
     const rawResult = await runClaudeGate(phase, preset, promptText, harnessDir, cwd);
     const durationMs = Date.now() - phaseStartTs;
     let result: GatePhaseResult = { ...rawResult, runner, promptBytes, durationMs };
-    if (phase === 2) {
+    if (phase === 2 && state.flow !== 'light') {
       const threshold = loadAmbiguityThreshold();
       result = applyAmbiguityGate(result, result.rawOutput ?? '', threshold);
     }
@@ -402,8 +402,8 @@ export async function runGatePhaseInteractive(
     };
   }
 
-  // Apply ambiguity gate for phase 2 (after verdict built, before sidecars)
-  if (phase === 2) {
+  // Apply ambiguity gate for full-flow phase 2 only (light-flow P2 is out of scope per spec B6)
+  if (phase === 2 && state.flow !== 'light') {
     const threshold = loadAmbiguityThreshold();
     gateResult = applyAmbiguityGate(gateResult, gateResult.rawOutput ?? '', threshold);
   }

--- a/src/phases/gate.ts
+++ b/src/phases/gate.ts
@@ -11,6 +11,7 @@ import { ensureCodexIsolation, CodexIsolationError } from '../runners/codex-isol
 import { writeState } from '../state.js';
 import { readCodexSessionUsage } from '../runners/codex-usage.js';
 import { parseVerdict, buildGateResult, buildGateResultFromFile } from './verdict.js';
+import { loadAmbiguityThreshold, applyAmbiguityGate } from './ambiguity.js';
 import { waitForPhaseCompletion } from './interactive.js';
 import { sendKeysToPane } from '../tmux.js';
 import { killProcessGroup } from '../process.js';
@@ -315,7 +316,11 @@ export async function runGatePhaseInteractive(
     const phaseStartTs = Date.now();
     const rawResult = await runClaudeGate(phase, preset, promptText, harnessDir, cwd);
     const durationMs = Date.now() - phaseStartTs;
-    const result: GatePhaseResult = { ...rawResult, runner, promptBytes, durationMs };
+    let result: GatePhaseResult = { ...rawResult, runner, promptBytes, durationMs };
+    if (phase === 2) {
+      const threshold = loadAmbiguityThreshold();
+      result = applyAmbiguityGate(result, result.rawOutput ?? '', threshold);
+    }
     if (state.currentPhase !== phase) return result;
     await _persistSidecars(result, runDir, phase, runner, promptBytes, durationMs, preset);
     return result;
@@ -394,6 +399,12 @@ export async function runGatePhaseInteractive(
       resumeFallback: false,
       sourcePreset: { model: preset.model, effort: preset.effort },
     };
+  }
+
+  // Apply ambiguity gate for phase 2 (after verdict built, before sidecars)
+  if (phase === 2) {
+    const threshold = loadAmbiguityThreshold();
+    gateResult = applyAmbiguityGate(gateResult, gateResult.rawOutput ?? '', threshold);
   }
 
   // Step 11: Collect codexTokens from JSONL

--- a/src/phases/gate.ts
+++ b/src/phases/gate.ts
@@ -70,6 +70,12 @@ export function checkGateSidecars(runDir: string, phase: number): GatePhaseResul
     tokensTotal: gateResult.tokensTotal,
     codexSessionId: gateResult.codexSessionId,
     sourcePreset: gateResult.sourcePreset,
+    // Ambiguity fields (Phase 2 only; absent on legacy sidecars and non-P2 gates).
+    ...(gateResult.clarityScores !== undefined ? { clarityScores: gateResult.clarityScores } : {}),
+    ...(gateResult.ambiguity !== undefined ? { ambiguity: gateResult.ambiguity } : {}),
+    ...(gateResult.ambiguityThreshold !== undefined ? { ambiguityThreshold: gateResult.ambiguityThreshold } : {}),
+    ...(gateResult.ambiguityVetoed !== undefined ? { ambiguityVetoed: gateResult.ambiguityVetoed } : {}),
+    ...(gateResult.clarityParseError !== undefined ? { clarityParseError: gateResult.clarityParseError } : {}),
   };
 
   if (gateResult.exitCode !== 0) {
@@ -162,6 +168,11 @@ async function _persistSidecars(
     ...(result.tokensTotal !== undefined ? { tokensTotal: result.tokensTotal } : {}),
     ...(effectiveSessionId !== undefined ? { codexSessionId: effectiveSessionId } : {}),
     ...(runner === 'codex' ? { sourcePreset: { model: preset.model, effort: preset.effort } } : {}),
+    ...(result.clarityScores !== undefined ? { clarityScores: result.clarityScores } : {}),
+    ...(result.ambiguity !== undefined ? { ambiguity: result.ambiguity } : {}),
+    ...(result.ambiguityThreshold !== undefined ? { ambiguityThreshold: result.ambiguityThreshold } : {}),
+    ...(result.ambiguityVetoed !== undefined ? { ambiguityVetoed: result.ambiguityVetoed } : {}),
+    ...(result.clarityParseError !== undefined ? { clarityParseError: result.clarityParseError } : {}),
   };
   try {
     fs.writeFileSync(rawPath, stdout);

--- a/src/phases/gate.ts
+++ b/src/phases/gate.ts
@@ -97,6 +97,7 @@ export function checkGateSidecars(runDir: string, phase: number): GatePhaseResul
     verdict: parsed.verdict,
     comments: parsed.comments,
     rawOutput,
+    ...(parsed.scope !== undefined ? { scope: parsed.scope } : {}),
     ...metadata,
   };
 }

--- a/src/phases/runner.ts
+++ b/src/phases/runner.ts
@@ -622,6 +622,11 @@ export async function handleGatePhase(
           resumedFrom: result.resumedFrom,
           resumeFallback: result.resumeFallback,
           preset: gatePresetMeta,
+          ...(phase === 2 && result.clarityScores !== undefined ? { clarityScores: result.clarityScores } : {}),
+          ...(phase === 2 && result.ambiguity !== undefined ? { ambiguity: result.ambiguity } : {}),
+          ...(phase === 2 && result.ambiguityThreshold !== undefined ? { ambiguityThreshold: result.ambiguityThreshold } : {}),
+          ...(phase === 2 && result.ambiguityVetoed !== undefined ? { ambiguityVetoed: result.ambiguityVetoed } : {}),
+          ...(phase === 2 && result.clarityParseError !== undefined ? { clarityParseError: result.clarityParseError } : {}),
         });
       }
 
@@ -675,6 +680,11 @@ export async function handleGatePhase(
           resumedFrom: result.resumedFrom,
           resumeFallback: result.resumeFallback,
           preset: gatePresetMeta,
+          ...(phase === 2 && result.clarityScores !== undefined ? { clarityScores: result.clarityScores } : {}),
+          ...(phase === 2 && result.ambiguity !== undefined ? { ambiguity: result.ambiguity } : {}),
+          ...(phase === 2 && result.ambiguityThreshold !== undefined ? { ambiguityThreshold: result.ambiguityThreshold } : {}),
+          ...(phase === 2 && result.ambiguityVetoed !== undefined ? { ambiguityVetoed: result.ambiguityVetoed } : {}),
+          ...(phase === 2 && result.clarityParseError !== undefined ? { clarityParseError: result.clarityParseError } : {}),
         });
       }
       logger.logEvent({

--- a/src/phases/verdict.ts
+++ b/src/phases/verdict.ts
@@ -131,13 +131,13 @@ export function parseClarityScores(rawOutput: string): ClarityScores | null {
   const found: Partial<Record<AmbiguityAxis, number>> = {};
   for (let i = headerIdx + 1; i < lines.length; i++) {
     const line = lines[i];
-    if (/^\s*##\s/.test(line)) break;
+    if (line.trim().startsWith('##')) break;
     const m = line.match(/^\s*-\s*(goal|constraint|success|context)\s*:\s*(\d+(?:\.\d+)?)\s*$/i);
     if (!m) continue;
     const axis = m[1].toLowerCase() as AmbiguityAxis;
     if (axis in found) continue; // first wins
     const value = parseFloat(m[2]);
-    if (value < 0 || value > 1) return null;
+    if (value > 1) return null;
     found[axis] = value;
   }
 

--- a/src/phases/verdict.ts
+++ b/src/phases/verdict.ts
@@ -107,6 +107,57 @@ export function buildGateResult(
   };
 }
 
+// ─── Ambiguity scoring ────────────────────────────────────────────────────────
+
+export const AMBIGUITY_AXES = ['goal', 'constraint', 'success', 'context'] as const;
+export type AmbiguityAxis = typeof AMBIGUITY_AXES[number];
+
+export const CLARITY_WEIGHTS: Readonly<Record<AmbiguityAxis, number>> = Object.freeze({
+  goal: 0.35,
+  constraint: 0.25,
+  success: 0.30,
+  context: 0.10,
+});
+
+export type ClarityScores = Record<AmbiguityAxis, number>;
+
+export function parseClarityScores(rawOutput: string): ClarityScores | null {
+  const lines = rawOutput.split('\n');
+  const headerIdx = lines.findIndex(
+    (l) => l.trim().toLowerCase() === '## clarity scores',
+  );
+  if (headerIdx === -1) return null;
+
+  const found: Partial<Record<AmbiguityAxis, number>> = {};
+  for (let i = headerIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^\s*##\s/.test(line)) break;
+    const m = line.match(/^\s*-\s*(goal|constraint|success|context)\s*:\s*(\d+(?:\.\d+)?)\s*$/i);
+    if (!m) continue;
+    const axis = m[1].toLowerCase() as AmbiguityAxis;
+    if (axis in found) continue; // first wins
+    const value = parseFloat(m[2]);
+    if (value < 0 || value > 1) return null;
+    found[axis] = value;
+  }
+
+  for (const axis of AMBIGUITY_AXES) {
+    if (!(axis in found)) return null;
+  }
+  return found as ClarityScores;
+}
+
+export function computeWeightedAmbiguity(scores: ClarityScores): number {
+  let clarity = 0;
+  for (const axis of AMBIGUITY_AXES) {
+    clarity += scores[axis] * CLARITY_WEIGHTS[axis];
+  }
+  // Round to 10 decimal places to eliminate IEEE-754 floating-point noise
+  // (e.g. 1 - 1.0 can yield ~1e-16 instead of exact 0).
+  const ambiguity = Math.round((1 - clarity) * 1e10) / 1e10;
+  return Math.min(1, Math.max(0, ambiguity));
+}
+
 /**
  * Read verdict from a file written by Codex (Output Protocol, R3).
  * Returns error result if file missing, unreadable, or has no ## Verdict header.

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,6 +137,13 @@ export interface GateResult {
   codexSessionId?: string;
   // Preset lineage at write time — used by sidecar replay compatibility gate (§4.7)
   sourcePreset?: { model: string; effort: string };
+  // Ambiguity gate fields (Phase 2 only; persisted so sidecar replay
+  // re-emits the same gate_verdict shape after a resume).
+  clarityScores?: ClarityScores;
+  ambiguity?: number;
+  ambiguityThreshold?: number;
+  ambiguityVetoed?: boolean;
+  clarityParseError?: boolean;
 }
 
 export interface VerifyResult {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { ClarityScores } from './phases/verdict.js';
+
 export type PhaseNumber = 1 | 2 | 3 | 4 | 5 | 6 | 7;
 export type InteractivePhase = 1 | 3 | 5;
 export type GatePhase = 2 | 4 | 7;
@@ -163,6 +165,12 @@ export interface GateOutcome {
   // Session resume metadata (§4.6)
   resumedFrom?: string | null;
   resumeFallback?: boolean;
+  // Ambiguity gate fields (Phase 2 only)
+  clarityScores?: ClarityScores;
+  ambiguity?: number;
+  ambiguityThreshold?: number;
+  ambiguityVetoed?: boolean;
+  clarityParseError?: boolean;
 }
 
 export interface GateError {
@@ -182,6 +190,12 @@ export interface GateError {
   // Session resume metadata (§4.6)
   resumedFrom?: string | null;
   resumeFallback?: boolean;
+  // Ambiguity gate fields (Phase 2 only)
+  clarityScores?: ClarityScores;
+  ambiguity?: number;
+  ambiguityThreshold?: number;
+  ambiguityVetoed?: boolean;
+  clarityParseError?: boolean;
 }
 
 export type GatePhaseResult = GateOutcome | GateError;
@@ -256,6 +270,12 @@ export type LogEvent =
       resumedFrom?: string | null;
       resumeFallback?: boolean;
       preset?: { id: string; runner: 'claude' | 'codex'; model: string; effort: string };
+      // New (Phase 2 only):
+      clarityScores?: ClarityScores;
+      ambiguity?: number;
+      ambiguityThreshold?: number;
+      ambiguityVetoed?: boolean;
+      clarityParseError?: boolean;
     })
   | (LogEventBase & {
       event: 'gate_error';

--- a/tests/context/__snapshots__/assembler.test.ts.snap
+++ b/tests/context/__snapshots__/assembler.test.ts.snap
@@ -37,6 +37,26 @@ Scope rules:
 3. Scope — 단일 구현 plan으로 분해 가능한 크기인가? 여러 독립 프로젝트 섞이지 않음?
 
 Note: Phase 1 resolves design ambiguities live with the developer. Do not penalize for missing "Open Questions" / "TODO" / deferred-items sections — those are intentionally absent.
+
+## Clarity Scores (REQUIRED — Phase 2 only)
+After \`## Summary\`, append a section titled exactly \`## Clarity Scores\`
+with one line per axis, in this exact order:
+
+  - goal: <0.0–1.0>
+  - constraint: <0.0–1.0>
+  - success: <0.0–1.0>
+  - context: <0.0–1.0>
+
+Each score is your assessment of how clear/unambiguous that aspect of the
+spec is — independent of whether you ultimately APPROVE or REJECT:
+  - goal       — Is the desired outcome stated unambiguously?
+  - constraint — Are non-requirements / forbidden behaviors / boundary conditions explicit?
+  - success    — Are success criteria measurable and concrete?
+  - context    — Are assumptions, inputs, and prior decisions captured?
+
+Use 1.0 for "fully clear, no reviewer-to-reviewer drift expected" and 0.0 for
+"so vague that two reviewers would reasonably reach different conclusions".
+Emit numbers, not adjectives. Do not omit axes.
 <harness_lifecycle>
 This is Gate 2 of a 7-phase harness lifecycle. You are reviewing ONLY the <spec> artifact. The implementation plan (Phase 3), the implementation itself (Phase 5), and the eval report (Phase 7) have not yet been produced; their absence must NOT appear as a finding.
 </harness_lifecycle>

--- a/tests/context/assembler.test.ts
+++ b/tests/context/assembler.test.ts
@@ -1344,4 +1344,14 @@ describe('CLARITY_SCORES_PROTOCOL — assembleGateResumePrompt', () => {
     expect(typeof result).toBe('string');
     expect(result as string).not.toContain('## Clarity Scores');
   });
+
+  it('Light-flow Phase-2 assembleGateResumePrompt output does NOT contain "## Clarity Scores" bullet', () => {
+    const cwd = makeTmpDir();
+    const runDir = path.join(cwd, '.harness', 'my-run');
+    const state = makeState({ flow: 'light' });
+    writeSpec(cwd, state);
+    const result = assembleGateResumePrompt(2, state, cwd, 'reject', 'P1 feedback', runDir);
+    expect(typeof result).toBe('string');
+    expect(result as string).not.toContain('## Clarity Scores');
+  });
 });

--- a/tests/context/assembler.test.ts
+++ b/tests/context/assembler.test.ts
@@ -1262,3 +1262,86 @@ describe('assembleGateResumePrompt — Output Protocol block', () => {
     expect(prompt).toContain('resume-uuid-456');
   });
 });
+
+// ─── Clarity Scores Protocol (P2 ambiguity gate) ────────────────────────────
+
+describe('CLARITY_SCORES_PROTOCOL — assembleGatePrompt', () => {
+  function writeSpec(cwd: string, state: HarnessState): void {
+    const specAbsPath = path.join(cwd, state.artifacts.spec);
+    fs.mkdirSync(path.dirname(specAbsPath), { recursive: true });
+    fs.writeFileSync(specAbsPath, '# My Spec\n\nSome spec content here.');
+  }
+
+  function writePlan(cwd: string, state: HarnessState): void {
+    const planAbsPath = path.join(cwd, state.artifacts.plan);
+    fs.mkdirSync(path.dirname(planAbsPath), { recursive: true });
+    fs.writeFileSync(planAbsPath, '# My Plan\n\nSome plan content here.');
+  }
+
+  it('Phase-2 assembleGatePrompt output contains "## Clarity Scores" (full flow)', () => {
+    const cwd = makeTmpDir();
+    const state = makeState();
+    writeSpec(cwd, state);
+    const result = assembleGatePrompt(2, state, '/tmp/harness', cwd);
+    expect(typeof result).toBe('string');
+    expect(result as string).toContain('## Clarity Scores');
+  });
+
+  it('Phase-4 assembleGatePrompt output does NOT contain "## Clarity Scores"', () => {
+    const cwd = makeTmpDir();
+    const state = makeState();
+    writeSpec(cwd, state);
+    writePlan(cwd, state);
+    const result = assembleGatePrompt(4, state, '/tmp/harness', cwd);
+    expect(typeof result).toBe('string');
+    expect(result as string).not.toContain('## Clarity Scores');
+  });
+
+  it('Phase-7 assembleGatePrompt output does NOT contain "## Clarity Scores"', () => {
+    const cwd = makeTmpDir();
+    const state = makeFullEvalState();
+    writeSpec(cwd, state);
+    writePlan(cwd, state);
+    const evalAbsPath = path.join(cwd, state.artifacts.evalReport);
+    fs.mkdirSync(path.dirname(evalAbsPath), { recursive: true });
+    fs.writeFileSync(evalAbsPath, '# Eval Report');
+    const result = assembleGatePrompt(7, state, '/tmp/harness', cwd);
+    expect(typeof result).toBe('string');
+    expect(result as string).not.toContain('## Clarity Scores');
+  });
+});
+
+describe('CLARITY_SCORES_PROTOCOL — assembleGateResumePrompt', () => {
+  function writeSpec(cwd: string, state: HarnessState): void {
+    const specAbsPath = path.join(cwd, state.artifacts.spec);
+    fs.mkdirSync(path.dirname(specAbsPath), { recursive: true });
+    fs.writeFileSync(specAbsPath, '# My Spec\n\nSome spec content here.');
+  }
+
+  function writePlan(cwd: string, state: HarnessState): void {
+    const planAbsPath = path.join(cwd, state.artifacts.plan);
+    fs.mkdirSync(path.dirname(planAbsPath), { recursive: true });
+    fs.writeFileSync(planAbsPath, '# My Plan\n\nSome plan content here.');
+  }
+
+  it('Phase-2 assembleGateResumePrompt output contains "## Clarity Scores" bullet', () => {
+    const cwd = makeTmpDir();
+    const runDir = path.join(cwd, '.harness', 'my-run');
+    const state = makeState();
+    writeSpec(cwd, state);
+    const result = assembleGateResumePrompt(2, state, cwd, 'reject', 'P1 feedback', runDir);
+    expect(typeof result).toBe('string');
+    expect(result as string).toContain('## Clarity Scores');
+  });
+
+  it('Phase-4 assembleGateResumePrompt output does NOT contain "## Clarity Scores" bullet', () => {
+    const cwd = makeTmpDir();
+    const runDir = path.join(cwd, '.harness', 'my-run');
+    const state = makeState();
+    writeSpec(cwd, state);
+    writePlan(cwd, state);
+    const result = assembleGateResumePrompt(4, state, cwd, 'reject', 'P1 feedback', runDir);
+    expect(typeof result).toBe('string');
+    expect(result as string).not.toContain('## Clarity Scores');
+  });
+});

--- a/tests/phases/ambiguity.test.ts
+++ b/tests/phases/ambiguity.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { loadAmbiguityThreshold, applyAmbiguityGate, __resetAmbiguityWarning } from '../../src/phases/ambiguity.js';
+import type { GatePhaseResult } from '../../src/types.js';
+
+function makeApprove(rawOutput: string): GatePhaseResult {
+  return {
+    type: 'verdict',
+    verdict: 'APPROVE',
+    comments: '',
+    rawOutput,
+    runner: 'codex',
+  };
+}
+
+function makeReject(rawOutput: string): GatePhaseResult {
+  return {
+    type: 'verdict',
+    verdict: 'REJECT',
+    comments: 'some finding',
+    rawOutput,
+    runner: 'codex',
+  };
+}
+
+function makeError(): GatePhaseResult {
+  return { type: 'error', error: 'subprocess failed', rawOutput: '' };
+}
+
+const highAmbiguityOutput = [
+  '## Verdict', 'APPROVE',
+  '## Summary', 'Spec looks decent.',
+  '## Clarity Scores',
+  '- goal: 0.45',
+  '- constraint: 0.60',
+  '- success: 0.85',
+  '- context: 0.90',
+].join('\n');
+// ambiguity = 1 - (0.45*0.35 + 0.60*0.25 + 0.85*0.30 + 0.90*0.10)
+//           = 1 - (0.1575 + 0.15 + 0.255 + 0.09) = 1 - 0.6525 = 0.3475 > 0.2
+
+const lowAmbiguityOutput = [
+  '## Clarity Scores',
+  '- goal: 0.90',
+  '- constraint: 0.85',
+  '- success: 0.95',
+  '- context: 0.80',
+].join('\n');
+// ambiguity = 1 - (0.90*0.35 + 0.85*0.25 + 0.95*0.30 + 0.80*0.10)
+//           = 1 - (0.315 + 0.2125 + 0.285 + 0.08) = 1 - 0.8925 = 0.1075 < 0.2
+
+const exactThresholdOutput = [
+  '## Clarity Scores',
+  '- goal: 0.8',
+  '- constraint: 0.8',
+  '- success: 0.8',
+  '- context: 0.8',
+].join('\n');
+// ambiguity = 1 - 0.8 = 0.2 (exactly at threshold, should NOT veto)
+
+beforeEach(() => {
+  __resetAmbiguityWarning();
+  vi.unstubAllEnvs();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  __resetAmbiguityWarning();
+});
+
+// ─── loadAmbiguityThreshold ──────────────────────────────────────────────────
+
+describe('loadAmbiguityThreshold', () => {
+  it('returns 0.2 when env var is unset', () => {
+    delete process.env['HARNESS_GATE_AMBIGUITY_THRESHOLD'];
+    expect(loadAmbiguityThreshold()).toBe(0.2);
+  });
+
+  it('returns 0.2 when env var is empty string', () => {
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', '');
+    expect(loadAmbiguityThreshold()).toBe(0.2);
+  });
+
+  it('returns null for "off" (case-insensitive, trimmed)', () => {
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', 'off');
+    expect(loadAmbiguityThreshold()).toBeNull();
+    __resetAmbiguityWarning();
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', 'OFF');
+    expect(loadAmbiguityThreshold()).toBeNull();
+    __resetAmbiguityWarning();
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', '  Off  ');
+    expect(loadAmbiguityThreshold()).toBeNull();
+  });
+
+  it('returns 0.0 for "0.0"', () => {
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', '0.0');
+    expect(loadAmbiguityThreshold()).toBe(0.0);
+  });
+
+  it('returns 1.0 for "1.0"', () => {
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', '1.0');
+    expect(loadAmbiguityThreshold()).toBe(1.0);
+  });
+
+  it('returns null + warn for value > 1', () => {
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', '1.5');
+    expect(loadAmbiguityThreshold()).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it('returns null + warn for value < 0', () => {
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', '-0.1');
+    expect(loadAmbiguityThreshold()).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it('returns null + warn for non-numeric', () => {
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', 'abc');
+    expect(loadAmbiguityThreshold()).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it('warned-once: second invalid load produces no extra warning', () => {
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', 'bad');
+    loadAmbiguityThreshold();
+    loadAmbiguityThreshold();
+    loadAmbiguityThreshold();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it('__resetAmbiguityWarning clears the warned-once state', () => {
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.stubEnv('HARNESS_GATE_AMBIGUITY_THRESHOLD', 'bad');
+    loadAmbiguityThreshold();
+    __resetAmbiguityWarning();
+    loadAmbiguityThreshold();
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    warnSpy.mockRestore();
+  });
+});
+
+// ─── applyAmbiguityGate ──────────────────────────────────────────────────────
+
+describe('applyAmbiguityGate', () => {
+  it('APPROVE + ambiguity > threshold → REJECT with ambiguityVetoed', () => {
+    const result = applyAmbiguityGate(makeApprove(highAmbiguityOutput), highAmbiguityOutput, 0.2);
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.verdict).toBe('REJECT');
+      expect(result.ambiguityVetoed).toBe(true);
+      expect(result.ambiguity).toBeCloseTo(0.3475, 4);
+      expect(result.ambiguityThreshold).toBe(0.2);
+      expect(result.clarityScores).toEqual({ goal: 0.45, constraint: 0.60, success: 0.85, context: 0.90 });
+      expect(result.comments).toMatch(/\[P1\]/);
+      expect(result.comments).toMatch(/Scope: design/);
+    }
+  });
+
+  it('APPROVE + ambiguity = threshold → unchanged (boundary inclusive on pass side)', () => {
+    const result = applyAmbiguityGate(makeApprove(exactThresholdOutput), exactThresholdOutput, 0.2);
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.verdict).toBe('APPROVE');
+      expect(result.ambiguityVetoed).toBeUndefined();
+    }
+  });
+
+  it('APPROVE + ambiguity < threshold → unchanged, scores attached', () => {
+    const result = applyAmbiguityGate(makeApprove(lowAmbiguityOutput), lowAmbiguityOutput, 0.2);
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.verdict).toBe('APPROVE');
+      expect(result.ambiguityVetoed).toBeUndefined();
+      expect(result.clarityScores).toBeDefined();
+      expect(result.ambiguity).toBeDefined();
+    }
+  });
+
+  it('REJECT + any ambiguity → verdict stays REJECT, scores attached', () => {
+    const result = applyAmbiguityGate(makeReject(highAmbiguityOutput), highAmbiguityOutput, 0.2);
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.verdict).toBe('REJECT');
+      expect(result.ambiguityVetoed).toBeUndefined();
+      expect(result.clarityScores).toBeDefined();
+    }
+  });
+
+  it('threshold null (off) → no veto even at ambiguity=1.0, scores still attached, ambiguityThreshold omitted', () => {
+    const allZero = [
+      '## Clarity Scores',
+      '- goal: 0.0', '- constraint: 0.0', '- success: 0.0', '- context: 0.0',
+    ].join('\n');
+    const result = applyAmbiguityGate(makeApprove(allZero), allZero, null);
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.verdict).toBe('APPROVE');
+      expect(result.ambiguityVetoed).toBeUndefined();
+      expect(result.ambiguityThreshold).toBeUndefined();
+      expect(result.clarityScores).toBeDefined();
+      expect(result.ambiguity).toBe(1.0);
+    }
+  });
+
+  it('error result → returned unchanged', () => {
+    const err = makeError();
+    const result = applyAmbiguityGate(err, '', 0.2);
+    expect(result).toBe(err);
+  });
+
+  it('parse failure → clarityParseError true, verdict unchanged, ambiguityThreshold attached', () => {
+    const noScores = '## Verdict\nAPPROVE\n## Summary\nLooks fine.';
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const result = applyAmbiguityGate(makeApprove(noScores), noScores, 0.2);
+    expect(result.clarityParseError).toBe(true);
+    expect(result.ambiguityThreshold).toBe(0.2);
+    if (result.type === 'verdict') {
+      expect(result.verdict).toBe('APPROVE');
+    }
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    // Second call: warned-once → no extra warning
+    applyAmbiguityGate(makeApprove(noScores), noScores, 0.2);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it('synthetic P1 comment names the two lowest-scoring axes', () => {
+    const result = applyAmbiguityGate(makeApprove(highAmbiguityOutput), highAmbiguityOutput, 0.2);
+    if (result.type === 'verdict') {
+      // goal=0.45 and constraint=0.60 are the two lowest
+      expect(result.comments).toMatch(/goal/);
+      expect(result.comments).toMatch(/constraint/);
+    }
+  });
+
+  it('regression: legacy output without ## Clarity Scores → fail-open, verdict unchanged', () => {
+    const legacy = '## Verdict\nAPPROVE\n## Comments\n- All good.\n## Summary\nSpec is clear.';
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const result = applyAmbiguityGate(makeApprove(legacy), legacy, 0.2);
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.verdict).toBe('APPROVE');
+    }
+    expect(result.clarityParseError).toBe(true);
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/phases/ambiguity.test.ts
+++ b/tests/phases/ambiguity.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { loadAmbiguityThreshold, applyAmbiguityGate, __resetAmbiguityWarning } from '../../src/phases/ambiguity.js';
+import { parseVerdict } from '../../src/phases/verdict.js';
 import type { GatePhaseResult } from '../../src/types.js';
 
 function makeApprove(rawOutput: string): GatePhaseResult {
@@ -160,6 +161,12 @@ describe('applyAmbiguityGate', () => {
       expect(result.clarityScores).toEqual({ goal: 0.45, constraint: 0.60, success: 0.85, context: 0.90 });
       expect(result.comments).toMatch(/\[P1\]/);
       expect(result.comments).toMatch(/Scope: design/);
+      // rawOutput must be rewritten so sidecar replay returns REJECT
+      expect(result.rawOutput).toBeDefined();
+      const parsed = parseVerdict(result.rawOutput!);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.verdict).toBe('REJECT');
+      expect(parsed!.scope).toBe('design');
     }
   });
 

--- a/tests/phases/gate.test.ts
+++ b/tests/phases/gate.test.ts
@@ -762,6 +762,57 @@ describe('runGatePhase — ambiguity gate (phase 2)', () => {
     expect(result.ambiguityVetoed).toBeUndefined();
   });
 
+  it('after vetoed P2 live run, checkGateSidecars replays as REJECT scope:design', async () => {
+    const { assembleGatePrompt: mockAssembler } = await import('../../src/context/assembler.js');
+    const { spawnCodexInPane: mockSpawn } = await import('../../src/runners/codex.js');
+    const { waitForPhaseCompletion: mockWait } = await import('../../src/phases/interactive.js');
+
+    vi.mocked(mockAssembler).mockReturnValue('mock prompt');
+    vi.mocked(mockSpawn).mockResolvedValue({ pid: null });
+
+    const runDir = makeTmpDir();
+    const verdictContent = [
+      '## Verdict', 'APPROVE',
+      '## Comments', '- looks fine',
+      '## Summary', 'OK.',
+      '## Clarity Scores',
+      '- goal: 0.45', '- constraint: 0.60', '- success: 0.85', '- context: 0.90',
+    ].join('\n');
+    // ambiguity = 0.3475 > 0.2 → veto
+
+    vi.mocked(mockWait).mockImplementationOnce(async () => {
+      fs.writeFileSync(path.join(runDir, 'gate-2-verdict.md'), verdictContent);
+      return { status: 'completed' };
+    });
+
+    const state = {
+      phasePresets: { '2': 'codex-high' },
+      gateRetries: { '2': 0, '4': 0, '7': 0 },
+      phaseCodexSessions: { '2': null, '4': null, '7': null },
+      phaseAttemptId: { '2': 'sidecar-replay-test-id' },
+      currentPhase: 2,
+      codexNoIsolate: false,
+      tmuxSession: undefined,
+      tmuxWorkspacePane: undefined,
+    } as any;
+
+    const liveResult = await runGatePhase(2, state, '/fake-harness', runDir, '/cwd');
+    expect(liveResult.type).toBe('verdict');
+    if (liveResult.type === 'verdict') {
+      expect(liveResult.verdict).toBe('REJECT');
+      expect(liveResult.ambiguityVetoed).toBe(true);
+    }
+
+    // Sidecar replay must also return REJECT (not the original APPROVE)
+    const replayResult = checkGateSidecars(runDir, 2);
+    expect(replayResult).not.toBeNull();
+    expect(replayResult!.type).toBe('verdict');
+    if (replayResult!.type === 'verdict') {
+      expect(replayResult!.verdict).toBe('REJECT');
+      expect(replayResult!.scope).toBe('design');
+    }
+  });
+
   it('sidecar replay of gate-2-result.json (no scores in raw) → verdict unchanged, no ambiguity fields', async () => {
     const runDir = makeTmpDir();
     // Use a sidecar with runner set (compatible with codex-high preset) but no ## Clarity Scores

--- a/tests/phases/gate.test.ts
+++ b/tests/phases/gate.test.ts
@@ -393,6 +393,42 @@ describe('checkGateSidecars — legacy vs extended sidecar', () => {
     expect((result as any).durationMs).toBe(30000);
   });
 
+  it('hydrates ambiguity fields from extended P2 sidecar', () => {
+    const runDir = makeTmpDir();
+    const ext = {
+      exitCode: 0,
+      timestamp: 1700000000,
+      runner: 'codex',
+      promptBytes: 1000,
+      durationMs: 30000,
+      tokensTotal: 45000,
+      sourcePreset: { model: 'gpt-5.5', effort: 'high' },
+      clarityScores: { goal: 0.45, constraint: 0.60, success: 0.85, context: 0.90 },
+      ambiguity: 0.34,
+      ambiguityThreshold: 0.2,
+      ambiguityVetoed: true,
+      clarityParseError: false,
+    };
+    fs.writeFileSync(path.join(runDir, 'gate-2-result.json'), JSON.stringify(ext));
+    fs.writeFileSync(
+      path.join(runDir, 'gate-2-raw.txt'),
+      '## Verdict\nREJECT\nScope: design\n\n## Comments\n- **[P1]** synthetic\n',
+    );
+
+    const result = checkGateSidecars(runDir, 2);
+    expect(result?.type).toBe('verdict');
+    expect((result as any).clarityScores).toEqual({
+      goal: 0.45,
+      constraint: 0.60,
+      success: 0.85,
+      context: 0.90,
+    });
+    expect((result as any).ambiguity).toBeCloseTo(0.34, 5);
+    expect((result as any).ambiguityThreshold).toBe(0.2);
+    expect((result as any).ambiguityVetoed).toBe(true);
+    expect((result as any).clarityParseError).toBe(false);
+  });
+
   it('hydrates metadata on error sidecar replay (non-zero exitCode)', () => {
     const runDir = makeTmpDir();
     const ext = {

--- a/tests/phases/gate.test.ts
+++ b/tests/phases/gate.test.ts
@@ -666,3 +666,136 @@ describe('runGatePhase — TUI interrupt after sentinel completion', () => {
 });
 
 void buildGateResultFromFileVerdict; // ensure the direct import is also exercised
+
+// ─── ambiguity gate integration ──────────────────────────────────────────────
+
+describe('runGatePhase — ambiguity gate (phase 2)', () => {
+  it('phase-2 verdict with low clarity scores → result has ambiguityVetoed and REJECT', async () => {
+    const { assembleGatePrompt: mockAssembler } = await import('../../src/context/assembler.js');
+    const { spawnCodexInPane: mockSpawn } = await import('../../src/runners/codex.js');
+    const { waitForPhaseCompletion: mockWait } = await import('../../src/phases/interactive.js');
+
+    vi.mocked(mockAssembler).mockReturnValue('mock prompt');
+    vi.mocked(mockSpawn).mockResolvedValue({ pid: null });
+
+    const runDir = makeTmpDir();
+
+    const verdictContent = [
+      '## Verdict', 'APPROVE',
+      '## Comments', '- looks fine',
+      '## Summary', 'OK.',
+      '## Clarity Scores',
+      '- goal: 0.45', '- constraint: 0.60', '- success: 0.85', '- context: 0.90',
+    ].join('\n');
+    // ambiguity = 1 - (0.45*0.35 + 0.60*0.25 + 0.85*0.30 + 0.90*0.10) = 0.3475 > 0.2
+
+    const attemptId = 'test-attempt-id-p2';
+    // Mock waitForPhaseCompletion to write the verdict file (simulating Codex agent output)
+    vi.mocked(mockWait).mockImplementationOnce(async (sentinelPath: string) => {
+      fs.writeFileSync(path.join(runDir, 'gate-2-verdict.md'), verdictContent);
+      return { status: 'completed' };
+    });
+
+    const state = {
+      phasePresets: { '2': 'codex-high' },
+      gateRetries: { '2': 0, '4': 0, '7': 0 },
+      phaseCodexSessions: { '2': null, '4': null, '7': null },
+      phaseAttemptId: { '2': attemptId },
+      currentPhase: 2,
+      codexNoIsolate: false,
+      tmuxSession: undefined,
+      tmuxWorkspacePane: undefined,
+    } as any;
+
+    const result = await runGatePhase(2, state, '/fake-harness', runDir, '/cwd');
+
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.verdict).toBe('REJECT');
+      expect(result.ambiguityVetoed).toBe(true);
+      expect(result.clarityScores).toEqual({ goal: 0.45, constraint: 0.60, success: 0.85, context: 0.90 });
+      expect(result.ambiguity).toBeCloseTo(0.3475, 4);
+      expect(result.ambiguityThreshold).toBe(0.2);
+    }
+  });
+
+  it('phase-4 verdict with ## Clarity Scores in file → result has NO clarity fields', async () => {
+    const { assembleGatePrompt: mockAssembler } = await import('../../src/context/assembler.js');
+    const { spawnCodexInPane: mockSpawn } = await import('../../src/runners/codex.js');
+    const { waitForPhaseCompletion: mockWait } = await import('../../src/phases/interactive.js');
+
+    vi.mocked(mockAssembler).mockReturnValue('mock prompt');
+    vi.mocked(mockSpawn).mockResolvedValue({ pid: null });
+
+    const runDir = makeTmpDir();
+
+    const verdictContent = [
+      '## Verdict', 'APPROVE',
+      '## Summary', 'Plan is solid.',
+      '## Clarity Scores',
+      '- goal: 0.90', '- constraint: 0.85', '- success: 0.95', '- context: 0.80',
+    ].join('\n');
+
+    const attemptId = 'test-attempt-id-p4';
+    // Mock waitForPhaseCompletion to write the verdict file (simulating Codex agent output)
+    vi.mocked(mockWait).mockImplementationOnce(async () => {
+      fs.writeFileSync(path.join(runDir, 'gate-4-verdict.md'), verdictContent);
+      return { status: 'completed' };
+    });
+
+    const state = {
+      phasePresets: { '4': 'codex-high' },
+      gateRetries: { '2': 0, '4': 0, '7': 0 },
+      phaseCodexSessions: { '2': null, '4': null, '7': null },
+      phaseAttemptId: { '4': attemptId },
+      currentPhase: 4,
+      codexNoIsolate: false,
+      tmuxSession: undefined,
+      tmuxWorkspacePane: undefined,
+    } as any;
+
+    const result = await runGatePhase(4, state, '/fake-harness', runDir, '/cwd');
+
+    expect(result.type).toBe('verdict');
+    expect(result.clarityScores).toBeUndefined();
+    expect(result.ambiguity).toBeUndefined();
+    expect(result.ambiguityVetoed).toBeUndefined();
+  });
+
+  it('sidecar replay of gate-2-result.json (no scores in raw) → verdict unchanged, no ambiguity fields', async () => {
+    const runDir = makeTmpDir();
+    // Use a sidecar with runner set (compatible with codex-high preset) but no ## Clarity Scores
+    const rawContent = '## Verdict\nAPPROVE\n## Summary\nOK.';
+    const sidecarResult: GateResult = {
+      exitCode: 0,
+      timestamp: Date.now(),
+      runner: 'codex',
+      promptBytes: 500,
+      durationMs: 1000,
+      sourcePreset: { model: 'gpt-5.5', effort: 'high' },
+    };
+    writeSidecars(runDir, 2, rawContent, sidecarResult);
+
+    const state = {
+      phasePresets: { '2': 'codex-high' },
+      gateRetries: { '2': 0, '4': 0, '7': 0 },
+      phaseCodexSessions: { '2': null, '4': null, '7': null },
+      phaseAttemptId: { '2': 'any-id' },
+      currentPhase: 2,
+      codexNoIsolate: false,
+    } as any;
+
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const result = await runGatePhase(2, state, '/fake-harness', runDir, '/cwd', { value: true });
+    warnSpy.mockRestore();
+
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.verdict).toBe('APPROVE');
+    }
+    expect(result.clarityScores).toBeUndefined();
+    expect(result.ambiguityVetoed).toBeUndefined();
+    // Sidecar replay should not trigger ambiguity warning
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/phases/gate.test.ts
+++ b/tests/phases/gate.test.ts
@@ -762,6 +762,56 @@ describe('runGatePhase — ambiguity gate (phase 2)', () => {
     expect(result.ambiguityVetoed).toBeUndefined();
   });
 
+  it('light-flow P2 with high-ambiguity verdict → no clarity fields, no warning emitted', async () => {
+    const { assembleGatePrompt: mockAssembler } = await import('../../src/context/assembler.js');
+    const { spawnCodexInPane: mockSpawn } = await import('../../src/runners/codex.js');
+    const { waitForPhaseCompletion: mockWait } = await import('../../src/phases/interactive.js');
+
+    vi.mocked(mockAssembler).mockReturnValue('mock prompt');
+    vi.mocked(mockSpawn).mockResolvedValue({ pid: null });
+
+    const runDir = makeTmpDir();
+    // High-ambiguity output that would trigger veto on full-flow
+    const verdictContent = [
+      '## Verdict', 'APPROVE',
+      '## Comments', '- looks fine',
+      '## Summary', 'OK.',
+      '## Clarity Scores',
+      '- goal: 0.45', '- constraint: 0.60', '- success: 0.85', '- context: 0.90',
+    ].join('\n');
+
+    vi.mocked(mockWait).mockImplementationOnce(async () => {
+      fs.writeFileSync(path.join(runDir, 'gate-2-verdict.md'), verdictContent);
+      return { status: 'completed' };
+    });
+
+    const warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const state = {
+      phasePresets: { '2': 'codex-high' },
+      gateRetries: { '2': 0, '4': 0, '7': 0 },
+      phaseCodexSessions: { '2': null, '4': null, '7': null },
+      phaseAttemptId: { '2': 'light-flow-test-id' },
+      currentPhase: 2,
+      codexNoIsolate: false,
+      tmuxSession: undefined,
+      tmuxWorkspacePane: undefined,
+      flow: 'light',
+    } as any;
+
+    const result = await runGatePhase(2, state, '/fake-harness', runDir, '/cwd');
+
+    expect(result.type).toBe('verdict');
+    if (result.type === 'verdict') {
+      expect(result.verdict).toBe('APPROVE');
+    }
+    expect(result.clarityScores).toBeUndefined();
+    expect(result.ambiguity).toBeUndefined();
+    expect(result.ambiguityVetoed).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
   it('after vetoed P2 live run, checkGateSidecars replays as REJECT scope:design', async () => {
     const { assembleGatePrompt: mockAssembler } = await import('../../src/context/assembler.js');
     const { spawnCodexInPane: mockSpawn } = await import('../../src/runners/codex.js');

--- a/tests/phases/runner.test.ts
+++ b/tests/phases/runner.test.ts
@@ -2231,3 +2231,68 @@ describe('Stagnation — Test 9b: WINDOW env set to non-2 value → stagnation s
     }
   });
 });
+
+describe('handleGatePhase — gate_verdict with clarity fields (phase 2 only)', () => {
+  it('emits gate_verdict with clarityScores/ambiguity/ambiguityVetoed when result has these fields (phase 2)', async () => {
+    const runDir = makeTmpDir();
+    const state = makeState({ currentPhase: 2 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    vi.mocked(runGatePhase).mockResolvedValueOnce({
+      type: 'verdict',
+      verdict: 'REJECT',
+      comments: '- **[P1]** synthetic veto\nScope: design',
+      rawOutput: '',
+      runner: 'codex',
+      promptBytes: 1000,
+      durationMs: 5000,
+      clarityScores: { goal: 0.45, constraint: 0.60, success: 0.85, context: 0.90 },
+      ambiguity: 0.3475,
+      ambiguityThreshold: 0.2,
+      ambiguityVetoed: true,
+    } as any);
+
+    try {
+      await handleGatePhase(2, state, HDIR, runDir, CWD, createNoOpInputManager(), logger, { value: false });
+      const events = readEvents(eventsPath);
+      const verdict = events.find((e: any) => e.event === 'gate_verdict');
+      expect(verdict).toBeDefined();
+      expect(verdict.phase).toBe(2);
+      expect(verdict.clarityScores).toEqual({ goal: 0.45, constraint: 0.60, success: 0.85, context: 0.90 });
+      expect(verdict.ambiguity).toBeCloseTo(0.3475, 4);
+      expect(verdict.ambiguityThreshold).toBe(0.2);
+      expect(verdict.ambiguityVetoed).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('does NOT emit clarityScores/ambiguity fields on phase-4 gate_verdict', async () => {
+    const runDir = makeTmpDir();
+    const state = makeState({ currentPhase: 4 });
+    const { logger, eventsPath, cleanup } = makeTestLogger(state.runId);
+
+    vi.mocked(runGatePhase).mockResolvedValueOnce({
+      type: 'verdict',
+      verdict: 'APPROVE',
+      comments: '',
+      rawOutput: '',
+      runner: 'codex',
+      promptBytes: 1000,
+      durationMs: 5000,
+    } as any);
+
+    try {
+      await handleGatePhase(4, state, HDIR, runDir, CWD, createNoOpInputManager(), logger, { value: false });
+      const events = readEvents(eventsPath);
+      const verdict = events.find((e: any) => e.event === 'gate_verdict');
+      expect(verdict).toBeDefined();
+      expect(verdict.phase).toBe(4);
+      expect(verdict.clarityScores).toBeUndefined();
+      expect(verdict.ambiguity).toBeUndefined();
+      expect(verdict.ambiguityVetoed).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/tests/phases/verdict.test.ts
+++ b/tests/phases/verdict.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { buildGateResult, extractCodexMetadata, parseVerdict } from '../../src/phases/verdict.js';
+import {
+  buildGateResult,
+  extractCodexMetadata,
+  parseVerdict,
+  parseClarityScores,
+  computeWeightedAmbiguity,
+  AMBIGUITY_AXES,
+  CLARITY_WEIGHTS,
+} from '../../src/phases/verdict.js';
 
 describe('parseVerdict', () => {
   it('parses REJECT with Scope: impl', () => {
@@ -141,13 +149,6 @@ more blah`;
     expect(extractCodexMetadata('session id: 1234-5678').codexSessionId).toBe('1234-5678');
   });
 });
-
-import {
-  parseClarityScores,
-  computeWeightedAmbiguity,
-  AMBIGUITY_AXES,
-  CLARITY_WEIGHTS,
-} from '../../src/phases/verdict.js';
 
 describe('parseClarityScores', () => {
   const good = [

--- a/tests/phases/verdict.test.ts
+++ b/tests/phases/verdict.test.ts
@@ -141,3 +141,103 @@ more blah`;
     expect(extractCodexMetadata('session id: 1234-5678').codexSessionId).toBe('1234-5678');
   });
 });
+
+import {
+  parseClarityScores,
+  computeWeightedAmbiguity,
+  AMBIGUITY_AXES,
+  CLARITY_WEIGHTS,
+} from '../../src/phases/verdict.js';
+
+describe('parseClarityScores', () => {
+  const good = [
+    '## Verdict', 'APPROVE',
+    '## Comments', '- looks good',
+    '## Summary', 'All clear.',
+    '## Clarity Scores',
+    '- goal: 0.85',
+    '- constraint: 0.70',
+    '- success: 0.90',
+    '- context: 0.60',
+  ].join('\n');
+
+  it('parses a well-formed block', () => {
+    const scores = parseClarityScores(good);
+    expect(scores).toEqual({ goal: 0.85, constraint: 0.70, success: 0.90, context: 0.60 });
+  });
+
+  it('returns null when ## Clarity Scores header is absent', () => {
+    expect(parseClarityScores('## Verdict\nAPPROVE\n## Summary\nOK.')).toBeNull();
+  });
+
+  it('returns null when any axis is missing', () => {
+    const partial = '## Clarity Scores\n- goal: 0.9\n- constraint: 0.8\n- success: 0.7\n';
+    expect(parseClarityScores(partial)).toBeNull();
+  });
+
+  it('returns null when any value is outside [0, 1]', () => {
+    const neg = '## Clarity Scores\n- goal: -0.1\n- constraint: 0.8\n- success: 0.7\n- context: 0.5\n';
+    const big = '## Clarity Scores\n- goal: 1.1\n- constraint: 0.8\n- success: 0.7\n- context: 0.5\n';
+    expect(parseClarityScores(neg)).toBeNull();
+    expect(parseClarityScores(big)).toBeNull();
+  });
+
+  it('accepts integer values (goal: 1 treated as 1.0)', () => {
+    const intVals = '## Clarity Scores\n- goal: 1\n- constraint: 0\n- success: 1\n- context: 0\n';
+    const scores = parseClarityScores(intVals);
+    expect(scores).toEqual({ goal: 1, constraint: 0, success: 1, context: 0 });
+  });
+
+  it('is case-insensitive on header and axis names', () => {
+    const mixed = '## clarity scores\n- Goal: 0.9\n- CONSTRAINT: 0.8\n- Success: 0.7\n- Context: 0.6\n';
+    expect(parseClarityScores(mixed)).toEqual({ goal: 0.9, constraint: 0.8, success: 0.7, context: 0.6 });
+  });
+
+  it('first duplicate axis wins, others ignored', () => {
+    const dup = '## Clarity Scores\n- goal: 0.9\n- goal: 0.1\n- constraint: 0.8\n- success: 0.7\n- context: 0.6\n';
+    const scores = parseClarityScores(dup);
+    expect(scores?.goal).toBe(0.9);
+  });
+
+  it('stops scanning at next ## header', () => {
+    const stop = '## Clarity Scores\n- goal: 0.9\n- constraint: 0.8\n## Other\n- success: 0.7\n- context: 0.6\n';
+    expect(parseClarityScores(stop)).toBeNull(); // success and context after ##, so missing
+  });
+
+  it('tolerates extra whitespace around separator', () => {
+    const spacy = '## Clarity Scores\n  -  goal :  0.85  \n- constraint: 0.70\n- success: 0.90\n- context: 0.60\n';
+    expect(parseClarityScores(spacy)).toEqual({ goal: 0.85, constraint: 0.70, success: 0.90, context: 0.60 });
+  });
+});
+
+describe('computeWeightedAmbiguity', () => {
+  it('all 1.0 scores → ambiguity 0.0', () => {
+    expect(computeWeightedAmbiguity({ goal: 1, constraint: 1, success: 1, context: 1 })).toBe(0);
+  });
+
+  it('all 0.0 scores → ambiguity 1.0', () => {
+    expect(computeWeightedAmbiguity({ goal: 0, constraint: 0, success: 0, context: 0 })).toBe(1);
+  });
+
+  it('weights sum to 1.0 (invariant)', () => {
+    const sum = Object.values(CLARITY_WEIGHTS).reduce((a, b) => a + b, 0);
+    expect(sum).toBeCloseTo(1.0, 10);
+  });
+
+  it('matches manual calculation', () => {
+    // goal=0.45 *0.35 + constraint=0.60 *0.25 + success=0.85 *0.30 + context=0.90 *0.10
+    // = 0.1575 + 0.15 + 0.255 + 0.09 = 0.6525 → ambiguity = 1 - 0.6525 = 0.3475
+    const scores = { goal: 0.45, constraint: 0.60, success: 0.85, context: 0.90 };
+    expect(computeWeightedAmbiguity(scores)).toBeCloseTo(0.3475, 6);
+  });
+
+  it('result is clamped to [0, 1]', () => {
+    const result = computeWeightedAmbiguity({ goal: 1, constraint: 1, success: 1, context: 1 });
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(1);
+  });
+
+  it('AMBIGUITY_AXES contains exactly goal, constraint, success, context', () => {
+    expect([...AMBIGUITY_AXES].sort()).toEqual(['constraint', 'context', 'goal', 'success']);
+  });
+});


### PR DESCRIPTION
## Summary

P2 spec-gate verdict has been Codex-qualitative only — same spec, two different reviews can disagree. This PR adds a 4-axis weighted clarity score that Codex emits alongside the verdict, and lets the harness deterministically veto a qualitative APPROVE when ambiguity exceeds a configurable threshold.

- New `src/phases/ambiguity.ts` — `loadAmbiguityThreshold()` + `applyAmbiguityGate()`. Pure functions, no LLM, no new deps.
- `src/phases/verdict.ts` — `parseClarityScores`, `computeWeightedAmbiguity`, `AMBIGUITY_AXES`, `CLARITY_WEIGHTS` (goal 0.35 / constraint 0.25 / success 0.30 / context 0.10).
- `src/context/assembler.ts` — `CLARITY_SCORES_PROTOCOL` appended to `FIVE_AXIS_SPEC_GATE` only; resume-prompt reminder gains a Phase-2 bullet (full-flow only — light-flow P2 is out of scope and uses `FIVE_AXIS_DESIGN_GATE_LIGHT`).
- `src/phases/gate.ts` — `applyAmbiguityGate` runs once after `buildGateResultFromFile`; on veto, rewrites verdict to REJECT, prepends a synthetic `[P1]` finding with the per-axis breakdown, and forces `Scope: design`. Sidecar JSON persists scores so replay re-emits the same `gate_verdict` shape.
- `src/types.ts` — five optional fields on `GateOutcome` / `GateError` / `GateResult` and the `gate_verdict` LogEvent variant: `clarityScores`, `ambiguity`, `ambiguityThreshold`, `ambiguityVetoed`, `clarityParseError`. Additive — legacy sidecars/readers unaffected.

### Configuration

- `HARNESS_GATE_AMBIGUITY_THRESHOLD` (default `0.2`, accepts `off`). Direction: weighted ambiguity `>` threshold ⇒ veto. Invalid values fail open with one stderr warning.
- Gates 4/7 emit no scores, parse nothing, behave exactly as today.

### Inspired by

[Q00/ouroboros](https://github.com/Q00/ouroboros) — `Ambiguity = 1 − Σ(clarity_i · w_i)`, threshold `≤ 0.2`. Scoped to the P2 noise this repo actually has; no temperature override yet (Codex CLI doesn't expose one — deferred).

### Dogfood notes

This PR was produced by phase-harness itself, then closed out by hand: P7 R1 caught two real spec-vs-implementation gaps (sidecar didn't roundtrip ambiguity fields; light-flow P2 resume wrongly inherited the Clarity Scores bullet). Both are addressed in the final commits (`eea57c6`, `c6676ed`). Manual close-out was needed because the harness wedged on \"Starting phase\" after retry-limit in manual mode without emitting an escalation event — separately tracked in https://github.com/DongGukMon/harness-cli/issues (filed alongside this PR).

## Test plan

- [x] \`pnpm tsc --noEmit\` (clean)
- [x] \`pnpm vitest run\` — 1144 passed / 1 skipped (pre-existing)
- [x] New tests:
  - \`tests/phases/gate.test.ts\` — extended-sidecar replay hydrates all five ambiguity fields
  - \`tests/context/assembler.test.ts\` — light-flow P2 \`assembleGateResumePrompt\` does NOT contain \`## Clarity Scores\`
- [x] \`pnpm build\` (clean)
- [ ] Verify with a real P2 reject in next dogfood (threshold default 0.2)
- [ ] Confirm \`HARNESS_GATE_AMBIGUITY_THRESHOLD=off\` reproduces pre-PR behavior