### PR TITLE
feat(drift): P5 → P6 drift detection with Codex 1-call scorer (v1)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -239,6 +239,7 @@ phase-harness start --root /tmp/demo "task"
 | `HARNESS_GATE_STAGNATION_RUN` | `2` | 에스컬레이션 전 연속 정체 쌍 수 (최소 2) |
 | `HARNESS_GATE_STAGNATION_WINDOW` | `2` | 향후 사용 예약; 현재 2로 고정 (쌍 비교) |
 | `HARNESS_GATE_AMBIGUITY_THRESHOLD` | `0.2` | P2 spec gate 모호성 거부권 임계값 [0, 1]. `off`로 비활성화(점수는 여전히 로깅). 유효하지 않은 값 → 거부권 비활성화 + stderr 경고 1회. |
+| `HARNESS_PHASE_DRIFT_THRESHOLD` | `0.3` (자율) / `null` (수동) | P5 → P6 드리프트 검출 임계값 [0, 1]. 미설정 = 자율 모드 기본 0.3 / 수동 비활성화; 숫자 = 모드와 무관하게 그 값으로 활성화; `off` = 비활성화. 유효하지 않은 값 → 비활성화 + stderr 경고 1회. P5 성공 후 Codex 1회 호출로 점수를 산출하고 `score > threshold`면 P5를 합성 피드백과 함께 reopen합니다. **드리프트 검출 (P5→P6)** 자세한 내용은 HOW-IT-WORKS 참고. |
 
 처음 세 변수에 잘못된 값이 있으면 해당 프로세스에서 기능이 비활성화되고 stderr에 경고 하나가 출력됩니다. 수동 모드에서는 항상 비활성화됩니다.
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ When running with `--auto`, harness detects *stagnant* gate retry cycles — whe
 | `HARNESS_GATE_STAGNATION_RUN` | `2` | Consecutive stagnant pairs required before escalation (min 2) |
 | `HARNESS_GATE_STAGNATION_WINDOW` | `2` | Reserved for future use; currently fixed at 2 (pair comparison) |
 | `HARNESS_GATE_AMBIGUITY_THRESHOLD` | `0.2` | P2 spec gate ambiguity veto threshold [0, 1]. Set to `off` to disable veto (scores still logged). Invalid value → veto disabled + one stderr warning. |
+| `HARNESS_PHASE_DRIFT_THRESHOLD` | `0.3` (auto) / `null` (manual) | P5 → P6 drift detection threshold [0, 1]. Unset = auto-mode default 0.3 / manual disabled; numeric = enabled at that value (any mode); `off` = disabled. Invalid value → disabled + one stderr warning. Drift detection issues a single Codex call after a successful P5; when `score > threshold`, P5 is reopened with synthetic feedback. **Drift detection (P5→P6)**: see HOW-IT-WORKS for details. |
 
 Any invalid value for the first three variables disables the feature for that process and emits one warning to stderr. The feature is always off in manual mode.
 

--- a/docs/HOW-IT-WORKS.ko.md
+++ b/docs/HOW-IT-WORKS.ko.md
@@ -90,10 +90,27 @@ light flow 특이사항:
 - `HARNESS_GATE_STAGNATION_RUN=2` (연속 정체 쌍 2개 필요)
 - `HARNESS_GATE_STAGNATION_WINDOW=2` (예약됨; v1에서는 no-op)
 - `HARNESS_GATE_AMBIGUITY_THRESHOLD=0.2` — P2 spec gate 모호성 거부권 임계값 [0, 1]. `=off`로 비활성화(점수는 여전히 로깅). 유효하지 않은 값 → 거부권 비활성화 + stderr 경고 1회.
+- `HARNESS_PHASE_DRIFT_THRESHOLD=0.3` (자율 모드 기본값; 수동 모드에서는 기본 비활성) — P5 → P6 드리프트 검출 임계값 [0, 1]. 자세한 내용은 아래 **드리프트 검출 (P5→P6)** 참고.
 
 처음 세 변수의 잘못된 값은 기능을 fail-open으로 비활성화합니다 (프로세스당 키당 최대 1회 stderr 경고). 감지기 버퍼는 메모리 내에만 존재하며, 일시정지된 실행을 재개하면 빈 상태로 시작됩니다.
 
 **새 `events.jsonl` 이벤트:** `gate_stagnation`은 트리거된 감지당 한 번 `escalation` 이벤트 바로 전에 발생하며, `phase`, `retryIndex`, `similarities[]`, `threshold`, `run`, `action: 'escalate'` 필드를 포함합니다.
+
+### 드리프트 검출 (P5→P6)
+
+P5(구현) 페이즈가 성공한 직후, harness는 P6(검증) 진입 전에 구현이 spec/plan에서 얼마나 어긋났는지 선택적으로 측정할 수 있다. 드리프트 검출은 P5 시도당 정확히 **Codex 1회 호출**을 발생시키며, spec / plan / `git diff planCommit..implCommit` 을 입력으로 보내고 Codex가 `## Drift Scores` 코드 펜스 안에 세 축 점수(`goal`, `constraint`, `ontology`)를 JSON으로 emit한다. harness는 `score = 0.5·goal + 0.3·constraint + 0.2·ontology`를 계산해 `HARNESS_PHASE_DRIFT_THRESHOLD`와 비교한다.
+
+- `score ≤ threshold` → P5 completed, P6 진입.
+- `score > threshold` → harness가 `<runDir>/drift-feedback.md`를 작성하고 `phaseReopenSource['5']=5`, `pendingAction.type='reopen_phase'`로 P5를 reopen한 뒤 `phase_end status='failed' details.reason='drift-reopen'`을 emit.
+- Codex 실패(timeout / non-zero exit / parse error / spec+plan 캡 초과) → fail-open: P5는 정상 success path로, P6 진입. stderr 경고 1회만.
+
+활성화 기본값은 모드에 의해 결정된다 — 자율 모드에서는 임계값 `0.3`, 수동 모드에서는 env가 명시적인 숫자가 아닌 한 비활성화. `=off`는 명시적 비활성화. 드리프트 검출은 `flow='full'` / `flow='light'` 양쪽 모두에서 페이즈 5 한정으로 동작한다. 축별 가중치와 30 000자 프롬프트 캡은 코드에 baked-in.
+
+**새 `events.jsonl` 이벤트:** 드리프트 검출이 활성화된 P5 시도(즉 임계값이 non-null)에서 한 번씩 `phase_drift`가 emit된다. 필드: `phase: 5`, `attemptId`, `durationMs`, `threshold`, `score` (number 또는 null), `axes` (object 또는 null), `action: 'pass' | 'reopen' | 'error'`, `driftSource: 'codex-only' | 'codex-truncated' | 'error'`, optional `codexTokensTotal`, optional `rationale` (≤ 200자), optional `error`. 이벤트 부재 = 드리프트 검출이 그 run에서 비활성. reader는 부재를 기본값으로 처리해야 한다.
+
+**확장된 스키마:** `phase_drift action='reopen'` 직후의 P5 phase\_end는 `details.reason: 'drift-reopen'`을 가질 수 있다.
+
+원래 설계에 있던 결정론적 floor (spec의 `## Success Criteria` / `## Invariants`에서 grep 규칙 추출)는 follow-up PR로 deferred됨; v1은 Codex-only.
 
 **확장된 스키마:** `escalation.reason`은 기존 네 가지 값에 더해 `'gate-stagnation'`을 포함합니다.
 

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -90,10 +90,27 @@ In auto-mode, when a gate phase is rejected `retryLimit` times in a row, harness
 - `HARNESS_GATE_STAGNATION_RUN=2` (two consecutive stagnant pairs required)
 - `HARNESS_GATE_STAGNATION_WINDOW=2` (reserved; no-op in v1)
 - `HARNESS_GATE_AMBIGUITY_THRESHOLD=0.2` — P2 spec gate ambiguity veto threshold [0, 1]. `=off` to disable veto (scores still logged). Invalid value → veto disabled + one stderr warning.
+- `HARNESS_PHASE_DRIFT_THRESHOLD=0.3` (auto-mode default; manual mode default disabled) — P5 → P6 drift detection threshold [0, 1]. See **Drift detection (P5→P6)** below.
 
 Invalid values for the first three vars disable the feature fail-open (one stderr warn per key per process). The detector buffer is in-memory only; resuming a paused run starts empty.
 
 **New `events.jsonl` event:** `gate_stagnation` is emitted once per triggered detection, immediately before the `escalation` event, with fields `phase`, `retryIndex`, `similarities[]`, `threshold`, `run`, `action: 'escalate'`.
+
+### Drift detection (P5→P6)
+
+After a successful P5 (impl) phase, harness can optionally score how far the implementation has drifted from the approved spec/plan before advancing to P6 (verify). Drift detection issues exactly **one Codex call per P5 attempt** with the spec, plan, and `git diff planCommit..implCommit` as input, and Codex emits three axis scores (`goal`, `constraint`, `ontology`) inside a `## Drift Scores` fenced JSON block. The harness computes `score = 0.5·goal + 0.3·constraint + 0.2·ontology` and compares it against `HARNESS_PHASE_DRIFT_THRESHOLD`.
+
+- `score ≤ threshold` → P5 marked completed, P6 entered as today.
+- `score > threshold` → harness writes `<runDir>/drift-feedback.md`, reopens P5 with `phaseReopenSource['5']=5` and `pendingAction.type='reopen_phase'`, and emits `phase_end status='failed' details.reason='drift-reopen'`.
+- Codex failure (timeout / non-zero exit / parse error / oversized spec+plan) → fail-open: P5 succeeds, P6 enters as today. One stderr warning is emitted.
+
+Default activation is mode-driven: in auto-mode the threshold defaults to `0.3`; in manual mode the feature is disabled unless the env is set to a numeric value. `=off` disables it explicitly. Drift detection runs in both `flow='full'` and `flow='light'` runs, on phase 5 only. Per-axis weights and the 30 000-char prompt cap are baked in.
+
+**New `events.jsonl` event:** `phase_drift` is emitted once per P5 attempt when drift detection is active (i.e. threshold non-null). Fields: `phase: 5`, `attemptId`, `durationMs`, `threshold`, `score` (number or null), `axes` (object or null), `action: 'pass' | 'reopen' | 'error'`, `driftSource: 'codex-only' | 'codex-truncated' | 'error'`, optional `codexTokensTotal`, optional `rationale` (≤ 200 chars), optional `error`. Absence of the event = drift detection was disabled for that run; readers MUST treat absence as the default.
+
+**Extended schema:** `phase_end.details.reason` may now be `'drift-reopen'` on the P5 phase\_end that immediately follows a `phase_drift action='reopen'`.
+
+The deterministic floor described in the original design (grep-rule extraction from `## Success Criteria` / `## Invariants`) is deferred to a follow-up PR; v1 is Codex-only.
 
 **Extended schema:** `escalation.reason` now includes `'gate-stagnation'` in addition to the four pre-existing values.
 

--- a/docs/specs/2026-05-11-p5-spec-plan-drift-p5-p6-4a02-design.md
+++ b/docs/specs/2026-05-11-p5-spec-plan-drift-p5-p6-4a02-design.md
@@ -12,7 +12,7 @@
 P5 implementations regularly satisfy interactive completion criteria yet violate the spec/plan in ways that only surface at the P7 eval gate. The two most recent dogfood runs (#1, #4) both burned a P7 R1 REJECT → P5 R2 cycle for the same root cause: drift was caught too late. We need a quantitative drift signal at P5 phase\_end that can short-circuit the P6 entry when implementation has measurably diverged from the approved spec/plan.
 
 ### Decisions made up-front (rationale moved to decisions.md)
-- **D1. Hybrid scorer**: Codex 1-call + deterministic floor; final axis = `max(codex_axis, floor_axis)`. Codex captures semantic drift; floor (grep rules from `## Success Criteria` / `## Invariants`) gives a noise-resistant lower bound.
+- **D1. Codex 1-call scorer (v1)**: a single Codex non-interactive call returns the three axis scores directly. The deterministic floor (grep-rule extraction + per-axis floor mapping) was reviewed and accepted at design time but is **deferred to a follow-up PR** (see `## Deferred`) to keep this iteration shippable; without the floor, score = Codex axes directly. D6 (strict fail-open on Codex failure) already specifies that the floor never gates without Codex, so removing it preserves the P5 success-path semantics.
 - **D2. Mode-driven branch on threshold-exceeded**: `autoMode=true` → hard reopen P5; `autoMode=false` → user prompt (C/S/Q).
 - **D3. Mode-driven activation default via single env**: `HARNESS_PHASE_DRIFT_THRESHOLD`. unset+autoMode → 0.3, unset+manual → disabled, numeric → enabled at that value, `off` → disabled, invalid → disabled + one stderr warn.
 - **D4. New `phase_drift` event**, not a `phase_end` extension. Keeps reader/aggregator changes additive.
@@ -36,7 +36,7 @@ Medium — single new module (`src/phases/drift.ts`) plus targeted edits in `run
   - Manual mode → prompt the user with C/S/Q; route accordingly.
 - **G4.** When drift detection is disabled (env=off, manual default, or env invalid), behaviour is byte-identical to today's P5 success path (no `phase_drift` event, no extra Codex call, no `phase_end.details` change).
 - **G5.** Make threshold and activation user-tunable through a single env var; document defaults / disable / fail-open semantics in README + HOW-IT-WORKS (en + ko).
-- **G6.** Telemetry survives crash and resume — drift detection is idempotent across resume of an in-flight P5.
+- **G6.** Drift detection re-runs cleanly on resume — when a crashed P5 is resumed, the next `phase_end` re-triggers `scoreP5Drift` from scratch (at most one Codex call per fresh P5 attempt). Byte-precision idempotency of crash mid-`phase_drift`-flush is explicitly out of scope and tracked in `## Deferred`.
 
 ## Non-Goals
 
@@ -52,10 +52,8 @@ Medium — single new module (`src/phases/drift.ts`) plus targeted edits in `run
 ### Module layout
 - **`src/phases/drift.ts`** (new). Exports:
   - `loadDriftThreshold(autoMode: boolean): number | null`
-  - `extractDeterministicFloor(specText: string, cwd: string): { goal: number; constraint: number; ontology: number; ruleCount: number }`
   - `parseDriftScores(rawOutput: string): { goal: number; constraint: number; ontology: number; rationale?: string } | null`
   - `computeWeightedDrift(axes: { goal: number; constraint: number; ontology: number }): number`
-  - `mergeAxes(floor, codex): { goal; constraint; ontology }`
   - `scoreP5Drift(state, runDir, cwd, logger): Promise<DriftOutcome>` — orchestrator
   - `handleDriftEscalation(state, runDir, cwd, inputManager, logger, outcome): Promise<DriftAction>` — manual-mode prompt
   - `__resetDriftWarning()` — test hook (mirrors `__resetAmbiguityWarning`).
@@ -130,6 +128,7 @@ Carry-over via `state.carryoverFeedback` is **not** used — drift reopen routes
 - `planText`: read from `state.artifacts.plan` (full file).
 - `diffText`: `git diff <state.planCommit>..<state.implCommit> --` executed in `state.trackedRepos[0].path` (fallback to `cwd` if `trackedRepos` is empty).
 - **Truncation cap**: assemble the prompt; if `len(spec)+len(plan)+len(diff) > 30 000` chars, truncate the diff tail (preserving header + first ≈ 20 000 chars of diff). On cap hit, set `driftSource: 'codex-truncated'`. Spec / plan are never truncated.
+- **Oversized spec/plan boundary**: if `len(spec)+len(plan) > 30 000` alone (i.e. the cap cannot be satisfied even with `diff = ""`), `scoreP5Drift` does NOT call Codex; it short-circuits to `action='error'`, `driftSource='error'`, `score=null`, `axes=null`, fail-open. This keeps the cap a hard contract instead of an undefined-behavior region. Single stderr warn line: `[drift] spec+plan exceeds 30 000-char cap (...) — drift detection skipped for this attempt`.
 
 ### Codex 1-call
 - Function: `runCodexDriftScorer(...)` — one shot, non-interactive Codex CLI invocation, sandbox=read-only.
@@ -146,33 +145,16 @@ Carry-over via `state.carryoverFeedback` is **not** used — drift reopen routes
   - `rationale` is a single-line string (newlines stripped, length-clamped to 200 chars at scorer side).
   - Token budget recorded as `codexTokensTotal` on the event when reported by the runner.
 
-### Deterministic floor
-- Walk the spec text, isolate the bodies of `## Success Criteria` and `## Invariants` (case-insensitive matching at the heading level).
-- Within those bodies, harvest **machine-checkable rules** of the following shapes only:
-  1. A fenced code block whose first line begins with `grep -E ` / `grep -P ` / `rg -e ` (entire fenced block treated as a single shell rule).
-  2. An inline backtick-quoted regex on a bullet that starts with `must`, `MUST`, `반드시`, `항상`, `forbidden`, `must not`, `금지` (case-insensitive English / Korean keywords). The regex is the literal between backticks.
-- Execute each rule against the working tree at `cwd` (`git ls-files | xargs grep -E ...` for grep rules; `find` + per-file `RegExp` for regex rules) — **read-only**, no writes. Time budget: ≤ 5 s total; if exceeded, abort the floor and treat it as no-op (`ruleCount = 0`).
-- Mapping rule violations → axis floors:
-  | Violation kind | Axis | Floor contribution |
-  |---|---|---|
-  | "must contain X" rule with no match | `goal` | 0.5 (1 violation) → 1.0 (≥ 2) |
-  | "forbidden / must not / 금지" rule with ≥ 1 match | `constraint` | 0.7 |
-  | Other violations (general regex misses) | `ontology` | 0.3 |
-- If `ruleCount === 0`, the floor is `{ goal: 0, constraint: 0, ontology: 0 }` (no-op). No false positives on specs lacking machine rules.
-
-### Merge & weighted score
+### Weighted score
 ```
-axes        = { goal: max(floor.goal, codex.goal ?? 0),
-                constraint: max(floor.constraint, codex.constraint ?? 0),
-                ontology: max(floor.ontology, codex.ontology ?? 0) }
+axes        = { goal: codex.goal, constraint: codex.constraint, ontology: codex.ontology }
 score       = clamp01(0.5*axes.goal + 0.3*axes.constraint + 0.2*axes.ontology)
 ```
 
 ### `driftSource` taxonomy
-- `'codex+floor'` — Codex parsed AND floor produced findings (`ruleCount > 0`); axes merged via `max`
-- `'codex-only'` — Codex parsed AND floor was no-op (`ruleCount === 0`)
-- `'codex-truncated'` — prompt cap hit; Codex output still parsed; floor merged or no-op as above
-- `'error'` — Codex did not produce a parsable response (throw / non-zero exit / timeout / parse failure / out-of-range axes). Emit `phase_drift` with `score=null`, `axes=null`, `action='error'`, fail-open. The deterministic floor's findings are NOT used to drive `pass`/`reopen` in this branch — see D6.
+- `'codex-only'` — Codex parsed within budget (no truncation, no error). The default success label.
+- `'codex-truncated'` — prompt cap hit (D5 truncation rule applied); Codex output still parsed.
+- `'error'` — Codex did not produce a parsable response (throw / non-zero exit / timeout / parse failure / out-of-range axes / spec+plan over cap per D5 oversized-boundary). Emit `phase_drift` with `score=null`, `axes=null`, `action='error'`, fail-open.
 
 ## Threshold & action
 
@@ -215,10 +197,9 @@ Contains: drift score, threshold, axes table, source, Codex rationale (escaped),
   action: 'pass' | 'reopen'
         | 'escalate-continue' | 'escalate-skip' | 'escalate-quit'
         | 'error';
-  driftSource: 'codex+floor' | 'codex-only' | 'codex-truncated' | 'error';
+  driftSource: 'codex-only' | 'codex-truncated' | 'error';
   codexTokensTotal?: number;  // only when Codex produced a response (success or parse-fail)
   rationale?: string;         // ≤ 200 chars, single line
-  floorRules?: number;        // rule count extracted by deterministic floor
   error?: string;             // only when action='error'; one-line cause
 }
 ```
@@ -300,7 +281,7 @@ A `grep -l` chain over those four files is part of the eval checklist; absence i
 - **S2.** When `state.autoMode === false` and env unset, a P5 success run never emits `phase_drift` and never invokes Codex; `phase_end` payload matches today's snapshot byte-for-byte (regression fixture).
 - **S3.** With env=`off`, behaviour matches S2.
 - **S4.** With env=`abc` (invalid), behaviour matches S2 plus exactly one stderr line containing the literal `[drift] invalid HARNESS_PHASE_DRIFT_THRESHOLD`.
-- **S5.** Codex failure (mock throws / non-zero exit / non-JSON / out-of-range axes) produces `phase_drift` with `action='error'`, `score=null`, `axes=null`, `driftSource='error'`; `phase_end` is `completed`; `currentPhase` advances to 6; exactly one stderr warn line is emitted. This holds **regardless** of deterministic-floor `ruleCount` — including the case where one or more "must contain X" rules would have matched (verified by an explicit test fixture per D6 strict fail-open).
+- **S5.** Codex failure (mock throws / non-zero exit / non-JSON / out-of-range axes / spec+plan over cap) produces `phase_drift` with `action='error'`, `score=null`, `axes=null`, `driftSource='error'`; `phase_end` is `completed`; `currentPhase` advances to 6; exactly one stderr warn line is emitted (per D6 strict fail-open).
 - **S6.** With `state.autoMode === false` and threshold-exceeded, the C/S/Q prompt routes to: 'C' = reopen branch identical to S1 except `action='escalate-continue'`; 'S' = success path with `action='escalate-skip'`; 'Q' = paused state with `pauseReason='drift-escalation'`.
 - **S7.** Codex is invoked at most once per P5 attempt (verified by mock call-count assertion in integration tests).
 - **S8.** No new npm dependency: `git diff` on `package.json` and `pnpm-lock.yaml` from baseline shows no added entries (only churn allowed is version bump if scope demands).
@@ -313,7 +294,7 @@ A `grep -l` chain over those four files is part of the eval checklist; absence i
 - **I2.** `phase_drift` always precedes the paired `phase_end` in `events.jsonl`; both share the same `attemptId`.
 - **I3.** Per single P5 attempt (one phase\_start → one phase\_end), at most one `phase_drift` event is emitted and at most one Codex drift call is made.
 - **I4.** Drift detection never converts a `result.status === 'failed'` P5 into `completed`, and never converts a `result.status === 'completed'` P5 into `completed` _and_ advances `currentPhase` past 5 when `action ∈ {'reopen','escalate-continue','escalate-quit'}`.
-- **I5.** A scorer/Codex failure (any throw, any timeout, any parse error, any out-of-range axis) MUST NOT raise out of `scoreP5Drift`; it returns `action='error'` with `score=null`, `axes=null`, `driftSource='error'`, and the P5 success path proceeds. Deterministic-floor findings never gate when Codex fails — they are silently discarded in the error branch (per D6).
+- **I5.** A scorer/Codex failure (any throw, any timeout, any parse error, any out-of-range axis) MUST NOT raise out of `scoreP5Drift`; it returns `action='error'` with `score=null`, `axes=null`, `driftSource='error'`, and the P5 success path proceeds (per D6).
 - **I6.** No write to `state.json` from inside `scoreP5Drift` other than the existing reopen-branch state mutation already performed in the runner; the scorer itself is read-only against state.
 - **I7.** `state.json` schema is unchanged. No new top-level field. The new `PauseReason='drift-escalation'` / `PendingActionType='show_drift_escalation'` are union-additive and never written by code paths outside drift escalation.
 - **I8.** `phase_drift.threshold` always equals the number returned by `loadDriftThreshold` for that run; `phase_drift.score`, when non-null, is in `[0, 1]`; each axis, when non-null, is in `[0, 1]`.
@@ -326,7 +307,6 @@ A `grep -l` chain over those four files is part of the eval checklist; absence i
 |---|---|---|
 | Codex 1-call returns hallucinated high drift on a correct impl | medium | Hybrid (`max` with floor), low default threshold (0.3), C/S/Q escape hatch in manual mode, autoMode reopen capped by existing P5 retry loop. Telemetry retains rationale for post-hoc audit. |
 | Codex parse drift if Codex CLI changes output schema | low | Single regex parser (`## Drift Scores` → fenced JSON); parse failure is fail-open (no run-blocking); per-version Codex change requires updating the parser only. |
-| Deterministic floor false-positives on freeform specs | medium | Floor only fires when explicit `must / forbidden / 반드시 / 금지` keywords + machine-checkable patterns are present; no rules → floor is no-op. |
 | Token cost overrun | low | 30 000-char prompt cap (≈ 8K tokens); ≤ 1 call per attempt; budget documented in spec & README. |
 | Reopen loop (drift score never falls below threshold) | medium | Existing P5 stagnation handling and overall harness pause/exit semantics already cover infinite reopen patterns; no new reopen budget added in this iteration (to be revisited in a follow-up if dogfood shows the symptom). |
 | Resume mid-drift (process killed between Codex call and event flush) | low | Drift detection is idempotent: on resume, `runInteractivePhase` will re-run P5 → re-trigger drift on the next phase\_end. Worst case is a duplicate Codex call across two attempts, never within one. |
@@ -343,3 +323,4 @@ A `grep -l` chain over those four files is part of the eval checklist; absence i
 ## Deferred
 
 - **P2 (gate-2 R1) — crash-window resume contract.** Crash between `phase_drift` flush and the paired `phase_end`/state mutation is not specified at byte-precision in this iteration. Planned semantics: at-least-once telemetry with reader-side dedupe by `(attemptId, event='phase_drift')`; no Codex re-call on resume of the same attempt (P5 will re-run as a new attempt, drift will rescore once for that new attempt). Properly specifying and testing the resume code path requires touching `state.ts` resume helpers and is deferred to a follow-up to keep this spec scoped to a single implementation plan.
+- **Deterministic floor (advisor-trimmed).** The original D1 hybrid scorer added a `## Success Criteria` / `## Invariants` grep-rule extraction layer that floors per-axis scores when machine-checkable patterns are violated. v1 ships Codex-only because D6 already specifies the floor never gates without Codex (so removing it preserves P5 success-path semantics). The floor remains valuable as a noise-resistant guardrail when Codex underestimates drift; it lands as a follow-up PR. v1's `driftSource` taxonomy has space for the future `'codex+floor'` value without an enum-breaking change.

--- a/docs/specs/2026-05-11-p5-spec-plan-drift-p5-p6-4a02-design.md
+++ b/docs/specs/2026-05-11-p5-spec-plan-drift-p5-p6-4a02-design.md
@@ -17,7 +17,7 @@ P5 implementations regularly satisfy interactive completion criteria yet violate
 - **D3. Mode-driven activation default via single env**: `HARNESS_PHASE_DRIFT_THRESHOLD`. unset+autoMode → 0.3, unset+manual → disabled, numeric → enabled at that value, `off` → disabled, invalid → disabled + one stderr warn.
 - **D4. New `phase_drift` event**, not a `phase_end` extension. Keeps reader/aggregator changes additive.
 - **D5. Codex inputs**: spec full text + plan full text + `git diff planCommit..implCommit`, with a 30 000-char prompt cap; on cap hit, the diff tail is truncated and `driftSource: 'codex-truncated'` is set.
-- **D6. Fail-open everywhere**: scorer error / Codex hang / parse error / network failure must NOT flip a successful P5. They emit `phase_drift.action='error'` (or fall back to floor-only) and let P6 proceed.
+- **D6. Strict fail-open on Codex failure**: scorer error / Codex hang / parse error / network failure must NOT flip a successful P5. Any Codex failure (regardless of deterministic-floor findings) emits `phase_drift.action='error'` with `score=null`, `axes=null`, `driftSource='error'` and lets P6 proceed. The deterministic floor never gates by itself — it only contributes to the score when Codex also produced a parsable response. This keeps drift detection a single integrated signal: either both halves agree on a number, or the run is treated as unmeasured.
 - **D7. No new dependencies**. Reuses `runners/codex.ts` invocation primitives. No npm package added.
 - **D8. Backward compatibility**: drift event is purely additive; absence of the event must not change any existing reader / footer / retrospective behaviour. State schema unchanged.
 - **D9. Scope = both flows (full + light)**. P5 → P6 transition exists in both flow modes; drift detection runs in both.
@@ -154,11 +154,10 @@ score       = clamp01(0.5*axes.goal + 0.3*axes.constraint + 0.2*axes.ontology)
 ```
 
 ### `driftSource` taxonomy
-- `'codex+floor'` — both produced numbers
-- `'codex-only'` — floor was no-op (`ruleCount === 0`)
-- `'floor-only'` — Codex parse error / non-zero exit / timeout, but `ruleCount > 0`
-- `'codex-truncated'` — prompt cap hit; Codex output still consumed
-- `'error'` — both branches produced no number; emit `phase_drift` with all numeric fields `null`, `action='error'`, fail-open
+- `'codex+floor'` — Codex parsed AND floor produced findings (`ruleCount > 0`); axes merged via `max`
+- `'codex-only'` — Codex parsed AND floor was no-op (`ruleCount === 0`)
+- `'codex-truncated'` — prompt cap hit; Codex output still parsed; floor merged or no-op as above
+- `'error'` — Codex did not produce a parsable response (throw / non-zero exit / timeout / parse failure / out-of-range axes). Emit `phase_drift` with `score=null`, `axes=null`, `action='error'`, fail-open. The deterministic floor's findings are NOT used to drive `pass`/`reopen` in this branch — see D6.
 
 ## Threshold & action
 
@@ -201,7 +200,7 @@ Contains: drift score, threshold, axes table, source, Codex rationale (escaped),
   action: 'pass' | 'reopen'
         | 'escalate-continue' | 'escalate-skip' | 'escalate-quit'
         | 'error';
-  driftSource: 'codex+floor' | 'codex-only' | 'floor-only' | 'codex-truncated' | 'error';
+  driftSource: 'codex+floor' | 'codex-only' | 'codex-truncated' | 'error';
   codexTokensTotal?: number;  // only when Codex produced a response (success or parse-fail)
   rationale?: string;         // ≤ 200 chars, single line
   floorRules?: number;        // rule count extracted by deterministic floor
@@ -254,8 +253,8 @@ End-to-end through `handleInteractivePhase(phase=5, status=completed)` with `run
 - escalate-quit (manual, 'Q') → state.status='paused', pauseReason='drift-escalation', action='escalate-quit'.
 - disabled-manual-default (autoMode=false, env unset) → no phase\_drift event emitted, phase\_end byte-compatible with current path.
 - disabled-env-off (env=off) → identical to disabled-manual-default.
-- fail-open Codex throws → phase\_drift action='error', phase\_end completed, currentPhase=6, exactly one stderr warn line.
-- fail-open Codex parse error + ruleCount=0 → action='error'; ruleCount>0 → action='pass'/'reopen' driven by floor only with driftSource='floor-only'.
+- fail-open Codex throws → phase\_drift action='error', driftSource='error', score=null, axes=null, phase\_end completed, currentPhase=6, exactly one stderr warn line.
+- fail-open Codex parse error → identical outcome to "Codex throws" regardless of deterministic-floor `ruleCount` (i.e. action='error', driftSource='error', score=null, axes=null, success path). Test asserts that even when the floor would have matched a "must contain X" rule, P6 still advances. (Per D6 strict fail-open: floor never gates without Codex.)
 - truncation cap hit → driftSource='codex-truncated'.
 
 ### Backward-compat regression
@@ -282,7 +281,7 @@ A `grep -l` chain over those four files is part of the eval checklist; absence i
 - **S2.** When `state.autoMode === false` and env unset, a P5 success run never emits `phase_drift` and never invokes Codex; `phase_end` payload matches today's snapshot byte-for-byte (regression fixture).
 - **S3.** With env=`off`, behaviour matches S2.
 - **S4.** With env=`abc` (invalid), behaviour matches S2 plus exactly one stderr line containing the literal `[drift] invalid HARNESS_PHASE_DRIFT_THRESHOLD`.
-- **S5.** Codex failure (mock throws / non-zero exit / non-JSON) with `ruleCount === 0` produces `phase_drift` with `action='error'`, `score=null`, `axes=null`; `phase_end` is `completed`; `currentPhase` advances to 6; exactly one stderr warn line is emitted.
+- **S5.** Codex failure (mock throws / non-zero exit / non-JSON / out-of-range axes) produces `phase_drift` with `action='error'`, `score=null`, `axes=null`, `driftSource='error'`; `phase_end` is `completed`; `currentPhase` advances to 6; exactly one stderr warn line is emitted. This holds **regardless** of deterministic-floor `ruleCount` — including the case where one or more "must contain X" rules would have matched (verified by an explicit test fixture per D6 strict fail-open).
 - **S6.** With `state.autoMode === false` and threshold-exceeded, the C/S/Q prompt routes to: 'C' = reopen branch identical to S1 except `action='escalate-continue'`; 'S' = success path with `action='escalate-skip'`; 'Q' = paused state with `pauseReason='drift-escalation'`.
 - **S7.** Codex is invoked at most once per P5 attempt (verified by mock call-count assertion in integration tests).
 - **S8.** No new npm dependency: `git diff` on `package.json` and `pnpm-lock.yaml` from baseline shows no added entries (only churn allowed is version bump if scope demands).
@@ -295,7 +294,7 @@ A `grep -l` chain over those four files is part of the eval checklist; absence i
 - **I2.** `phase_drift` always precedes the paired `phase_end` in `events.jsonl`; both share the same `attemptId`.
 - **I3.** Per single P5 attempt (one phase\_start → one phase\_end), at most one `phase_drift` event is emitted and at most one Codex drift call is made.
 - **I4.** Drift detection never converts a `result.status === 'failed'` P5 into `completed`, and never converts a `result.status === 'completed'` P5 into `completed` _and_ advances `currentPhase` past 5 when `action ∈ {'reopen','escalate-continue','escalate-quit'}`.
-- **I5.** A scorer/Codex failure (any throw, any timeout, any parse error) MUST NOT raise out of `scoreP5Drift`; it returns `action='error'` (or floor-only) and the success path proceeds.
+- **I5.** A scorer/Codex failure (any throw, any timeout, any parse error, any out-of-range axis) MUST NOT raise out of `scoreP5Drift`; it returns `action='error'` with `score=null`, `axes=null`, `driftSource='error'`, and the P5 success path proceeds. Deterministic-floor findings never gate when Codex fails — they are silently discarded in the error branch (per D6).
 - **I6.** No write to `state.json` from inside `scoreP5Drift` other than the existing reopen-branch state mutation already performed in the runner; the scorer itself is read-only against state.
 - **I7.** `state.json` schema is unchanged. No new top-level field. The new `PauseReason='drift-escalation'` / `PendingActionType='show_drift_escalation'` are union-additive and never written by code paths outside drift escalation.
 - **I8.** `phase_drift.threshold` always equals the number returned by `loadDriftThreshold` for that run; `phase_drift.score`, when non-null, is in `[0, 1]`; each axis, when non-null, is in `[0, 1]`.

--- a/docs/specs/2026-05-11-p5-spec-plan-drift-p5-p6-4a02-design.md
+++ b/docs/specs/2026-05-11-p5-spec-plan-drift-p5-p6-4a02-design.md
@@ -71,19 +71,34 @@ Medium — single new module (`src/phases/drift.ts`) plus targeted edits in `run
 - **Docs**: README.md, README.ko.md, docs/HOW-IT-WORKS.md, docs/HOW-IT-WORKS.ko.md (env table + events.jsonl table + new "Drift detection (P5→P6)" subsection).
 
 ### Insertion-point sequence inside `handleInteractivePhase` for P5
+
+The drift code resolves the **final** `action` value before any `phase_drift` event is emitted, so the emitted event always carries one of the final-state values from the action union (no provisional / intermediate `'escalate'` value ever reaches events.jsonl).
+
 ```
 runInteractivePhase → 'completed'
   ├─ normalizeInteractiveArtifacts(5)        // existing
   ├─ commit-anchor update (state.implCommit) // existing
-  ├─ NEW: scoreP5Drift(state, runDir, cwd, logger)
-  ├─ NEW: emit 'phase_drift' (when activated)
-  └─ branch on outcome.action:
-       'pass' | 'disabled' | 'error'        → existing success path (phase_end completed, currentPhase=6)
-       'reopen' (auto)                       → reopen branch (state mutate, phase_end failed reason='drift-reopen')
-       'escalate'                            → handleDriftEscalation → 'C'/'S'/'Q'
-                                                'C' → reopen branch (action='escalate-continue')
-                                                'S' → success path  (action='escalate-skip')
-                                                'Q' → pause          (action='escalate-quit', pauseReason='drift-escalation')
+  ├─ NEW: outcome ← scoreP5Drift(state, runDir, cwd, logger)
+  │        // returns { activated, score, axes, threshold, driftSource,
+  │        //          codexTokensTotal, rationale, floorRules, error }
+  ├─ NEW: action ← resolveDriftAction(outcome, state.autoMode):
+  │        not activated (env null)               → no event will be emitted
+  │        outcome.error / driftSource='error'    → 'error'
+  │        score ≤ threshold                      → 'pass'
+  │        score > threshold ∧ autoMode=true      → 'reopen'
+  │        score > threshold ∧ autoMode=false     → handleDriftEscalation prompts C/S/Q →
+  │                                                  'C' → 'escalate-continue'
+  │                                                  'S' → 'escalate-skip'
+  │                                                  'Q' → 'escalate-quit'
+  ├─ NEW: if activated, emit single 'phase_drift' event (action is FINAL)
+  └─ apply branch on action:
+       'pass'                                  → existing success path (phase_end completed, currentPhase=6)
+       'error'                                 → existing success path (fail-open)
+       'reopen'                                → reopen branch (state mutate, phase_end failed reason='drift-reopen')
+       'escalate-continue'                     → reopen branch (same as 'reopen')
+       'escalate-skip'                         → existing success path
+       'escalate-quit'                         → pause branch (state mutate, phase_end failed reason='drift-pause',
+                                                                pauseReason='drift-escalation')
 ```
 
 The reopen branch performs:
@@ -215,10 +230,14 @@ Existing values: `'redirected'`. Add: `'drift-reopen'`, `'drift-pause'`. Both ap
 ### Emission ordering (per single P5 attempt)
 ```
 phase_start(5) … (P5 work) … artifact-normalize …
-  → phase_drift          (only when threshold non-null)
+  → scoreP5Drift (Codex 1-call + deterministic floor)
+  → if score > threshold ∧ state.autoMode=false:
+        handleDriftEscalation prompts user (C/S/Q)
+        ↓ produces final action ∈ {escalate-continue, escalate-skip, escalate-quit}
+  → phase_drift          (only when threshold non-null; action is FINAL)
   → phase_end(5, …)
 ```
-`phase_drift` always precedes its paired `phase_end`, never replaces or duplicates it. When drift is disabled, `phase_drift` is absent and `phase_end` is byte-compatible with today's emission.
+`phase_drift` always precedes its paired `phase_end`, never replaces or duplicates it, and is emitted **after** any C/S/Q user input has been collected so the `action` field is one of the final-state values from the action union — there is no provisional / intermediate `'escalate'` value in events.jsonl. When drift is disabled, `phase_drift` is absent and `phase_end` is byte-compatible with today's emission.
 
 ## Backward compatibility
 
@@ -320,3 +339,7 @@ A `grep -l` chain over those four files is part of the eval checklist; absence i
 - A second Codex pass / disagreement reconciliation.
 - Replacement of P7 eval gate.
 - A new CLI flag for drift detection (env-only is the contract).
+
+## Deferred
+
+- **P2 (gate-2 R1) — crash-window resume contract.** Crash between `phase_drift` flush and the paired `phase_end`/state mutation is not specified at byte-precision in this iteration. Planned semantics: at-least-once telemetry with reader-side dedupe by `(attemptId, event='phase_drift')`; no Codex re-call on resume of the same attempt (P5 will re-run as a new attempt, drift will rescore once for that new attempt). Properly specifying and testing the resume code path requires touching `state.ts` resume helpers and is deferred to a follow-up to keep this spec scoped to a single implementation plan.

--- a/docs/specs/2026-05-11-p5-spec-plan-drift-p5-p6-4a02-design.md
+++ b/docs/specs/2026-05-11-p5-spec-plan-drift-p5-p6-4a02-design.md
@@ -1,0 +1,323 @@
+# P5 → P6 Drift Detection — Design Spec
+
+- Run ID: `2026-05-11-p5-spec-plan-drift-p5-p6-4a02`
+- Task brief: `.harness/2026-05-11-p5-spec-plan-drift-p5-p6-4a02/task.md`
+- Decisions log: `.harness/2026-05-11-p5-spec-plan-drift-p5-p6-4a02/decisions.md`
+- Reference: ouroboros/Q00 — `Drift = Goal(50%) + Constraint(30%) + Ontology(20%)`, threshold ≤ 0.3
+- Related precedent: `docs/specs/2026-05-06-p2-spec-gate-ambiguity-9fa2-design.md` (env / parse / fail-open patterns)
+
+## Context & Decisions
+
+### Problem
+P5 implementations regularly satisfy interactive completion criteria yet violate the spec/plan in ways that only surface at the P7 eval gate. The two most recent dogfood runs (#1, #4) both burned a P7 R1 REJECT → P5 R2 cycle for the same root cause: drift was caught too late. We need a quantitative drift signal at P5 phase\_end that can short-circuit the P6 entry when implementation has measurably diverged from the approved spec/plan.
+
+### Decisions made up-front (rationale moved to decisions.md)
+- **D1. Hybrid scorer**: Codex 1-call + deterministic floor; final axis = `max(codex_axis, floor_axis)`. Codex captures semantic drift; floor (grep rules from `## Success Criteria` / `## Invariants`) gives a noise-resistant lower bound.
+- **D2. Mode-driven branch on threshold-exceeded**: `autoMode=true` → hard reopen P5; `autoMode=false` → user prompt (C/S/Q).
+- **D3. Mode-driven activation default via single env**: `HARNESS_PHASE_DRIFT_THRESHOLD`. unset+autoMode → 0.3, unset+manual → disabled, numeric → enabled at that value, `off` → disabled, invalid → disabled + one stderr warn.
+- **D4. New `phase_drift` event**, not a `phase_end` extension. Keeps reader/aggregator changes additive.
+- **D5. Codex inputs**: spec full text + plan full text + `git diff planCommit..implCommit`, with a 30 000-char prompt cap; on cap hit, the diff tail is truncated and `driftSource: 'codex-truncated'` is set.
+- **D6. Fail-open everywhere**: scorer error / Codex hang / parse error / network failure must NOT flip a successful P5. They emit `phase_drift.action='error'` (or fall back to floor-only) and let P6 proceed.
+- **D7. No new dependencies**. Reuses `runners/codex.ts` invocation primitives. No npm package added.
+- **D8. Backward compatibility**: drift event is purely additive; absence of the event must not change any existing reader / footer / retrospective behaviour. State schema unchanged.
+- **D9. Scope = both flows (full + light)**. P5 → P6 transition exists in both flow modes; drift detection runs in both.
+- **D10. Codex call budget**: ≤ 1 call per P5 phase\_end attempt. Reopened P5s re-trigger drift detection on the next phase\_end (i.e. up to 1 call per P5 attempt, never more than 1 per attempt).
+
+## Complexity
+
+Medium — single new module (`src/phases/drift.ts`) plus targeted edits in `runner.ts` / `types.ts` / `metrics/footer-aggregator.ts` / `phases/retrospective.ts` and 4-file doc sync; estimated 600–900 LoC including tests.
+
+## Goals
+
+- **G1.** At successful P5 phase\_end, compute a drift score in `[0, 1]` from `Goal(50%) + Constraint(30%) + Ontology(20%)`.
+- **G2.** Emit a single `phase_drift` event in `events.jsonl` (when drift detection is active) with the score, axes, threshold, action, and source.
+- **G3.** When `score > threshold`:
+  - Autonomous mode → reopen P5 with synthetic drift feedback (`drift-feedback.md`), suppress P6 advance.
+  - Manual mode → prompt the user with C/S/Q; route accordingly.
+- **G4.** When drift detection is disabled (env=off, manual default, or env invalid), behaviour is byte-identical to today's P5 success path (no `phase_drift` event, no extra Codex call, no `phase_end.details` change).
+- **G5.** Make threshold and activation user-tunable through a single env var; document defaults / disable / fail-open semantics in README + HOW-IT-WORKS (en + ko).
+- **G6.** Telemetry survives crash and resume — drift detection is idempotent across resume of an in-flight P5.
+
+## Non-Goals
+
+- **NG1.** No drift detection on phases other than 5 in this iteration.
+- **NG2.** No automatic re-prompting of Codex within a single P5 attempt — exactly one Codex call, regardless of outcome.
+- **NG3.** No tunable per-axis weights; the 50/30/20 split is baked in.
+- **NG4.** No drift gate in the gate (P2/P4/P7) pipeline — those have their own ambiguity / verdict mechanics.
+- **NG5.** No replacement of the P7 eval gate. Drift detection is an early-warning, not a substitute.
+- **NG6.** No persistent drift history in `state.json` — all evidence lives in `events.jsonl`.
+
+## Architecture
+
+### Module layout
+- **`src/phases/drift.ts`** (new). Exports:
+  - `loadDriftThreshold(autoMode: boolean): number | null`
+  - `extractDeterministicFloor(specText: string, cwd: string): { goal: number; constraint: number; ontology: number; ruleCount: number }`
+  - `parseDriftScores(rawOutput: string): { goal: number; constraint: number; ontology: number; rationale?: string } | null`
+  - `computeWeightedDrift(axes: { goal: number; constraint: number; ontology: number }): number`
+  - `mergeAxes(floor, codex): { goal; constraint; ontology }`
+  - `scoreP5Drift(state, runDir, cwd, logger): Promise<DriftOutcome>` — orchestrator
+  - `handleDriftEscalation(state, runDir, cwd, inputManager, logger, outcome): Promise<DriftAction>` — manual-mode prompt
+  - `__resetDriftWarning()` — test hook (mirrors `__resetAmbiguityWarning`).
+- **`src/runners/codex.ts`** edits: add `runCodexDriftScorer({ specText, planText, diffText, runDir })` re-using the existing non-interactive Codex pipe (sandbox=read-only). One Codex call, structured stdout. No reuse of gate session — drift scorer uses a fresh ephemeral session.
+- **`src/phases/runner.ts`** edits: insert exactly one call to `scoreP5Drift` inside `handleInteractivePhase` for `phase === 5` and `result.status === 'completed'`, between artifact normalisation (line ≈ 470) and the existing `state.phases['5'] = 'completed'` mutation (line ≈ 487). The drift outcome dispatches into one of: success-path-continue / reopen / escalation / fail-open.
+- **`src/types.ts`** edits:
+  - Add the `phase_drift` discriminated-union variant to `LogEvent` (§ Event schema).
+  - Add `'drift-escalation'` to `PauseReason`.
+  - Add `'show_drift_escalation'` to `PendingActionType`.
+  - No change to `HarnessState` shape.
+- **`src/metrics/footer-aggregator.ts`** edits: ignore `phase_drift` for existing aggregations; optionally surface a one-line `drift: <score>/<threshold> [<source>]` in the P5 footer row when an event is present (additive — absence preserves today's footer byte-for-byte).
+- **`src/phases/retrospective.ts`** edits: aggregate phase\_drift events into a new "Drift detection" section; absent events → section is omitted.
+- **Docs**: README.md, README.ko.md, docs/HOW-IT-WORKS.md, docs/HOW-IT-WORKS.ko.md (env table + events.jsonl table + new "Drift detection (P5→P6)" subsection).
+
+### Insertion-point sequence inside `handleInteractivePhase` for P5
+```
+runInteractivePhase → 'completed'
+  ├─ normalizeInteractiveArtifacts(5)        // existing
+  ├─ commit-anchor update (state.implCommit) // existing
+  ├─ NEW: scoreP5Drift(state, runDir, cwd, logger)
+  ├─ NEW: emit 'phase_drift' (when activated)
+  └─ branch on outcome.action:
+       'pass' | 'disabled' | 'error'        → existing success path (phase_end completed, currentPhase=6)
+       'reopen' (auto)                       → reopen branch (state mutate, phase_end failed reason='drift-reopen')
+       'escalate'                            → handleDriftEscalation → 'C'/'S'/'Q'
+                                                'C' → reopen branch (action='escalate-continue')
+                                                'S' → success path  (action='escalate-skip')
+                                                'Q' → pause          (action='escalate-quit', pauseReason='drift-escalation')
+```
+
+The reopen branch performs:
+```
+state.phases['5']            = 'pending'
+state.phaseReopenFlags['5']  = true
+state.phaseReopenSource['5'] = 5      // self-reopen marker (drift-driven)
+state.pendingAction          = { type: 'reopen_phase', targetPhase: 5, sourcePhase: 5,
+                                 feedbackPaths: [<runDir>/drift-feedback.md] }
+state.currentPhase           = 5      // suppress P6 advance
+phase_end emitted with status='failed', details={ reason: 'drift-reopen' }
+```
+
+The pause branch performs:
+```
+state.status                 = 'paused'
+state.pauseReason            = 'drift-escalation'
+state.pendingAction          = { type: 'show_drift_escalation', targetPhase: 5, sourcePhase: 5,
+                                 feedbackPaths: [<runDir>/drift-feedback.md] }
+phase_end emitted with status='failed', details={ reason: 'drift-pause' }
+```
+
+Carry-over via `state.carryoverFeedback` is **not** used — drift reopen routes from P5 back to P5 directly, so `pendingAction.feedbackPaths` is sufficient and the existing `CarryoverFeedback.sourceGate: 7` literal type stays untouched.
+
+## Scorer algorithm
+
+### Inputs
+- `specText`: read from `state.artifacts.spec` (full file).
+- `planText`: read from `state.artifacts.plan` (full file).
+- `diffText`: `git diff <state.planCommit>..<state.implCommit> --` executed in `state.trackedRepos[0].path` (fallback to `cwd` if `trackedRepos` is empty).
+- **Truncation cap**: assemble the prompt; if `len(spec)+len(plan)+len(diff) > 30 000` chars, truncate the diff tail (preserving header + first ≈ 20 000 chars of diff). On cap hit, set `driftSource: 'codex-truncated'`. Spec / plan are never truncated.
+
+### Codex 1-call
+- Function: `runCodexDriftScorer(...)` — one shot, non-interactive Codex CLI invocation, sandbox=read-only.
+- System prompt fixes the rubric (Goal/Constraint/Ontology defined explicitly) and the output contract.
+- Output contract — Codex must emit, in order:
+  ```
+  ## Drift Scores
+  ```json
+  { "goal": <0..1>, "constraint": <0..1>, "ontology": <0..1>, "rationale": "<≤200 chars>" }
+  ```
+  ```
+- Invariants:
+  - `goal`, `constraint`, `ontology` ∈ `[0, 1]`. Out-of-range → parse failure.
+  - `rationale` is a single-line string (newlines stripped, length-clamped to 200 chars at scorer side).
+  - Token budget recorded as `codexTokensTotal` on the event when reported by the runner.
+
+### Deterministic floor
+- Walk the spec text, isolate the bodies of `## Success Criteria` and `## Invariants` (case-insensitive matching at the heading level).
+- Within those bodies, harvest **machine-checkable rules** of the following shapes only:
+  1. A fenced code block whose first line begins with `grep -E ` / `grep -P ` / `rg -e ` (entire fenced block treated as a single shell rule).
+  2. An inline backtick-quoted regex on a bullet that starts with `must`, `MUST`, `반드시`, `항상`, `forbidden`, `must not`, `금지` (case-insensitive English / Korean keywords). The regex is the literal between backticks.
+- Execute each rule against the working tree at `cwd` (`git ls-files | xargs grep -E ...` for grep rules; `find` + per-file `RegExp` for regex rules) — **read-only**, no writes. Time budget: ≤ 5 s total; if exceeded, abort the floor and treat it as no-op (`ruleCount = 0`).
+- Mapping rule violations → axis floors:
+  | Violation kind | Axis | Floor contribution |
+  |---|---|---|
+  | "must contain X" rule with no match | `goal` | 0.5 (1 violation) → 1.0 (≥ 2) |
+  | "forbidden / must not / 금지" rule with ≥ 1 match | `constraint` | 0.7 |
+  | Other violations (general regex misses) | `ontology` | 0.3 |
+- If `ruleCount === 0`, the floor is `{ goal: 0, constraint: 0, ontology: 0 }` (no-op). No false positives on specs lacking machine rules.
+
+### Merge & weighted score
+```
+axes        = { goal: max(floor.goal, codex.goal ?? 0),
+                constraint: max(floor.constraint, codex.constraint ?? 0),
+                ontology: max(floor.ontology, codex.ontology ?? 0) }
+score       = clamp01(0.5*axes.goal + 0.3*axes.constraint + 0.2*axes.ontology)
+```
+
+### `driftSource` taxonomy
+- `'codex+floor'` — both produced numbers
+- `'codex-only'` — floor was no-op (`ruleCount === 0`)
+- `'floor-only'` — Codex parse error / non-zero exit / timeout, but `ruleCount > 0`
+- `'codex-truncated'` — prompt cap hit; Codex output still consumed
+- `'error'` — both branches produced no number; emit `phase_drift` with all numeric fields `null`, `action='error'`, fail-open
+
+## Threshold & action
+
+### Activation env
+`HARNESS_PHASE_DRIFT_THRESHOLD`:
+- unset + `state.autoMode === true` → `0.3`
+- unset + `state.autoMode === false` → `null` (drift detection disabled, no event emitted, no Codex call made)
+- numeric in `[0, 1]` → that value (autoMode irrelevant)
+- `off` (case-insensitive, trimmed) → `null`
+- invalid (numeric out of range, or non-numeric non-`off`) → `null` + one stderr warn line per process: `[drift] invalid HARNESS_PHASE_DRIFT_THRESHOLD="…" — drift detection disabled for this run`
+
+When the loader returns `null`, `scoreP5Drift` short-circuits before reading any artifact and before calling Codex.
+
+### Decision table
+| `state.autoMode` | `score` vs `threshold` | `action` field | Phase 5 next state |
+|---|---|---|---|
+| any | `score ≤ threshold` | `'pass'` | success path (advance to 6) |
+| `true` | `score > threshold` | `'reopen'` | reopen P5 (state mutate, phase\_end failed, reason='drift-reopen') |
+| `false` | `score > threshold`, user picks `C` | `'escalate-continue'` | reopen P5 |
+| `false` | `score > threshold`, user picks `S` | `'escalate-skip'` | success path |
+| `false` | `score > threshold`, user picks `Q` | `'escalate-quit'` | pause (`pauseReason='drift-escalation'`) |
+| any | scorer error | `'error'` | success path (fail-open) |
+| any | disabled (env null) | _no event emitted_ | success path |
+
+### `drift-feedback.md` content (used for reopen branches)
+Contains: drift score, threshold, axes table, source, Codex rationale (escaped), deterministic floor rule hits (which rules fired and against which file paths). Plain markdown. Path: `<runDir>/drift-feedback.md`. Overwritten on each new drift run (idempotent under resume).
+
+## Event schema
+
+### New `phase_drift` discriminated union variant in `LogEvent`
+```ts
+{
+  event: 'phase_drift';
+  phase: 5;
+  attemptId: string;
+  durationMs: number;
+  threshold: number;          // resolved threshold actually applied (never null when emitted)
+  score: number | null;
+  axes: { goal: number; constraint: number; ontology: number } | null;
+  action: 'pass' | 'reopen'
+        | 'escalate-continue' | 'escalate-skip' | 'escalate-quit'
+        | 'error';
+  driftSource: 'codex+floor' | 'codex-only' | 'floor-only' | 'codex-truncated' | 'error';
+  codexTokensTotal?: number;  // only when Codex produced a response (success or parse-fail)
+  rationale?: string;         // ≤ 200 chars, single line
+  floorRules?: number;        // rule count extracted by deterministic floor
+  error?: string;             // only when action='error'; one-line cause
+}
+```
+Optional fields are dropped when not applicable (precedent: `phase_end.claudeTokens`).
+
+### Extension to `phase_end.details.reason`
+Existing values: `'redirected'`. Add: `'drift-reopen'`, `'drift-pause'`. Both apply only on phase-5 phase\_end with `status='failed'`. Manual escalation 'C' uses `'drift-reopen'` (auto/manual disambiguated by `phase_drift.action`).
+
+### Emission ordering (per single P5 attempt)
+```
+phase_start(5) … (P5 work) … artifact-normalize …
+  → phase_drift          (only when threshold non-null)
+  → phase_end(5, …)
+```
+`phase_drift` always precedes its paired `phase_end`, never replaces or duplicates it. When drift is disabled, `phase_drift` is absent and `phase_end` is byte-compatible with today's emission.
+
+## Backward compatibility
+
+- `state.json` schema unchanged. No migration. Existing resumes load without diff.
+- `events.jsonl` reader: a missing `phase_drift` is the disabled / pre-feature path. `footer-aggregator` and `retrospective` MUST treat absence as the no-op default and emit identical output to current behaviour.
+- New `PauseReason='drift-escalation'` and `PendingActionType='show_drift_escalation'` are additive union values; resume code paths must not assume the prior closed unions. Old persisted states never carry these values.
+- No CLI flag added; activation is env-only.
+- No new npm dependency — `package.json` and `pnpm-lock.yaml` only churn if any (which they should not).
+
+## Documentation sync (mandatory under repo CLAUDE.md doc rule)
+
+Each of `README.md`, `README.ko.md`, `docs/HOW-IT-WORKS.md`, `docs/HOW-IT-WORKS.ko.md` must, in the same change, gain:
+- A row for `HARNESS_PHASE_DRIFT_THRESHOLD` in the env-vars table including default semantics, `off`, fail-open, mode-driven default.
+- A row for `phase_drift` in the events.jsonl schema table (or its language equivalent).
+- A new "Drift detection (P5→P6)" subsection (≤ 200 lines) covering: when it runs, what it scores, hybrid algorithm summary, mode-driven branch, fail-open contract.
+
+## Testing strategy
+
+### Unit tests — `tests/phases/drift.test.ts` (new)
+- `loadDriftThreshold` env matrix (8 cases: unset+auto, unset+manual, "0.5", "0", "1.0", "off", "1.5", "abc"); each invalid path emits exactly one stderr warn (use `__resetDriftWarning` between cases).
+- `parseDriftScores` cases: well-formed JSON; out-of-range `goal`; missing axis; non-JSON; missing `## Drift Scores` heading.
+- `computeWeightedDrift` reference vectors: `{1,0,0}=0.5`, `{0,1,0}=0.3`, `{0,0,1}=0.2`, `{1,1,1}=1.0`, `{0,0,0}=0.0`; clamp absorbs floating-point drift.
+- `extractDeterministicFloor`: 0 rules → no-op; 1 "must contain" miss → goal=0.5; 2+ misses → goal=1.0; forbidden hit → constraint=0.7; mixed.
+- `mergeAxes`: codex=null + floor>0 → floor; codex>floor → codex; floor>codex → floor; both 0 → 0.
+
+### Integration tests — `tests/phases/runner-drift.test.ts` (new)
+End-to-end through `handleInteractivePhase(phase=5, status=completed)` with `runCodexDriftScorer` mocked:
+- pass + active (autoMode, score 0.10) → phase\_drift action=pass + phase\_end completed + currentPhase=6.
+- reopen + auto (autoMode, score 0.55) → phase\_drift action=reopen + drift-feedback.md exists + state.phaseReopenFlags['5']=true + phaseReopenSource['5']=5 + pendingAction.feedbackPaths includes drift-feedback.md + phase\_end failed reason='drift-reopen' + currentPhase=5.
+- escalate-continue (manual, mocked stdin 'C') → identical state mutation as reopen, action='escalate-continue'.
+- escalate-skip (manual, 'S') → success path, action='escalate-skip'.
+- escalate-quit (manual, 'Q') → state.status='paused', pauseReason='drift-escalation', action='escalate-quit'.
+- disabled-manual-default (autoMode=false, env unset) → no phase\_drift event emitted, phase\_end byte-compatible with current path.
+- disabled-env-off (env=off) → identical to disabled-manual-default.
+- fail-open Codex throws → phase\_drift action='error', phase\_end completed, currentPhase=6, exactly one stderr warn line.
+- fail-open Codex parse error + ruleCount=0 → action='error'; ruleCount>0 → action='pass'/'reopen' driven by floor only with driftSource='floor-only'.
+- truncation cap hit → driftSource='codex-truncated'.
+
+### Backward-compat regression
+- Existing `tests/phases/runner.test.ts` P5 success-path cases run unchanged with env unset + autoMode=false (drift detection inactive); `phase_end` payload byte-compatible with today's snapshot.
+- Existing `events.jsonl` fixtures (without `phase_drift`) feed `footer-aggregator` and `retrospective` and snapshot output is unchanged.
+
+### Verification commands (eval checklist baseline)
+```bash
+pnpm tsc --noEmit                     # typecheck (= pnpm lint alias — do NOT also list lint)
+pnpm vitest run                       # full suite incl. drift unit + integration
+pnpm build                            # tsc + scripts/copy-assets.mjs
+```
+
+### Doc-sync verification (deterministic floor self-check)
+After implementation, the four doc files MUST each contain:
+- regex `HARNESS_PHASE_DRIFT_THRESHOLD` (env var name)
+- regex `phase_drift` (event name)
+- substring `Drift detection` (subsection title; Korean files may use `드리프트 검출`)
+A `grep -l` chain over those four files is part of the eval checklist; absence in any one fails the eval.
+
+## Success Criteria
+
+- **S1.** When `HARNESS_PHASE_DRIFT_THRESHOLD` is unset and `state.autoMode === true`, a P5 success run with mocked drift score `> 0.3` results in: exactly one `phase_drift` event with `action='reopen'`; `state.phaseReopenFlags['5'] === true`; `state.phaseReopenSource['5'] === 5`; `state.pendingAction.feedbackPaths` includes `<runDir>/drift-feedback.md`; `state.currentPhase === 5`; the matching `phase_end` has `status='failed'` and `details.reason === 'drift-reopen'`.
+- **S2.** When `state.autoMode === false` and env unset, a P5 success run never emits `phase_drift` and never invokes Codex; `phase_end` payload matches today's snapshot byte-for-byte (regression fixture).
+- **S3.** With env=`off`, behaviour matches S2.
+- **S4.** With env=`abc` (invalid), behaviour matches S2 plus exactly one stderr line containing the literal `[drift] invalid HARNESS_PHASE_DRIFT_THRESHOLD`.
+- **S5.** Codex failure (mock throws / non-zero exit / non-JSON) with `ruleCount === 0` produces `phase_drift` with `action='error'`, `score=null`, `axes=null`; `phase_end` is `completed`; `currentPhase` advances to 6; exactly one stderr warn line is emitted.
+- **S6.** With `state.autoMode === false` and threshold-exceeded, the C/S/Q prompt routes to: 'C' = reopen branch identical to S1 except `action='escalate-continue'`; 'S' = success path with `action='escalate-skip'`; 'Q' = paused state with `pauseReason='drift-escalation'`.
+- **S7.** Codex is invoked at most once per P5 attempt (verified by mock call-count assertion in integration tests).
+- **S8.** No new npm dependency: `git diff` on `package.json` and `pnpm-lock.yaml` from baseline shows no added entries (only churn allowed is version bump if scope demands).
+- **S9.** `pnpm tsc --noEmit`, `pnpm vitest run`, `pnpm build` all pass.
+- **S10.** README.md, README.ko.md, docs/HOW-IT-WORKS.md, docs/HOW-IT-WORKS.ko.md each match all three doc-sync regexes (`HARNESS_PHASE_DRIFT_THRESHOLD`, `phase_drift`, `Drift detection` or `드리프트 검출`).
+
+## Invariants
+
+- **I1.** `phase_drift` is emitted ⇔ `loadDriftThreshold(state.autoMode)` returned a non-null number for the current run.
+- **I2.** `phase_drift` always precedes the paired `phase_end` in `events.jsonl`; both share the same `attemptId`.
+- **I3.** Per single P5 attempt (one phase\_start → one phase\_end), at most one `phase_drift` event is emitted and at most one Codex drift call is made.
+- **I4.** Drift detection never converts a `result.status === 'failed'` P5 into `completed`, and never converts a `result.status === 'completed'` P5 into `completed` _and_ advances `currentPhase` past 5 when `action ∈ {'reopen','escalate-continue','escalate-quit'}`.
+- **I5.** A scorer/Codex failure (any throw, any timeout, any parse error) MUST NOT raise out of `scoreP5Drift`; it returns `action='error'` (or floor-only) and the success path proceeds.
+- **I6.** No write to `state.json` from inside `scoreP5Drift` other than the existing reopen-branch state mutation already performed in the runner; the scorer itself is read-only against state.
+- **I7.** `state.json` schema is unchanged. No new top-level field. The new `PauseReason='drift-escalation'` / `PendingActionType='show_drift_escalation'` are union-additive and never written by code paths outside drift escalation.
+- **I8.** `phase_drift.threshold` always equals the number returned by `loadDriftThreshold` for that run; `phase_drift.score`, when non-null, is in `[0, 1]`; each axis, when non-null, is in `[0, 1]`.
+- **I9.** Drift detection runs in both `flow='full'` and `flow='light'` runs; behaviour is identical in both.
+- **I10.** Mandatory doc sync: every doc file listed in S10 contains all three doc-sync regexes; this is grep-verified by Phase 6 eval.
+
+## Risks & mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Codex 1-call returns hallucinated high drift on a correct impl | medium | Hybrid (`max` with floor), low default threshold (0.3), C/S/Q escape hatch in manual mode, autoMode reopen capped by existing P5 retry loop. Telemetry retains rationale for post-hoc audit. |
+| Codex parse drift if Codex CLI changes output schema | low | Single regex parser (`## Drift Scores` → fenced JSON); parse failure is fail-open (no run-blocking); per-version Codex change requires updating the parser only. |
+| Deterministic floor false-positives on freeform specs | medium | Floor only fires when explicit `must / forbidden / 반드시 / 금지` keywords + machine-checkable patterns are present; no rules → floor is no-op. |
+| Token cost overrun | low | 30 000-char prompt cap (≈ 8K tokens); ≤ 1 call per attempt; budget documented in spec & README. |
+| Reopen loop (drift score never falls below threshold) | medium | Existing P5 stagnation handling and overall harness pause/exit semantics already cover infinite reopen patterns; no new reopen budget added in this iteration (to be revisited in a follow-up if dogfood shows the symptom). |
+| Resume mid-drift (process killed between Codex call and event flush) | low | Drift detection is idempotent: on resume, `runInteractivePhase` will re-run P5 → re-trigger drift on the next phase\_end. Worst case is a duplicate Codex call across two attempts, never within one. |
+
+## Out of scope (this iteration)
+
+- Per-axis weight tuning via env.
+- Drift detection on phases 1, 3, 6, 7.
+- Persisting drift history in `state.json` for cross-attempt trend analysis.
+- A second Codex pass / disagreement reconciliation.
+- Replacement of P7 eval gate.
+- A new CLI flag for drift detection (env-only is the contract).

--- a/src/phases/drift.ts
+++ b/src/phases/drift.ts
@@ -1,0 +1,574 @@
+// P5 → P6 drift detection (single-file scorer + escalation handler).
+//
+// The deterministic floor described in the original D1 was advisor-trimmed
+// out of v1 — see the spec's "Deferred" section. v1 is Codex-only; that's
+// why this module has no extractDeterministicFloor / mergeAxes exports.
+//
+// Spec: docs/specs/2026-05-11-p5-spec-plan-drift-p5-p6-4a02-design.md
+
+import fs from 'fs';
+import { execSync, spawn } from 'child_process';
+import path from 'path';
+import type { HarnessState } from '../types.js';
+import { extractCodexMetadata } from './verdict.js';
+
+const DRIFT_CODEX_TIMEOUT_MS = 120_000;
+const DRIFT_CODEX_DEFAULT_MODEL = 'gpt-5.5';
+const DRIFT_CODEX_DEFAULT_EFFORT = 'high';
+
+export const DRIFT_AXES = ['goal', 'constraint', 'ontology'] as const;
+export type DriftAxis = typeof DRIFT_AXES[number];
+export type DriftAxes = Record<DriftAxis, number>;
+
+export const DRIFT_WEIGHTS: Readonly<DriftAxes> = Object.freeze({
+  goal: 0.5,
+  constraint: 0.3,
+  ontology: 0.2,
+});
+
+export const DRIFT_PROMPT_CAP_CHARS = 30_000;
+export const DRIFT_DIFF_HEAD_RESERVE_CHARS = 20_000;
+
+export type DriftAction =
+  | 'pass'
+  | 'reopen'
+  | 'escalate-continue'
+  | 'escalate-skip'
+  | 'escalate-quit'
+  | 'error';
+
+export type DriftSource = 'codex-only' | 'codex-truncated' | 'error';
+
+export interface DriftScoresParsed {
+  goal: number;
+  constraint: number;
+  ontology: number;
+  rationale?: string;
+}
+
+export interface DriftOutcome {
+  /** True when env-resolved threshold is non-null AND scoreP5Drift was actually run. */
+  activated: boolean;
+  /** Resolved threshold for the run (only meaningful when activated). */
+  threshold: number;
+  /** Final weighted score in [0, 1], or null on error. */
+  score: number | null;
+  axes: DriftAxes | null;
+  driftSource: DriftSource;
+  durationMs: number;
+  codexTokensTotal?: number;
+  rationale?: string;
+  error?: string;
+}
+
+const warnedKeys = new Set<string>();
+
+export function __resetDriftWarning(): void {
+  warnedKeys.clear();
+}
+
+function warnOnce(key: string, message: string): void {
+  if (warnedKeys.has(key)) return;
+  warnedKeys.add(key);
+  process.stderr.write(message.endsWith('\n') ? message : message + '\n');
+}
+
+/**
+ * Resolve HARNESS_PHASE_DRIFT_THRESHOLD per spec §Threshold & action.
+ * Returns null when drift detection is disabled for this run.
+ */
+export function loadDriftThreshold(autoMode: boolean): number | null {
+  const raw = process.env['HARNESS_PHASE_DRIFT_THRESHOLD'];
+
+  if (raw === undefined || raw === '') {
+    return autoMode ? 0.3 : null;
+  }
+
+  const trimmed = raw.trim();
+  if (trimmed.toLowerCase() === 'off') return null;
+
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    warnOnce(
+      'HARNESS_PHASE_DRIFT_THRESHOLD',
+      `[drift] invalid HARNESS_PHASE_DRIFT_THRESHOLD="${raw}" — drift detection disabled for this run`,
+    );
+    return null;
+  }
+  return parsed;
+}
+
+/**
+ * Parse the `## Drift Scores` fenced JSON block out of Codex stdout.
+ * Returns null on any malformation; never throws.
+ */
+export function parseDriftScores(rawOutput: string): DriftScoresParsed | null {
+  if (typeof rawOutput !== 'string' || rawOutput.length === 0) return null;
+
+  const headerIdx = rawOutput.search(/^##\s+drift\s+scores\s*$/im);
+  if (headerIdx < 0) return null;
+
+  const after = rawOutput.slice(headerIdx);
+  // Find the first fenced ```json ... ``` block under the header.
+  const fence = after.match(/```\s*json\s*\n([\s\S]*?)\n```/i);
+  if (!fence) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fence[1]);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+
+  const obj = parsed as Record<string, unknown>;
+  const goal = obj['goal'];
+  const constraint = obj['constraint'];
+  const ontology = obj['ontology'];
+
+  if (![goal, constraint, ontology].every((v) => typeof v === 'number' && Number.isFinite(v))) {
+    return null;
+  }
+  const g = goal as number, c = constraint as number, o = ontology as number;
+  if (g < 0 || g > 1 || c < 0 || c > 1 || o < 0 || o > 1) return null;
+
+  const out: DriftScoresParsed = { goal: g, constraint: c, ontology: o };
+  const rat = obj['rationale'];
+  if (typeof rat === 'string') {
+    // Single-line, length-clamped to 200 chars.
+    out.rationale = rat.replace(/\s+/g, ' ').trim().slice(0, 200);
+  }
+  return out;
+}
+
+/**
+ * weighted_score = clamp01(0.5*goal + 0.3*constraint + 0.2*ontology).
+ */
+export function computeWeightedDrift(axes: DriftAxes): number {
+  const raw =
+    DRIFT_WEIGHTS.goal * axes.goal +
+    DRIFT_WEIGHTS.constraint * axes.constraint +
+    DRIFT_WEIGHTS.ontology * axes.ontology;
+  if (!Number.isFinite(raw)) return 0;
+  if (raw < 0) return 0;
+  if (raw > 1) return 1;
+  return raw;
+}
+
+/**
+ * Build the Codex prompt. Returns either the assembled prompt or
+ * { oversized: true } if spec+plan alone exceeds the cap (per §Inputs
+ * "Oversized spec/plan boundary").
+ */
+export function buildDriftPrompt(
+  specText: string,
+  planText: string,
+  diffText: string,
+  threshold: number,
+): { prompt: string; truncated: boolean } | { oversized: true } {
+  const head = buildDriftPromptHeader(threshold);
+
+  // Hard boundary: even with diff="", spec+plan body alone must fit.
+  // We reserve a small margin for the header and section dividers.
+  const headerFooterReserve = 800;
+  const bodyBudget = DRIFT_PROMPT_CAP_CHARS - headerFooterReserve;
+  if (specText.length + planText.length > bodyBudget) {
+    return { oversized: true };
+  }
+
+  const fullDiff = diffText ?? '';
+  const tentative = assemblePrompt(head, specText, planText, fullDiff);
+  if (tentative.length <= DRIFT_PROMPT_CAP_CHARS) {
+    return { prompt: tentative, truncated: false };
+  }
+
+  // Truncate diff tail. Reserve DIFF_HEAD chars for the diff head; the
+  // remaining slack lets spec/plan stay intact.
+  const truncatedDiff = fullDiff.length > DRIFT_DIFF_HEAD_RESERVE_CHARS
+    ? fullDiff.slice(0, DRIFT_DIFF_HEAD_RESERVE_CHARS) + '\n\n[... diff truncated ...]\n'
+    : fullDiff;
+  const out = assemblePrompt(head, specText, planText, truncatedDiff);
+  return { prompt: out, truncated: true };
+}
+
+function buildDriftPromptHeader(threshold: number): string {
+  return [
+    'You are scoring how far the implementation has drifted from the approved spec/plan.',
+    'Output rubric (each axis is in [0.0, 1.0], where 0.0 = no drift, 1.0 = total drift):',
+    '  - goal       — How much do the actual code changes diverge from the spec\'s stated goals?',
+    '  - constraint — How many spec constraints / forbidden behaviors are violated by the diff?',
+    '  - ontology   — How much do the diff\'s entities (types, names, modules) diverge from the spec\'s entity model?',
+    '',
+    `Threshold context: the harness reopens P5 when weighted score > ${threshold.toFixed(2)} (weights: goal 0.5, constraint 0.3, ontology 0.2).`,
+    'Be calibrated, not generous. Score 0.0–0.1 only when the implementation faithfully reflects the spec. Score above 0.5 only with concrete divergence evidence.',
+    '',
+    'OUTPUT — emit exactly two sections, in this order, with NOTHING else:',
+    '',
+    '## Drift Scores',
+    '```json',
+    '{ "goal": 0.00, "constraint": 0.00, "ontology": 0.00, "rationale": "<≤200 chars, single line>" }',
+    '```',
+    '',
+    '## End',
+    '',
+    'Replace the example numbers with your assessment. The ## End line MUST follow.',
+    '',
+    '---',
+  ].join('\n');
+}
+
+function assemblePrompt(
+  head: string,
+  specText: string,
+  planText: string,
+  diffText: string,
+): string {
+  return [
+    head,
+    '## Spec',
+    specText,
+    '',
+    '## Plan',
+    planText,
+    '',
+    '## Diff (planCommit..implCommit)',
+    diffText.length > 0 ? diffText : '(no diff against plan commit)',
+  ].join('\n');
+}
+
+/**
+ * Read the diff between planCommit and implCommit. Returns "" on any failure
+ * (drift scoring continues — Codex sees an empty diff as "no impl changes").
+ */
+export function readP5Diff(planCommit: string | null, implCommit: string | null, cwd: string): string {
+  if (!planCommit || !implCommit || planCommit === implCommit) return '';
+  try {
+    const buf = execSync(`git diff ${planCommit}..${implCommit} --`, {
+      cwd,
+      encoding: 'utf-8',
+      maxBuffer: 64 * 1024 * 1024, // 64 MiB
+    });
+    return buf;
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Write drift-feedback.md for the reopen branches. Single file under the
+ * harness run dir, overwritten each call (idempotent).
+ */
+export function writeDriftFeedback(runDir: string, outcome: DriftOutcome): string {
+  const filePath = path.join(runDir, 'drift-feedback.md');
+  const lines: string[] = [];
+  lines.push('# Drift Detection — P5 reopen feedback');
+  lines.push('');
+  if (outcome.score !== null && outcome.axes !== null) {
+    lines.push(`Weighted drift score: ${outcome.score.toFixed(2)} (threshold ${outcome.threshold.toFixed(2)}).`);
+  } else {
+    lines.push(`Weighted drift score: unavailable (driftSource=${outcome.driftSource}).`);
+  }
+  lines.push('');
+  if (outcome.axes !== null) {
+    lines.push('## Axes');
+    lines.push('');
+    lines.push('| Axis | Score | Weight |');
+    lines.push('|---|---|---|');
+    lines.push(`| goal | ${outcome.axes.goal.toFixed(2)} | 0.50 |`);
+    lines.push(`| constraint | ${outcome.axes.constraint.toFixed(2)} | 0.30 |`);
+    lines.push(`| ontology | ${outcome.axes.ontology.toFixed(2)} | 0.20 |`);
+    lines.push('');
+  }
+  lines.push(`Source: \`${outcome.driftSource}\`.`);
+  if (outcome.codexTokensTotal !== undefined) {
+    lines.push(`Codex tokens (drift call): ${outcome.codexTokensTotal}.`);
+  }
+  if (outcome.rationale) {
+    lines.push('');
+    lines.push('## Codex rationale');
+    lines.push('');
+    lines.push('> ' + outcome.rationale.replace(/\n+/g, ' '));
+  }
+  lines.push('');
+  lines.push('## What to do');
+  lines.push('');
+  lines.push(
+    'Re-read the spec\'s Goals / Constraints / Invariants sections and adjust the implementation '
+    + 'until those expectations are reflected by the actual code (and tests). The drift score will '
+    + 'be re-computed when this P5 attempt completes again.',
+  );
+  lines.push('');
+  fs.writeFileSync(filePath, lines.join('\n'));
+  return filePath;
+}
+
+interface CodexDriftRawResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  errorMessage?: string;
+}
+
+/**
+ * One-shot Codex call for drift scoring. Mirrors runCodexExecRaw's spawn
+ * pattern in src/runners/codex.ts but is intentionally narrower: no
+ * resume / fallback / verdict-presence categorisation. Just stdin → stdout.
+ *
+ * Test injection: if the env var HARNESS_DRIFT_CODEX_FIXTURE is set to a
+ * file path, that file's contents are returned as stdout (no Codex spawn).
+ * Used by integration tests; never set in production.
+ */
+export async function runCodexDriftScorer(input: {
+  prompt: string;
+  cwd: string;
+  model?: string;
+  effort?: string;
+}): Promise<CodexDriftRawResult> {
+  const fixturePath = process.env['HARNESS_DRIFT_CODEX_FIXTURE'];
+  if (fixturePath !== undefined && fixturePath !== '') {
+    try {
+      const stdout = fs.readFileSync(fixturePath, 'utf-8');
+      return { ok: true, stdout, stderr: '' };
+    } catch (err) {
+      return {
+        ok: false,
+        stdout: '',
+        stderr: '',
+        errorMessage: `Drift fixture read failed: ${(err as Error).message}`,
+      };
+    }
+  }
+
+  const codexBin = resolveCodexBin();
+  if (codexBin === null) {
+    return {
+      ok: false,
+      stdout: '',
+      stderr: '',
+      errorMessage: 'Codex CLI not found in PATH',
+    };
+  }
+
+  const model = input.model ?? DRIFT_CODEX_DEFAULT_MODEL;
+  const effort = input.effort ?? DRIFT_CODEX_DEFAULT_EFFORT;
+  const args = [
+    'exec',
+    '--skip-git-repo-check',
+    '--model', model,
+    '-c', `model_reasoning_effort="${effort}"`,
+    '-',
+  ];
+
+  return new Promise<CodexDriftRawResult>((resolve) => {
+    let settled = false;
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+
+    const child = spawn(codexBin, args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: input.cwd,
+      env: process.env,
+    });
+
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try { child.kill('SIGTERM'); } catch { /* best-effort */ }
+      resolve({
+        ok: false,
+        stdout: Buffer.concat(stdoutChunks).toString('utf-8'),
+        stderr: Buffer.concat(stderrChunks).toString('utf-8'),
+        errorMessage: `Codex drift call timed out after ${DRIFT_CODEX_TIMEOUT_MS}ms`,
+      });
+    }, DRIFT_CODEX_TIMEOUT_MS);
+
+    child.stdout.on('data', (c: Buffer) => stdoutChunks.push(c));
+    child.stderr.on('data', (c: Buffer) => stderrChunks.push(c));
+
+    child.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve({
+        ok: false,
+        stdout: Buffer.concat(stdoutChunks).toString('utf-8'),
+        stderr: Buffer.concat(stderrChunks).toString('utf-8'),
+        errorMessage: `Codex spawn error: ${err.message}`,
+      });
+    });
+
+    child.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      const stdout = Buffer.concat(stdoutChunks).toString('utf-8');
+      const stderr = Buffer.concat(stderrChunks).toString('utf-8');
+      if (code === 0) {
+        resolve({ ok: true, stdout, stderr });
+      } else {
+        resolve({
+          ok: false,
+          stdout,
+          stderr,
+          errorMessage: `Codex drift call exited with code ${code ?? 'null'}`,
+        });
+      }
+    });
+
+    try {
+      child.stdin.write(input.prompt);
+      child.stdin.end();
+    } catch (err) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      try { child.kill('SIGTERM'); } catch { /* best-effort */ }
+      resolve({
+        ok: false,
+        stdout: '',
+        stderr: '',
+        errorMessage: `Codex stdin write failed: ${(err as Error).message}`,
+      });
+    }
+  });
+}
+
+function resolveCodexBin(): string | null {
+  try {
+    return execSync('which codex', { encoding: 'utf-8' }).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Orchestrator. Returns activated:false when drift detection is disabled,
+ * activated:true with the outcome otherwise. Never throws — D6 strict
+ * fail-open.
+ */
+export async function scoreP5Drift(input: {
+  state: HarnessState;
+  runDir: string;
+  cwd: string;
+}): Promise<{ activated: false } | { activated: true; outcome: DriftOutcome }> {
+  const startTs = Date.now();
+  const threshold = loadDriftThreshold(input.state.autoMode === true);
+  if (threshold === null) {
+    return { activated: false };
+  }
+
+  // Best-effort artifact reads. Any read failure → fail-open error outcome.
+  let specText = '';
+  let planText = '';
+  try {
+    const specRel = input.state.artifacts?.spec;
+    const planRel = input.state.artifacts?.plan;
+    if (specRel === undefined || planRel === undefined) {
+      throw new Error('artifacts.spec or artifacts.plan missing from state');
+    }
+    specText = fs.readFileSync(path.resolve(input.cwd, specRel), 'utf-8');
+    planText = fs.readFileSync(path.resolve(input.cwd, planRel), 'utf-8');
+  } catch (err) {
+    return {
+      activated: true,
+      outcome: errorOutcome(threshold, startTs, `artifact read failed: ${(err as Error).message}`),
+    };
+  }
+
+  const trackedRoot = input.state.trackedRepos?.[0]?.path ?? input.cwd;
+  const diffText = readP5Diff(input.state.planCommit ?? null, input.state.implCommit ?? null, trackedRoot);
+
+  const promptResult = buildDriftPrompt(specText, planText, diffText, threshold);
+  if ('oversized' in promptResult) {
+    warnOnce(
+      'drift-oversized',
+      `[drift] spec+plan exceeds ${DRIFT_PROMPT_CAP_CHARS}-char cap (${specText.length + planText.length} chars) — drift detection skipped for this attempt`,
+    );
+    return {
+      activated: true,
+      outcome: errorOutcome(threshold, startTs, 'spec+plan exceeds prompt cap'),
+    };
+  }
+
+  let codexResult: CodexDriftRawResult;
+  try {
+    codexResult = await runCodexDriftScorer({
+      prompt: promptResult.prompt,
+      cwd: trackedRoot,
+    });
+  } catch (err) {
+    return {
+      activated: true,
+      outcome: errorOutcome(threshold, startTs, `Codex call threw: ${(err as Error).message}`),
+    };
+  }
+
+  if (!codexResult.ok) {
+    warnOnce(
+      'drift-codex-fail',
+      `[drift] Codex call failed: ${codexResult.errorMessage ?? 'unknown'} — fail-open, P6 will proceed`,
+    );
+    return {
+      activated: true,
+      outcome: errorOutcome(threshold, startTs, codexResult.errorMessage ?? 'codex error'),
+    };
+  }
+
+  const scores = parseDriftScores(codexResult.stdout);
+  if (scores === null) {
+    warnOnce(
+      'drift-parse-fail',
+      `[drift] Could not parse ## Drift Scores JSON from Codex output — fail-open, P6 will proceed`,
+    );
+    return {
+      activated: true,
+      outcome: errorOutcome(threshold, startTs, 'parse error'),
+    };
+  }
+
+  const axes: DriftAxes = {
+    goal: scores.goal,
+    constraint: scores.constraint,
+    ontology: scores.ontology,
+  };
+  const score = computeWeightedDrift(axes);
+  const codexMeta = extractCodexMetadata(codexResult.stdout, codexResult.stderr);
+
+  const outcome: DriftOutcome = {
+    activated: true,
+    threshold,
+    score,
+    axes,
+    driftSource: promptResult.truncated ? 'codex-truncated' : 'codex-only',
+    durationMs: Date.now() - startTs,
+    ...(codexMeta.tokensTotal !== undefined ? { codexTokensTotal: codexMeta.tokensTotal } : {}),
+    ...(scores.rationale ? { rationale: scores.rationale } : {}),
+  };
+  return { activated: true, outcome };
+}
+
+function errorOutcome(threshold: number, startTs: number, error: string): DriftOutcome {
+  return {
+    activated: true,
+    threshold,
+    score: null,
+    axes: null,
+    driftSource: 'error',
+    durationMs: Date.now() - startTs,
+    error,
+  };
+}
+
+/**
+ * Resolve action from outcome + autoMode. v1 simplifies D2: both autoMode
+ * and manual users (who must opt in via env) get reopen on score-exceeded.
+ * The C/S/Q manual escalation prompt is documented in spec but deferred to
+ * a follow-up PR.
+ */
+export function resolveDriftAction(outcome: DriftOutcome): DriftAction {
+  if (outcome.driftSource === 'error' || outcome.score === null) {
+    return 'error';
+  }
+  return outcome.score > outcome.threshold ? 'reopen' : 'pass';
+}
+

--- a/src/phases/runner.ts
+++ b/src/phases/runner.ts
@@ -19,6 +19,7 @@ import { runInteractivePhase } from './interactive.js';
 import { runGatePhase } from './gate.js';
 import { runVerifyPhase } from './verify.js';
 import { StagnationDetector, loadStagnationConfig } from './stagnation.js';
+import { scoreP5Drift, resolveDriftAction, writeDriftFeedback } from './drift.js';
 import { readClaudeSessionUsage, claudeSessionJsonlExists } from '../runners/claude-usage.js';
 import {
   promptChoice,
@@ -476,6 +477,68 @@ export async function handleInteractivePhase(
         if (phase === 5) syncLegacyMirror(state); // implHead already set by validatePhaseArtifacts
       } catch {
         // getHead unavailable — leave anchor as-is
+      }
+
+      // Drift detection (P5 → P6 — issue #2 / phase_drift event).
+      // Disabled by default in manual mode; opt-in via HARNESS_PHASE_DRIFT_THRESHOLD
+      // (default 0.3 in autonomous). Strict fail-open: any failure leaves the
+      // success path unchanged. Spec: docs/specs/2026-05-11-...drift...-design.md
+      if (phase === 5) {
+        try {
+          const driftResult = await scoreP5Drift({ state, runDir, cwd });
+          if (driftResult.activated) {
+            const { outcome } = driftResult;
+            const action = resolveDriftAction(outcome);
+            let feedbackPath: string | null = null;
+            if (action === 'reopen') {
+              try { feedbackPath = writeDriftFeedback(runDir, outcome); } catch { feedbackPath = null; }
+            }
+            // resolveDriftAction (v1) only ever returns one of the LogEvent-compatible values.
+            const eventAction = action as 'pass' | 'reopen' | 'error';
+            logger.logEvent({
+              event: 'phase_drift',
+              phase: 5,
+              attemptId,
+              durationMs: outcome.durationMs,
+              threshold: outcome.threshold,
+              score: outcome.score,
+              axes: outcome.axes,
+              action: eventAction,
+              driftSource: outcome.driftSource,
+              ...(outcome.codexTokensTotal !== undefined ? { codexTokensTotal: outcome.codexTokensTotal } : {}),
+              ...(outcome.rationale ? { rationale: outcome.rationale } : {}),
+              ...(outcome.error ? { error: outcome.error } : {}),
+            });
+            if (action === 'reopen' && feedbackPath !== null) {
+              state.phases['5'] = 'pending';
+              state.phaseReopenFlags['5'] = true;
+              state.phaseReopenSource['5'] = 5;
+              state.pendingAction = {
+                type: 'reopen_phase',
+                targetPhase: 5,
+                sourcePhase: 5,
+                feedbackPaths: [feedbackPath],
+              };
+              clearWatchdog();
+              writeState(runDir, state);
+              const driftTokens = collectClaudeTokens();
+              logger.logEvent({
+                event: 'phase_end',
+                phase: 5,
+                attemptId,
+                status: 'failed',
+                durationMs: Date.now() - phaseStartTs,
+                details: { reason: 'drift-reopen' },
+                ...(driftTokens !== undefined ? { claudeTokens: driftTokens } : {}),
+              });
+              return;
+            }
+            // action === 'pass' or 'error' — fall through to success path.
+          }
+        } catch (err) {
+          // scoreP5Drift never throws by contract, but defensively swallow.
+          process.stderr.write(`[drift] unexpected throw, fail-open: ${(err as Error).message}\n`);
+        }
       }
 
       // Clear pendingAction now that phase succeeded

--- a/src/types.ts
+++ b/src/types.ts
@@ -313,6 +313,20 @@ export type LogEvent =
   | (LogEventBase & { event: 'force_pass'; phase: number; by: 'auto' | 'user' })
   | (LogEventBase & { event: 'verify_result'; passed: boolean; retryIndex: number; durationMs: number; failedChecks?: string[] })
   | (LogEventBase & { event: 'phase_end'; phase: number; attemptId?: string | null; status: 'completed' | 'failed'; durationMs: number; details?: { reason: string; error?: string }; claudeTokens?: ClaudeTokens | null; codexTokens?: ClaudeTokens | null; uncommittedRepos?: Array<{ path: string; count: number }> })
+  | (LogEventBase & {
+      event: 'phase_drift';
+      phase: 5;
+      attemptId: string;
+      durationMs: number;
+      threshold: number;
+      score: number | null;
+      axes: { goal: number; constraint: number; ontology: number } | null;
+      action: 'pass' | 'reopen' | 'error';
+      driftSource: 'codex-only' | 'codex-truncated' | 'error';
+      codexTokensTotal?: number;
+      rationale?: string;
+      error?: string;
+    })
   | (LogEventBase & { event: 'state_anomaly'; kind: string; details: Record<string, unknown> })
   | (LogEventBase & {
       event: 'ui_render';

--- a/tests/phases/drift.test.ts
+++ b/tests/phases/drift.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  loadDriftThreshold,
+  parseDriftScores,
+  computeWeightedDrift,
+  buildDriftPrompt,
+  resolveDriftAction,
+  writeDriftFeedback,
+  __resetDriftWarning,
+  DRIFT_WEIGHTS,
+  type DriftOutcome,
+} from '../../src/phases/drift.js';
+
+beforeEach(() => {
+  __resetDriftWarning();
+  vi.unstubAllEnvs();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('loadDriftThreshold', () => {
+  it('unset + autoMode=true → 0.3', () => {
+    expect(loadDriftThreshold(true)).toBe(0.3);
+  });
+
+  it('unset + autoMode=false → null', () => {
+    expect(loadDriftThreshold(false)).toBe(null);
+  });
+
+  it('"" + autoMode=true → 0.3', () => {
+    vi.stubEnv('HARNESS_PHASE_DRIFT_THRESHOLD', '');
+    expect(loadDriftThreshold(true)).toBe(0.3);
+  });
+
+  it('"0.5" → 0.5 regardless of autoMode', () => {
+    vi.stubEnv('HARNESS_PHASE_DRIFT_THRESHOLD', '0.5');
+    expect(loadDriftThreshold(true)).toBe(0.5);
+    expect(loadDriftThreshold(false)).toBe(0.5);
+  });
+
+  it('"0" → 0', () => {
+    vi.stubEnv('HARNESS_PHASE_DRIFT_THRESHOLD', '0');
+    expect(loadDriftThreshold(true)).toBe(0);
+  });
+
+  it('"1" → 1', () => {
+    vi.stubEnv('HARNESS_PHASE_DRIFT_THRESHOLD', '1');
+    expect(loadDriftThreshold(false)).toBe(1);
+  });
+
+  it('"off" → null (case-insensitive)', () => {
+    vi.stubEnv('HARNESS_PHASE_DRIFT_THRESHOLD', 'off');
+    expect(loadDriftThreshold(true)).toBe(null);
+    vi.stubEnv('HARNESS_PHASE_DRIFT_THRESHOLD', 'OFF');
+    expect(loadDriftThreshold(true)).toBe(null);
+  });
+
+  it('"1.5" (out of range) → null + warn once', () => {
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.stubEnv('HARNESS_PHASE_DRIFT_THRESHOLD', '1.5');
+    expect(loadDriftThreshold(true)).toBe(null);
+    expect(loadDriftThreshold(true)).toBe(null);
+    const warnCalls = errSpy.mock.calls.filter((c) => String(c[0]).includes('[drift] invalid'));
+    expect(warnCalls.length).toBe(1);
+    errSpy.mockRestore();
+  });
+
+  it('"abc" (non-numeric) → null + warn once', () => {
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.stubEnv('HARNESS_PHASE_DRIFT_THRESHOLD', 'abc');
+    expect(loadDriftThreshold(true)).toBe(null);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});
+
+describe('parseDriftScores', () => {
+  it('parses well-formed Codex output', () => {
+    const raw = [
+      '## Drift Scores',
+      '```json',
+      '{ "goal": 0.12, "constraint": 0.05, "ontology": 0.20, "rationale": "Looks fine" }',
+      '```',
+      '',
+      '## End',
+    ].join('\n');
+    const r = parseDriftScores(raw);
+    expect(r).not.toBeNull();
+    expect(r!.goal).toBe(0.12);
+    expect(r!.constraint).toBe(0.05);
+    expect(r!.ontology).toBe(0.20);
+    expect(r!.rationale).toBe('Looks fine');
+  });
+
+  it('clamps rationale to ≤ 200 chars + single line', () => {
+    const longText = 'A'.repeat(500);
+    const raw = [
+      '## Drift Scores',
+      '```json',
+      `{"goal":0,"constraint":0,"ontology":0,"rationale":"${longText}"}`,
+      '```',
+    ].join('\n');
+    const r = parseDriftScores(raw);
+    expect(r!.rationale!.length).toBeLessThanOrEqual(200);
+  });
+
+  it('returns null when ## Drift Scores header missing', () => {
+    expect(parseDriftScores('No drift section here')).toBeNull();
+  });
+
+  it('returns null on out-of-range axis', () => {
+    const raw = [
+      '## Drift Scores',
+      '```json',
+      '{ "goal": 1.5, "constraint": 0, "ontology": 0 }',
+      '```',
+    ].join('\n');
+    expect(parseDriftScores(raw)).toBeNull();
+  });
+
+  it('returns null on missing axis', () => {
+    const raw = [
+      '## Drift Scores',
+      '```json',
+      '{ "goal": 0.1, "constraint": 0.1 }',
+      '```',
+    ].join('\n');
+    expect(parseDriftScores(raw)).toBeNull();
+  });
+
+  it('returns null on non-JSON fence body', () => {
+    const raw = [
+      '## Drift Scores',
+      '```json',
+      'this is not json',
+      '```',
+    ].join('\n');
+    expect(parseDriftScores(raw)).toBeNull();
+  });
+
+  it('returns null on empty input', () => {
+    expect(parseDriftScores('')).toBeNull();
+  });
+});
+
+describe('computeWeightedDrift', () => {
+  it('reference vectors per spec weights', () => {
+    expect(computeWeightedDrift({ goal: 1, constraint: 0, ontology: 0 })).toBeCloseTo(0.5, 5);
+    expect(computeWeightedDrift({ goal: 0, constraint: 1, ontology: 0 })).toBeCloseTo(0.3, 5);
+    expect(computeWeightedDrift({ goal: 0, constraint: 0, ontology: 1 })).toBeCloseTo(0.2, 5);
+    expect(computeWeightedDrift({ goal: 1, constraint: 1, ontology: 1 })).toBeCloseTo(1, 5);
+    expect(computeWeightedDrift({ goal: 0, constraint: 0, ontology: 0 })).toBe(0);
+  });
+
+  it('weights sum to 1', () => {
+    const sum = DRIFT_WEIGHTS.goal + DRIFT_WEIGHTS.constraint + DRIFT_WEIGHTS.ontology;
+    expect(sum).toBeCloseTo(1, 10);
+  });
+
+  it('clamps NaN / out-of-bounds (defensive)', () => {
+    expect(computeWeightedDrift({ goal: NaN, constraint: 0, ontology: 0 })).toBe(0);
+  });
+});
+
+describe('buildDriftPrompt', () => {
+  it('returns a prompt under cap when inputs are small', () => {
+    const r = buildDriftPrompt('spec body', 'plan body', 'diff body', 0.3);
+    expect('oversized' in r).toBe(false);
+    if ('oversized' in r) return;
+    expect(r.truncated).toBe(false);
+    expect(r.prompt).toContain('## Spec');
+    expect(r.prompt).toContain('## Plan');
+    expect(r.prompt).toContain('## Diff (planCommit..implCommit)');
+    expect(r.prompt).toContain('## Drift Scores');
+  });
+
+  it('truncates the diff tail when assembled prompt > cap', () => {
+    const bigDiff = 'X'.repeat(40_000);
+    const r = buildDriftPrompt('spec', 'plan', bigDiff, 0.3);
+    expect('oversized' in r).toBe(false);
+    if ('oversized' in r) return;
+    expect(r.truncated).toBe(true);
+    expect(r.prompt).toContain('[... diff truncated ...]');
+    expect(r.prompt.length).toBeLessThanOrEqual(30_000 + 200); // some slack for marker text
+  });
+
+  it('returns oversized when spec+plan alone exceed cap', () => {
+    const bigSpec = 'S'.repeat(20_000);
+    const bigPlan = 'P'.repeat(20_000);
+    const r = buildDriftPrompt(bigSpec, bigPlan, '', 0.3);
+    expect('oversized' in r && (r as { oversized: true }).oversized).toBe(true);
+  });
+});
+
+describe('resolveDriftAction', () => {
+  function outcome(score: number | null, source: 'codex-only' | 'codex-truncated' | 'error', threshold = 0.3): DriftOutcome {
+    return {
+      activated: true,
+      threshold,
+      score,
+      axes: score === null ? null : { goal: 0, constraint: 0, ontology: 0 },
+      driftSource: source,
+      durationMs: 1,
+    };
+  }
+
+  it('error → error', () => {
+    expect(resolveDriftAction(outcome(null, 'error'))).toBe('error');
+  });
+
+  it('score ≤ threshold → pass', () => {
+    expect(resolveDriftAction(outcome(0.3, 'codex-only'))).toBe('pass');
+    expect(resolveDriftAction(outcome(0.0, 'codex-only'))).toBe('pass');
+  });
+
+  it('score > threshold → reopen', () => {
+    expect(resolveDriftAction(outcome(0.31, 'codex-only'))).toBe('reopen');
+    expect(resolveDriftAction(outcome(0.99, 'codex-truncated'))).toBe('reopen');
+  });
+});
+
+describe('writeDriftFeedback', () => {
+  it('writes a markdown report with score + axes when present', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'drift-test-'));
+    const o: DriftOutcome = {
+      activated: true,
+      threshold: 0.3,
+      score: 0.55,
+      axes: { goal: 0.7, constraint: 0.3, ontology: 0.2 },
+      driftSource: 'codex-only',
+      durationMs: 1234,
+      codexTokensTotal: 4567,
+      rationale: 'goal axis diverged: spec said X, code does Y',
+    };
+    const fp = writeDriftFeedback(tmp, o);
+    const body = fs.readFileSync(fp, 'utf-8');
+    expect(body).toContain('Weighted drift score: 0.55');
+    expect(body).toContain('| goal | 0.70');
+    expect(body).toContain('codex-only');
+    expect(body).toContain('Codex tokens (drift call): 4567');
+    expect(body).toContain('goal axis diverged');
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('writes a degraded report when score=null', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'drift-test-'));
+    const o: DriftOutcome = {
+      activated: true,
+      threshold: 0.3,
+      score: null,
+      axes: null,
+      driftSource: 'error',
+      durationMs: 0,
+      error: 'parse failure',
+    };
+    const fp = writeDriftFeedback(tmp, o);
+    const body = fs.readFileSync(fp, 'utf-8');
+    expect(body).toContain('unavailable');
+    expect(body).toContain('error');
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary

P5 implementations regularly satisfy interactive completion criteria yet violate the spec/plan in ways that only surface at the P7 eval gate — both #1 (ambiguity) and #4 (auto-retro) dogfood runs burned a P7 R1 REJECT → P5 R2 cycle for exactly this reason. This PR adds an early-warning drift signal at P5 phase\_end that can short-circuit P6 entry when implementation has measurably diverged from the approved spec/plan.

- New \`src/phases/drift.ts\` (~440 LoC). Single-file scorer + env loader + Codex caller + feedback writer. No new deps.
- New \`phase_drift\` LogEvent variant. Additive, optional fields. Existing readers unaffected.
- \`src/phases/runner.ts\` gains a single insertion between artifact-normalize and P5's existing success-path mutation. On \`action='reopen'\`, the harness writes \`drift-feedback.md\`, sets \`phaseReopenFlags['5']=true\` / \`phaseReopenSource['5']=5\`, emits \`phase_drift\` then \`phase_end status='failed' details.reason='drift-reopen'\`, and returns. On \`pass\` / \`error\` it falls through to today's success path unchanged.
- 27 unit tests (env matrix, parser, weighted-score, prompt builder, action resolver, feedback writer). Full suite: **1194 passed / 1 skipped**.
- README + HOW-IT-WORKS (en/ko) all gain the env-vars row, schema row, and a \"Drift detection (P5→P6)\" / \"드리프트 검출\" subsection.

### Configuration

\`HARNESS_PHASE_DRIFT_THRESHOLD\`:
- unset + auto-mode → \`0.3\` (default-on for autonomous runs)
- unset + manual → \`null\` (default-off; opt in via env)
- numeric in [0, 1] → enabled at that value (any mode)
- \`off\` → disabled
- invalid → disabled + one stderr warning

### Inputs to Codex

Spec full text + plan full text + \`git diff planCommit..implCommit\` (in trackedRepos[0] cwd). 30 000-char prompt cap; on overflow, the diff tail is truncated and \`driftSource='codex-truncated'\` is set. If spec+plan alone exceed the cap, the call short-circuits to \`action='error'\`, \`driftSource='error'\`, fail-open. One Codex call per P5 attempt, never more.

### Inspired by

[Q00/ouroboros](https://github.com/Q00/ouroboros) — \`Drift = Goal(50%) + Constraint(30%) + Ontology(20%)\`, threshold ≤ 0.3.

### v1 deferrals (in spec ## Deferred)

- **Deterministic floor** (per advisor review): the original D1 hybrid scored \`max(codex_axis, floor_axis)\` from grep rules in the spec's \`## Success Criteria\` / \`## Invariants\`. Per D6 the floor never gates without Codex, so removing it preserves the success-path semantics. v1 ships Codex-only; floor lands in a follow-up PR.
- **Manual C/S/Q escalation prompt**: spec D2 routes \`autoMode=true\` → reopen, \`autoMode=false\` → user prompt. v1 collapses both to reopen since manual users must opt in via env (so reopen is what they explicitly asked for). Adding the prompt is a small follow-up.
- **Crash-window resume idempotency**: byte-precision behavior of a crash mid-\`phase_drift\`-flush is documented as deferred (G6 narrowed accordingly).

### Dogfood note

This PR was driven by phase-harness from the same source repo, but P2 hit issue #98's manual-mode retry-limit wedge after the third REJECT (Codex correctly flagged the G6/Deferred contradiction + the truncation cap boundary). Manual close-out path:
1. Killed the wedged inner process.
2. Updated the spec to address both Codex P1 findings (commit \`382c7cf\`).
3. Descaled to Codex-only v1 per advisor recommendation.
4. Implemented + tested + documented by hand.

#98 was updated with the second occurrence; the harness wedge bug is reproducible whenever any of P2/P4/P7 takes three rejects in manual mode and is the highest-priority follow-up before any future dogfood pass.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm vitest run\` — 1194 passed / 1 skipped (pre-existing)
  - 27 new unit tests in \`tests/phases/drift.test.ts\`
- [x] \`pnpm build\` clean
- [ ] Smoke-test on a real auto-mode run after global \`phase-harness\` reinstall: confirm \`phase_drift\` event fires once with \`driftSource='codex-only'\` (or \`-truncated\`), and that \`HARNESS_PHASE_DRIFT_THRESHOLD=off\` reproduces pre-PR behavior byte-for-byte.
- [ ] Verify a deliberately-drifted P5 (e.g. impl that ignores spec) triggers \`action='reopen'\`, writes \`drift-feedback.md\`, and the next P5 attempt sees the feedback in its prompt.