### PR TITLE
fix(ui): render escalation prompts via Ink so users can see C/S/Q (#98)

### DIFF
--- a/src/ink/components/ActionMenu.tsx
+++ b/src/ink/components/ActionMenu.tsx
@@ -9,6 +9,87 @@ interface Props {
 }
 
 export function ActionMenu({ state, callsite }: Props): React.ReactElement {
+  // Issue #98: when promptChoice opens for gate / verify retry-limit escalation
+  // the harness-inner main loop is awaiting `inputManager.waitForKey(['c','s','q'])`.
+  // Ink stays mounted on the same TTY, so a stderr `process.stderr.write` of the
+  // prompt is clobbered by the next Ink render — the wedge looks like a hang
+  // because the user can't see what keys to press. Fix: render the prompt as a
+  // first-class action menu when the dispatcher passes the matching callsite.
+  if (callsite === 'gate-escalation-pending') {
+    return (
+      <Box flexDirection="column">
+        <Box>
+          <Text bold color={COLORS.fail}>Gate retry limit reached. </Text>
+          <Text dimColor>Pick an action below:</Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>Actions </Text>
+          <Text bold color={COLORS.ok}>[C]</Text>
+          <Text> Continue (reset retries, reopen)  </Text>
+          <Text bold color={COLORS.accent}>[S]</Text>
+          <Text> Skip (force-pass)  </Text>
+          <Text bold color={COLORS.fail}>[Q]</Text>
+          <Text> Quit (pause)</Text>
+        </Box>
+      </Box>
+    );
+  }
+  if (callsite === 'verify-escalation-pending') {
+    return (
+      <Box flexDirection="column">
+        <Box>
+          <Text bold color={COLORS.fail}>Verify retry limit reached. </Text>
+          <Text dimColor>Pick an action below:</Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>Actions </Text>
+          <Text bold color={COLORS.ok}>[C]</Text>
+          <Text> Continue (reset, reopen P5)  </Text>
+          <Text bold color={COLORS.accent}>[S]</Text>
+          <Text> Skip (force-pass)  </Text>
+          <Text bold color={COLORS.fail}>[Q]</Text>
+          <Text> Quit (pause)</Text>
+        </Box>
+      </Box>
+    );
+  }
+  if (callsite === 'gate-error-pending') {
+    return (
+      <Box flexDirection="column">
+        <Box>
+          <Text bold color={COLORS.fail}>Gate error. </Text>
+          <Text dimColor>Pick an action below:</Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>Actions </Text>
+          <Text bold color={COLORS.ok}>[R]</Text>
+          <Text> Retry  </Text>
+          <Text bold color={COLORS.accent}>[S]</Text>
+          <Text> Skip (force-pass)  </Text>
+          <Text bold color={COLORS.fail}>[Q]</Text>
+          <Text> Quit (pause)</Text>
+        </Box>
+      </Box>
+    );
+  }
+  if (callsite === 'verify-error-pending') {
+    return (
+      <Box flexDirection="column">
+        <Box>
+          <Text bold color={COLORS.fail}>Verify error. </Text>
+          <Text dimColor>Pick an action below:</Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>Actions </Text>
+          <Text bold color={COLORS.ok}>[R]</Text>
+          <Text> Retry  </Text>
+          <Text bold color={COLORS.fail}>[Q]</Text>
+          <Text> Quit (pause)</Text>
+        </Box>
+      </Box>
+    );
+  }
+
   const prominent = callsite === 'terminal-failed';
   if (!prominent) {
     if (callsite === 'terminal-complete' || state.status === 'completed') {

--- a/src/phases/runner.ts
+++ b/src/phases/runner.ts
@@ -945,6 +945,11 @@ export async function handleGateEscalation(
   const retryLimit = getGateRetryLimit(state.flow, phase);
   printWarning(`Gate ${phase} retry limit reached (${retryLimit})`);
 
+  // Issue #98: render the C/S/Q prompt through Ink so the user can actually
+  // see it. promptChoice's stderr write alone is invisible while Ink is
+  // mounted on the same TTY (Ink redraw covers it on the next loop tick).
+  renderControlPanel(state, logger, 'gate-escalation-pending');
+
   const choice = await promptChoice(
     `Gate ${phase} has been rejected ${retryLimit} times. What would you like to do?`,
     [
@@ -1076,6 +1081,9 @@ export async function handleGateError(
   logger: SessionLogger,
 ): Promise<void> {
   printError(`Gate ${phase} error: ${error}`);
+
+  // Issue #98: render the R/S/Q prompt through Ink (see handleGateEscalation).
+  renderControlPanel(state, logger, 'gate-error-pending');
 
   const choice = await promptChoice(
     `Gate ${phase} encountered an error. What would you like to do?`,
@@ -1292,6 +1300,9 @@ export async function handleVerifyEscalation(
 ): Promise<void> {
   printWarning(`Verify retry limit reached (${VERIFY_RETRY_LIMIT})`);
 
+  // Issue #98: render the C/S/Q prompt through Ink (see handleGateEscalation).
+  renderControlPanel(state, logger, 'verify-escalation-pending');
+
   const choice = await promptChoice(
     `Verify has failed ${VERIFY_RETRY_LIMIT} times. What would you like to do?`,
     [
@@ -1427,6 +1438,9 @@ export async function handleVerifyError(
 ): Promise<void> {
   const errorInfo = errorPath ? ` (see ${errorPath})` : '';
   printError(`Verify error${errorInfo}`);
+
+  // Issue #98: render the R/Q prompt through Ink (see handleGateEscalation).
+  renderControlPanel(state, logger, 'verify-error-pending');
 
   const choice = await promptChoice(
     'Verify encountered an error. What would you like to do?',

--- a/src/types.ts
+++ b/src/types.ts
@@ -237,7 +237,11 @@ export type RenderCallsite =
   | 'verify-complete'
   | 'verify-redirect'
   | 'terminal-failed'
-  | 'terminal-complete';
+  | 'terminal-complete'
+  | 'gate-escalation-pending'
+  | 'gate-error-pending'
+  | 'verify-escalation-pending'
+  | 'verify-error-pending';
 
 // Distributive Omit: applies Omit to each member of a union separately,
 // preserving discriminated-union specificity (needed for LogEvent variants).

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -73,11 +73,17 @@ export async function promptChoice(
   choices: { key: string; label: string }[],
   inputManager: InputManager,
 ): Promise<string> {
-  const choiceText = choices.map((c) => `[${c.key.toUpperCase()}] ${c.label}`).join('  ');
-  process.stderr.write(`\n${message}\n${choiceText}\n`);
+  // Issue #98: when Ink is mounted, our stderr write here is hidden by the
+  // next Ink redraw. Callers that need a visible prompt MUST first call
+  // `renderControlPanel(state, logger, '<X>-pending')` so ActionMenu renders
+  // the matching action keys; this stderr write is a non-Ink fallback only.
+  if (!mounted) {
+    const choiceText = choices.map((c) => `[${c.key.toUpperCase()}] ${c.label}`).join('  ');
+    process.stderr.write(`\n${message}\n${choiceText}\n`);
+  }
   const validKeys = new Set(choices.map((c) => c.key.toLowerCase()));
   const key = await inputManager.waitForKey(validKeys);
-  process.stderr.write('\n');
+  if (!mounted) process.stderr.write('\n');
   return key;
 }
 

--- a/tests/phases/runner.test.ts
+++ b/tests/phases/runner.test.ts
@@ -1445,6 +1445,43 @@ describe('handleGatePhase — gate_error emission', () => {
 });
 
 describe('escalation — handleGateEscalation emission', () => {
+  // Issue #98: harness wedged at "Starting phase…" after the third gate REJECT
+  // in manual mode. Root cause: handleGateEscalation called promptChoice which
+  // wrote the C/S/Q prompt to stderr, but Ink (mounted on the same TTY) overwrote
+  // the prompt on its next loop tick. Users couldn't see the prompt → couldn't
+  // respond → wedge. Fix: render the prompt through Ink via a dedicated
+  // 'gate-escalation-pending' callsite BEFORE awaiting promptChoice.
+  it('calls renderControlPanel with gate-escalation-pending callsite before awaiting C/S/Q (issue #98 regression)', async () => {
+    const runDir = makeTmpDir();
+    const state = makeState({
+      currentPhase: 2,
+      gateRetries: { '2': FULL_GATE_RETRY_LIMIT, '4': 0, '7': 0 },
+    });
+    const { logger, cleanup } = makeTestLogger(state.runId);
+
+    vi.mocked(renderControlPanel).mockClear();
+    let promptCalledAt = -1;
+    let callsitesAtPromptTime: Array<unknown> = [];
+    vi.mocked(promptChoice).mockImplementationOnce(async () => {
+      const calls = vi.mocked(renderControlPanel).mock.calls;
+      promptCalledAt = calls.length;
+      callsitesAtPromptTime = calls.map((args) => args[2]);
+      return 'Q';
+    });
+
+    try {
+      await handleGateEscalation(2, 'Feedback', undefined, FULL_GATE_RETRY_LIMIT - 1, state, runDir, CWD, createNoOpInputManager(), logger);
+
+      // promptChoice must have observed at least one renderControlPanel call,
+      // and that call must carry the pending-callsite. Without this the user
+      // sees "Starting phase…" forever (issue #98 wedge).
+      expect(promptCalledAt).toBeGreaterThan(0);
+      expect(callsitesAtPromptTime).toContain('gate-escalation-pending');
+    } finally {
+      cleanup();
+    }
+  });
+
   it('emits exactly one escalation event with reason=gate-retry-limit after promptChoice', async () => {
     const runDir = makeTmpDir();
     const state = makeState({


### PR DESCRIPTION
## Summary

Fixes #98 — the manual-mode "wedge" where the harness appeared to hang at \`Status: Starting phase…\` after any of P2/P4/P7 took three rejects in a row.

### Root cause

\`handleGateEscalation\` (and the three sibling escalation paths — gate-error, verify-escalation, verify-error) called \`promptChoice\` which writes the action prompt to \`process.stderr\` and then \`await inputManager.waitForKey(...)\`. Because the harness inner process keeps Ink mounted on the same TTY (control pane), Ink's next redraw clobbers the stderr-rendered prompt. The user sees the stale \`Starting phase…\` panel, doesn't know to type \`C/S/Q\`, and the harness blocks on stdin forever.

This was hit twice in consecutive dogfood runs while building the ouroboros-port features (P7 in PR #97, P2 in PR #100), forcing manual close-out both times.

### Fix

Route the prompt UI through Ink's \`ActionMenu\` via four new \`RenderCallsite\` values:

- \`gate-escalation-pending\` (C/S/Q, retry-limit)
- \`gate-error-pending\` (R/S/Q, gate subprocess error)
- \`verify-escalation-pending\` (C/S/Q, verify retry-limit)
- \`verify-error-pending\` (R/Q, verify subprocess error)

Each escalation handler calls \`renderControlPanel(state, logger, '<X>-pending')\` immediately before awaiting \`promptChoice\`. \`ActionMenu\` now renders the matching keys prominently when it sees one of these callsites; the rest of the control panel (header, phase timeline, footer) stays put. \`promptChoice\` itself suppresses its stderr write while Ink is mounted to avoid duplicate / clobbered output.

No autonomous-mode behavior changes (force_pass, stagnation, drift-reopen all unaffected). No state-schema or event-schema changes.

### Regression test

\`tests/phases/runner.test.ts\` adds a regression test that asserts \`handleGateEscalation\` calls \`renderControlPanel\` with the \`gate-escalation-pending\` callsite *before* its \`promptChoice\` await. Future paths that reintroduce a stderr-only prompt will fail this test.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm vitest run\` — 1195 passed / 1 skipped (pre-existing) including the new regression
- [x] \`pnpm build\` clean
- [ ] Manual smoke: deliberately force three Codex P2 rejects in a manual-mode run, confirm the C/S/Q action menu appears immediately in the control pane and that pressing each key (C / S / Q) routes correctly.
- [ ] Repeat for verify retry-limit (deliberately failing tests three times) and gate-error (Codex spawn failure) paths.