### PR TITLE
fix(inner): restore pre-run pane layout when Phase 7 completes

### DIFF
--- a/src/commands/inner.ts
+++ b/src/commands/inner.ts
@@ -7,7 +7,7 @@ import { readState, writeState, invalidatePhaseSessionsOnPresetChange, invalidat
 import { startFooterTicker } from './footer-ticker.js';
 import { runPhaseLoop, handleVerifyError } from '../phases/runner.js';
 import { registerSignalHandlers } from '../signal.js';
-import { killSession, killWindow, selectWindow, splitPane, paneExists, selectPane } from '../tmux.js';
+import { killSession, killSessionDetached, killWindow, killWindowDetached, selectWindow, splitPane, paneExists, selectPane } from '../tmux.js';
 import { renderWelcome, promptModelConfig } from '../ui.js';
 import { unmountInk } from '../ink/render.js';
 import { InputManager } from '../input.js';
@@ -319,18 +319,34 @@ export async function innerCommand(runId: string, options: InnerOptions = {}): P
     unmountInk();
     inputManager.stop();
     releaseLock(harnessDir, runId);
-  }
 
-  // 7. Cleanup tmux on completion
-  if (state.tmuxMode === 'dedicated') {
-    killSession(state.tmuxSession);
-  } else {
-    // Reused mode: kill only harness-owned windows
-    for (const windowId of state.tmuxWindows) {
-      killWindow(state.tmuxSession, windowId);
-    }
-    if (state.tmuxOriginalWindow) {
-      selectWindow(state.tmuxSession, state.tmuxOriginalWindow);
+    // Restore the pre-run pane layout: kill the harness-owned tmux window(s)
+    // (reused) or the whole dedicated session, then refocus the original
+    // window the user was on. This used to live AFTER the finally block,
+    // which meant it never ran when `await enterIdle()` returned via SIGINT
+    // — the harness left dangling `harness-ctrl` windows after every
+    // completed run (observed during PR #102 dogfood). Moving it into the
+    // finally guarantees execution on all exit paths.
+    //
+    // Self-kill race: in `reused` mode the inner Node process is itself
+    // running inside the window we're about to kill, so the synchronous
+    // `tmux kill-window` races our incoming SIGHUP — Node sometimes dies
+    // before tmux's kill side-effect propagates, leaving the window alive.
+    // `killWindowDetached` / `killSessionDetached` fire the tmux command
+    // as a detached child so it lives past this process's exit.
+    if (state.tmuxMode === 'dedicated') {
+      process.stderr.write(`[harness] cleanup: killing dedicated session ${state.tmuxSession}\n`);
+      killSessionDetached(state.tmuxSession);
+    } else if (state.tmuxWindows.length > 0) {
+      process.stderr.write(`[harness] cleanup: killing ${state.tmuxWindows.length} harness window(s) in session ${state.tmuxSession}\n`);
+      // Refocus the original window FIRST while it's still selectable —
+      // doing so after kill-window can race with the destruction.
+      if (state.tmuxOriginalWindow) {
+        selectWindow(state.tmuxSession, state.tmuxOriginalWindow);
+      }
+      for (const windowId of state.tmuxWindows) {
+        killWindowDetached(state.tmuxSession, windowId);
+      }
     }
   }
 }

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execSync, spawn } from 'child_process';
 
 /**
  * Create a detached tmux session.
@@ -60,6 +60,29 @@ export function killWindow(session: string, windowTarget: string): void {
 }
 
 /**
+ * Kill a window asynchronously via detached `tmux kill-window`. Use this
+ * variant when the caller may itself be running inside the window being
+ * killed (e.g. end-of-run cleanup from inner.ts in `reused` mode): the
+ * synchronous `killWindow` races with our own SIGHUP — `tmux kill-window`
+ * runs, returns, and the SIGHUP arriving in the same tick can take the
+ * Node process down before either the kill side-effect propagates or the
+ * follow-up `select-window` call runs. Detaching + `unref()` lets the
+ * tmux process keep going after we exit, so the window destruction is
+ * decoupled from this process's lifetime.
+ */
+export function killWindowDetached(session: string, windowTarget: string): void {
+  try {
+    const child = spawn('tmux', ['kill-window', '-t', `${session}:${windowTarget}`], {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.unref();
+  } catch {
+    // Spawn failure — best-effort
+  }
+}
+
+/**
  * Kill an entire tmux session. Best-effort — ignores errors (session may already be gone).
  */
 export function killSession(name: string): void {
@@ -67,6 +90,23 @@ export function killSession(name: string): void {
     execSync(`tmux kill-session -t ${esc(name)}`, { stdio: 'pipe' });
   } catch {
     // Session may already be gone
+  }
+}
+
+/**
+ * Kill a session asynchronously via detached `tmux kill-session`. Same
+ * rationale as `killWindowDetached` — use when the caller may be inside
+ * the session being killed (end-of-run cleanup in `dedicated` mode).
+ */
+export function killSessionDetached(name: string): void {
+  try {
+    const child = spawn('tmux', ['kill-session', '-t', name], {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.unref();
+  } catch {
+    // Spawn failure — best-effort
   }
 }
 

--- a/tests/commands/inner-footer.test.ts
+++ b/tests/commands/inner-footer.test.ts
@@ -79,7 +79,9 @@ vi.mock('../../src/signal.js', () => ({
 
 vi.mock('../../src/tmux.js', () => ({
   killSession: vi.fn(),
+  killSessionDetached: vi.fn(),
   killWindow: vi.fn(),
+  killWindowDetached: vi.fn(),
   selectWindow: vi.fn(),
   splitPane: vi.fn(() => '%3'),
   paneExists: vi.fn(() => true),

--- a/tests/commands/inner.test.ts
+++ b/tests/commands/inner.test.ts
@@ -21,10 +21,13 @@ vi.mock('../../src/signal.js', () => ({
 }));
 vi.mock('../../src/tmux.js', () => ({
   killSession: vi.fn(),
+  killSessionDetached: vi.fn(),
   killWindow: vi.fn(),
+  killWindowDetached: vi.fn(),
   selectWindow: vi.fn(),
   splitPane: vi.fn(() => '%1'),
   paneExists: vi.fn(() => false),
+  selectPane: vi.fn(),
 }));
 vi.mock('../../src/root.js', () => ({
   findHarnessRoot: vi.fn(),


### PR DESCRIPTION
## Summary

After every successful harness run, the \`harness-ctrl\` window (reused mode) or the dedicated \`harness-<runId>\` session was left dangling in the user's tmux. Every PR #96–#104 dogfood ended with a leftover split that the user had to \`tmux kill-window\` by hand. This PR makes Phase 7 completion restore the user's pre-run layout.

## Root cause

The cleanup logic lived *after* the outer try/finally in \`inner.ts\`:

\`\`\`ts
} finally { ... logger.close(); inputManager.stop(); releaseLock(...); }

// 7. Cleanup tmux on completion         ← never reached on the completed path
if (state.tmuxMode === 'dedicated') { killSession(...); }
else { for (...) killWindow(...); selectWindow(...); }
\`\`\`

The completed path blocks on \`await enterIdle()\` ("Press Ctrl+C to exit."). When the user Ctrl+Cs, Node's async-await teardown apparently didn't reliably reach the post-finally section. Empirically, after every dogfood the \`harness-ctrl\` window stayed alive.

## Fix

Two changes:

1. **Move cleanup into the finally block.** Now it executes on every exit path including SIGINT-interrupted \`await enterIdle()\`.
2. **New \`killSessionDetached\` / \`killWindowDetached\`** (\`src/tmux.ts\`) that fire \`tmux kill-window\` / \`kill-session\` via \`spawn(detached: true).unref()\` instead of \`execSync\`. When the inner Node process is itself running inside the window being killed, the synchronous variant races our own incoming SIGHUP — Node can die before the kill side-effect propagates. Detached spawn decouples the tmux command from this process's lifetime, so the kill completes regardless of how fast we exit. \`select-window\` is moved to run *before* the kill so it doesn't race with destruction.

The synchronous \`killSession\` / \`killWindow\` are still exported and still used by \`cancelAndExit\` (pre-tmux-setup error paths, where the self-kill race doesn't apply).

Single \`[harness] cleanup: …\` stderr line added so the next dogfood can verify the path ran.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm vitest run\` — 1216 passed / 1 skipped (2 mock fixtures extended to include the new exports)
- [x] \`pnpm build\` clean
- [ ] Next dogfood: confirm \`harness-ctrl\` window is gone after the run completes and the user is auto-refocused back to their original window. Look for \`[harness] cleanup: killing 1 harness window(s) in session …\` in stderr.