### PR TITLE
fix(inner): flush session_end + retro before idle wait

### DIFF
--- a/src/commands/inner.ts
+++ b/src/commands/inner.ts
@@ -278,34 +278,43 @@ export async function innerCommand(runId: string, options: InnerOptions = {}): P
       }
     };
 
+    // Decide sessionEndStatus first WITHOUT blocking on the idle wait. The
+    // failed-terminal R/J/Q flow can mutate state.status, so it must run before
+    // we read the final status. The completed-idle wait, however, MUST run
+    // AFTER we flush session_end / retro to disk (see flush block below).
     if (state.status === 'completed') {
       sessionEndStatus = 'completed';
-      await enterIdle();
     } else if (state.status === 'paused') {
       sessionEndStatus = 'paused';
     } else if (anyPhaseFailed(state)) {
       await enterFailedTerminalState(state, harnessDir, runDir, cwd, inputManager, logger);
-      // After R/J flow returns: classify, and surface idle panel if it ended in completion.
-      // The else-if chain narrowed state.status to 'in_progress'; the call above can mutate it,
-      // so widen via indirect access before classifying.
+      // After R/J flow returns: classify. The else-if chain narrowed state.status
+      // to 'in_progress'; enterFailedTerminalState can mutate it, so widen via
+      // indirect access before classifying.
       const postStatus = (state as HarnessState).status;
-      if (postStatus === 'completed') {
-        sessionEndStatus = 'completed';
-        await enterIdle();
-      } else if (postStatus === 'paused') {
-        sessionEndStatus = 'paused';
-      } else {
-        sessionEndStatus = 'interrupted';
-      }
+      if (postStatus === 'completed') sessionEndStatus = 'completed';
+      else if (postStatus === 'paused') sessionEndStatus = 'paused';
+      else sessionEndStatus = 'interrupted';
     } else {
       sessionEndStatus = 'interrupted';
+    }
+
+    // Flush session_end / summary / retro BEFORE the completed-idle wait.
+    // Previously these lived in the outer finally, but when state.status was
+    // 'completed' the harness blocked in `await enterIdle()` and the user's
+    // Ctrl+C arrived through Node's SIGINT default path before the async
+    // finally got a chance to flush — session_end and retrospective.md never
+    // reached disk (issue #98 follow-up observed during PR #102 dogfood).
+    logger.logEvent({ event: 'session_end', status: sessionEndStatus, totalWallMs: Date.now() - logger.getStartedAt() });
+    logger.finalizeSummary(state);
+    await emitRetroHook(logger, harnessDir, runId);
+
+    if (sessionEndStatus === 'completed' && (state as HarnessState).status === 'completed') {
+      await enterIdle();
     }
   } finally {
     footerTimer.stop();
     process.removeListener('SIGWINCH', footerTimer.forceTick);
-    logger.logEvent({ event: 'session_end', status: sessionEndStatus, totalWallMs: Date.now() - logger.getStartedAt() });
-    logger.finalizeSummary(state);
-    await emitRetroHook(logger, harnessDir, runId);
     logger.close();
     unmountInk();
     inputManager.stop();


### PR DESCRIPTION
## Summary

Follow-up to the PR #102 dogfood. When a run lands at \`state.status === 'completed'\`, the harness was logging \`session_end\` + writing \`summary.json\` + emitting \`retrospective.md\` inside the outer try/finally block — *after* \`await enterIdle()\` returned. \`enterIdle\` blocks on \`Press Ctrl+C to exit.\`, so the user's Ctrl+C raced Node's SIGINT default path against the in-flight async finally. The retrospective never reached disk, and \`events.jsonl\` was left without a \`session_end\` record (only recoverable via the manual \`phase-harness retro\` subcommand).

Fix: decide \`sessionEndStatus\` first (the failed-terminal R/J/Q flow that can mutate \`state.status\` still runs *before* this point), then flush \`session_end\` / \`finalizeSummary\` / \`emitRetroHook\` synchronously, and only then call \`enterIdle()\`. The outer finally now owns *only* unconditional cleanup that's safe to lose under SIGINT: footer ticker stop, logger close, Ink unmount, input manager stop, lock release.

## Behavior change

| Path | Before | After |
|---|---|---|
| 'completed' + Ctrl+C | \`session_end\` log + \`retrospective.md\` dropped | Both written before idle wait; Ctrl+C is safe |
| 'completed' + no Ctrl+C (hang forever) | Same dropped behavior on hard kill | Both written immediately; idle wait can be left as long as the user likes |
| 'paused' | Worked (no \`enterIdle\` call) | Same — synchronous flush is at the same code position |
| 'failed' → R/J/Q → 'completed' | Same drop pattern via the inner \`enterIdle\` | Inner \`enterIdle\` removed; outer post-classify flush covers both branches |
| 'interrupted' | Worked | Same |

No state-schema or event-schema change. No new env var or CLI flag.

## Why no new test?

The bug is a SIGINT timing race against an \`await\` inside the outer try. A focused regression would need to wire real subprocess + SIGINT into the harness inner loop and assert ordering on \`events.jsonl\` after a forced kill — that's an integration-test-class fixture, not a fast unit one. The existing 1215-test suite still passes (the refactor is purely structural — same events emitted, same order, just moved out of finally). A real-run smoke after merge is the right validation:

\`\`\`
phase-harness start --enable-logging 'trivial task'  # auto-mode, force-passes early
# wait for "Run complete. Press Ctrl+C to exit."
# Ctrl+C
ls .harness/<runId>/retrospective.md   # should now exist
grep '\"session_end\"' \$(find ~/.harness/sessions -name events.jsonl)   # should match
\`\`\`

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm vitest run\` — 1215 passed / 1 skipped (no regressions from the reorder)
- [x] \`pnpm build\` clean
- [ ] Manual smoke: start a run, Ctrl+C from "Run complete." panel, confirm \`retrospective.md\` exists and \`events.jsonl\` contains \`session_end\`.