### PR TITLE
feat(config): add phase-harness config subcommand for persistent phase preset overrides

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -246,6 +246,21 @@ phase-harness start --root /tmp/demo "task"
 
 처음 세 변수에 잘못된 값이 있으면 해당 프로세스에서 기능이 비활성화되고 stderr에 경고 하나가 출력됩니다. 수동 모드에서는 항상 비활성화됩니다.
 
+### `phase-harness config`
+
+`~/.harness/config.json`에 저장되는 페이즈별 프리셋 오버라이드를 관리합니다. 오버라이드는 새 `start`/`run` 실행 시에만 적용되며, 기존 실행에는 영향을 주지 않습니다.
+
+```bash
+phase-harness config list                           # 전체 페이즈 키와 현재 값·출처 표시
+phase-harness config get phase.1.preset             # 유효 값 확인 (오버라이드 또는 기본값)
+phase-harness config set phase.1.preset opus-1m-max # 오버라이드 저장
+phase-harness config reset phase.1.preset           # 오버라이드 제거, 내장 기본값으로 복원
+```
+
+`start`/`run` 시 해결 우선순위: (1) 저장된 config 오버라이드, (2) 내장 `PHASE_DEFAULTS`.
+
+`resume`은 항상 실행 생성 시 `state.json`에 고정된 프리셋을 사용합니다. 저장된 config는 resume 시 재적용되지 않습니다.
+
 ### `phase-harness resume [runId]`
 
 현재 run 또는 특정 run을 재개합니다.

--- a/README.md
+++ b/README.md
@@ -246,6 +246,21 @@ When running with `--auto`, harness detects *stagnant* gate retry cycles — whe
 
 Any invalid value for the first three variables disables the feature for that process and emits one warning to stderr. The feature is always off in manual mode.
 
+### `phase-harness config`
+
+Manage per-phase preset overrides saved in `~/.harness/config.json`. Overrides apply to fresh `start`/`run` calls only; existing runs are unaffected.
+
+```bash
+phase-harness config list                           # show all phase keys with value and source
+phase-harness config get phase.1.preset             # effective value (override or default)
+phase-harness config set phase.1.preset opus-1m-max # persist override
+phase-harness config reset phase.1.preset           # remove override, revert to built-in default
+```
+
+Resolution precedence on `start`/`run`: (1) saved config override, (2) built-in `PHASE_DEFAULTS`.
+
+`resume` always uses the presets frozen in `state.json` at run-creation time — saved config is never re-applied on resume.
+
 ### `phase-harness resume [runId]`
 
 Resumes the current run or a specific run.

--- a/bin/harness.ts
+++ b/bin/harness.ts
@@ -11,6 +11,12 @@ import { installSkillsCommand } from '../src/commands/install-skills.js';
 import { uninstallSkillsCommand } from '../src/commands/uninstall-skills.js';
 import { cleanupCommand } from '../src/commands/cleanup.js';
 import { retroCommand } from '../src/commands/retro.js';
+import {
+  configListCommand,
+  configGetCommand,
+  configSetCommand,
+  configResetCommand,
+} from '../src/commands/config.js';
 import { HARNESS_VERSION } from '../src/version.js';
 
 const program = new Command();
@@ -145,6 +151,30 @@ program
     const globalOpts = program.opts();
     await retroCommand(runId, { stdout: opts.stdout, root: opts.root ?? globalOpts.root });
   });
+
+const configCmd = program
+  .command('config')
+  .description('manage per-phase preset overrides in ~/.harness/config.json');
+
+configCmd
+  .command('list')
+  .description('list all phase preset keys with their current value and source')
+  .action(() => { configListCommand(); });
+
+configCmd
+  .command('get <key>')
+  .description('get the effective value for a config key (e.g. phase.1.preset)')
+  .action((key: string) => { configGetCommand(key); });
+
+configCmd
+  .command('set <key> <value>')
+  .description('set a config key to a preset id (e.g. phase.1.preset opus-1m-max)')
+  .action((key: string, value: string) => { configSetCommand(key, value); });
+
+configCmd
+  .command('reset <key>')
+  .description('remove the override for a config key, reverting to the built-in default')
+  .action((key: string) => { configResetCommand(key); });
 
 program.parseAsync(process.argv).catch((err) => {
   process.stderr.write(`Error: ${err.message}\n`);

--- a/docs/HOW-IT-WORKS.ko.md
+++ b/docs/HOW-IT-WORKS.ko.md
@@ -53,6 +53,14 @@ P1 design+plan → P2 pre-impl gate → P5 implement → P6 verify → P7 eval g
 선택값은 `state.phasePresets`에 저장됩니다.
 기존 saved run은 자동으로 1M 기본값으로 마이그레이션되지 않고, 새로 만드는 run에만 1M 기본값이 자동 적용됩니다.
 
+### 사용자 config 오버라이드
+
+`phase-harness config set`으로 `~/.harness/config.json`에 페이즈별 프리셋 오버라이드를 저장할 수 있습니다. 새 `phase-harness start` / `phase-harness run` 실행 시, 하네스가 이 파일을 읽어 내장 `PHASE_DEFAULTS` 위에 오버라이드를 덮어쓴 후 `state.json`을 기록합니다. 저장된 프리셋 id가 카탈로그에 더 이상 없으면(stale) stderr 경고를 출력하고 내장 기본값을 사용합니다.
+
+`phase-harness resume`은 `~/.harness/config.json`을 읽지 않습니다. 기존 실행의 프리셋은 `state.json`이 기준입니다.
+
+`~/.harness/config.json`이 유효하지 않은 JSON이면, 모든 `config` 서브커맨드와 새 `start`/`run`은 즉시 non-zero로 종료됩니다.
+
 ---
 
 ## Full flow와 light flow

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -53,6 +53,14 @@ Users can change every non-verify phase preset during `phase-harness start` and 
 Selections persist in `state.phasePresets`.
 Existing saved runs are not auto-migrated to the new 1M defaults; only newly created runs pick them up automatically.
 
+### User config overrides
+
+Users can persist per-phase preset overrides in `~/.harness/config.json` via `phase-harness config set`. On every fresh `phase-harness start` / `phase-harness run`, the harness reads this file and overlays any saved overrides onto the built-in `PHASE_DEFAULTS` before writing `state.json`. If a saved preset id is no longer in the catalog (stale), a stderr warning is emitted and the built-in default is used instead.
+
+`phase-harness resume` never reads `~/.harness/config.json`; the presets in `state.json` are authoritative for existing runs.
+
+If `~/.harness/config.json` contains invalid JSON, every `config` subcommand and any new `start`/`run` exits non-zero immediately.
+
 ---
 
 ## Full flow vs light flow

--- a/docs/plans/2026-05-12-phase-harness-cli-config-b565.md
+++ b/docs/plans/2026-05-12-phase-harness-cli-config-b565.md
@@ -1,0 +1,889 @@
+# phase-harness `config` subcommand — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `phase-harness config list|get|set|reset` to persist per-phase preset overrides in `~/.harness/config.json` and auto-apply them on fresh `start`/`run`.
+
+**Architecture:** A new pure-I/O module `src/userConfig.ts` owns all config file access, key parsing, and start-time overlay logic. Four thin CLI handlers in `src/commands/config.ts` call into it. `src/commands/start.ts` calls `applyUserConfigOverrides(state)` once, between `createInitialState()` and the first `writeState()`.
+
+**Tech Stack:** TypeScript, Node.js `fs`/`path`/`os` (stdlib only — no new deps), commander (existing), vitest.
+
+- Related spec: `docs/specs/2026-05-12-phase-harness-cli-config-b565-design.md`
+- Related decisions: `.harness/2026-05-12-phase-harness-cli-config-b565/decisions.md`
+
+---
+
+### Task 1: `src/userConfig.ts` + unit tests
+
+**Files:**
+- Create: `src/userConfig.ts`
+- Create: `tests/userConfig.test.ts`
+- Create: `tests/userConfigStartOverlay.test.ts`
+
+- [ ] **Step 1: Write failing tests for `userConfig.ts`**
+
+Create `tests/userConfig.test.ts`:
+
+```typescript
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  loadUserConfig,
+  saveUserConfig,
+  parseConfigKey,
+  getEffectivePreset,
+  UserConfigParseError,
+  UserConfigKeyError,
+} from '../src/userConfig.js';
+import { PHASE_DEFAULTS } from '../src/config.js';
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  vi.restoreAllMocks();
+});
+function makeTmp(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'userconfig-test-'));
+  tmpDirs.push(d);
+  return d;
+}
+
+describe('loadUserConfig', () => {
+  it('returns {} when file absent', () => {
+    expect(loadUserConfig(makeTmp())).toEqual({});
+  });
+  it('parses valid JSON', () => {
+    const home = makeTmp();
+    fs.mkdirSync(path.join(home, '.harness'));
+    fs.writeFileSync(
+      path.join(home, '.harness', 'config.json'),
+      JSON.stringify({ phase: { '1': { preset: 'opus-1m-max' } } }),
+    );
+    expect(loadUserConfig(home)).toEqual({ phase: { '1': { preset: 'opus-1m-max' } } });
+  });
+  it('throws UserConfigParseError on malformed JSON', () => {
+    const home = makeTmp();
+    fs.mkdirSync(path.join(home, '.harness'));
+    fs.writeFileSync(path.join(home, '.harness', 'config.json'), '{bad json}');
+    expect(() => loadUserConfig(home)).toThrowError(UserConfigParseError);
+  });
+});
+
+describe('saveUserConfig', () => {
+  it('writes atomically — no tmp file left behind', () => {
+    const home = makeTmp();
+    saveUserConfig({ phase: { '1': { preset: 'sonnet-high' } } }, home);
+    const configPath = path.join(home, '.harness', 'config.json');
+    expect(fs.existsSync(configPath)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(configPath, 'utf-8'))).toEqual({
+      phase: { '1': { preset: 'sonnet-high' } },
+    });
+    expect(fs.existsSync(configPath + '.tmp')).toBe(false);
+  });
+  it('creates ~/.harness/ when missing', () => {
+    const home = makeTmp();
+    saveUserConfig({}, home);
+    expect(fs.existsSync(path.join(home, '.harness'))).toBe(true);
+  });
+});
+
+describe('parseConfigKey', () => {
+  it("parses 'phase.1.preset' → { phase: '1' }", () => {
+    expect(parseConfigKey('phase.1.preset')).toEqual({ phase: '1' });
+  });
+  it("throws UserConfigKeyError for 'phase.6.preset' and names phase 6", () => {
+    expect(() => parseConfigKey('phase.6.preset')).toThrowError(UserConfigKeyError);
+    try { parseConfigKey('phase.6.preset'); } catch (e) {
+      expect((e as Error).message).toContain('phase 6');
+    }
+  });
+  it.each(['phase.0.preset', 'phase.8.preset', 'phase.foo.preset', 'phase.1.model', 'random.thing', ''])(
+    'throws UserConfigKeyError for invalid key %s',
+    (key) => expect(() => parseConfigKey(key)).toThrowError(UserConfigKeyError),
+  );
+});
+
+describe('getEffectivePreset', () => {
+  it('returns built-in default when no override', () => {
+    expect(getEffectivePreset({}, '1')).toEqual({ value: PHASE_DEFAULTS[1], source: 'default' });
+  });
+  it('returns override when present', () => {
+    expect(getEffectivePreset({ phase: { '1': { preset: 'opus-1m-max' } } }, '1')).toEqual({
+      value: 'opus-1m-max',
+      source: 'override',
+    });
+  });
+});
+```
+
+Create `tests/userConfigStartOverlay.test.ts`:
+
+```typescript
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { applyUserConfigOverrides, UserConfigParseError } from '../src/userConfig.js';
+import { PHASE_DEFAULTS, REQUIRED_PHASE_KEYS } from '../src/config.js';
+import type { HarnessState } from '../src/types.js';
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  vi.restoreAllMocks();
+});
+function makeTmp(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'overlay-test-'));
+  tmpDirs.push(d);
+  return d;
+}
+function makeState(): HarnessState {
+  const phasePresets: Record<string, string> = {};
+  for (const p of REQUIRED_PHASE_KEYS) phasePresets[p] = PHASE_DEFAULTS[Number(p)];
+  return { phasePresets } as unknown as HarnessState;
+}
+
+describe('applyUserConfigOverrides', () => {
+  it('no-op when config.json absent', () => {
+    const state = makeState();
+    const before = { ...state.phasePresets };
+    applyUserConfigOverrides(state, makeTmp());
+    expect(state.phasePresets).toEqual(before);
+  });
+  it('applies override for phase 1, leaves other phases at built-in default', () => {
+    const home = makeTmp();
+    fs.mkdirSync(path.join(home, '.harness'));
+    fs.writeFileSync(
+      path.join(home, '.harness', 'config.json'),
+      JSON.stringify({ phase: { '1': { preset: 'opus-1m-max' } } }),
+    );
+    const state = makeState();
+    applyUserConfigOverrides(state, home);
+    expect(state.phasePresets['1']).toBe('opus-1m-max');
+    expect(state.phasePresets['2']).toBe(PHASE_DEFAULTS[2]);
+  });
+  it('warns to stderr and keeps built-in default for stale override', () => {
+    const home = makeTmp();
+    fs.mkdirSync(path.join(home, '.harness'));
+    fs.writeFileSync(
+      path.join(home, '.harness', 'config.json'),
+      JSON.stringify({ phase: { '1': { preset: 'stale-gone-preset' } } }),
+    );
+    const state = makeState();
+    const stderrSpy = vi.spyOn(process.stderr, 'write');
+    applyUserConfigOverrides(state, home);
+    expect(state.phasePresets['1']).toBe(PHASE_DEFAULTS[1]);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('stale-gone-preset'));
+  });
+  it('throws UserConfigParseError on malformed config.json', () => {
+    const home = makeTmp();
+    fs.mkdirSync(path.join(home, '.harness'));
+    fs.writeFileSync(path.join(home, '.harness', 'config.json'), '{bad}');
+    expect(() => applyUserConfigOverrides(makeState(), home)).toThrowError(UserConfigParseError);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+cd /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/config-cmd
+pnpm vitest run tests/userConfig.test.ts tests/userConfigStartOverlay.test.ts
+```
+
+Expected: errors like "Cannot find module '../src/userConfig.js'"
+
+- [ ] **Step 3: Implement `src/userConfig.ts`**
+
+Create `src/userConfig.ts`:
+
+```typescript
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { MODEL_PRESETS, PHASE_DEFAULTS, REQUIRED_PHASE_KEYS } from './config.js';
+import type { HarnessState } from './types.js';
+
+export interface UserConfig {
+  phase?: Record<string, { preset?: string }>;
+}
+
+export class UserConfigParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UserConfigParseError';
+  }
+}
+
+export class UserConfigKeyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UserConfigKeyError';
+  }
+}
+
+const SUPPORTED_PHASES = new Set(['1', '2', '3', '4', '5', '7']);
+
+export function getUserConfigPath(homeDir?: string): string {
+  return path.join(homeDir ?? os.homedir(), '.harness', 'config.json');
+}
+
+export function loadUserConfig(homeDir?: string): UserConfig {
+  const configPath = getUserConfigPath(homeDir);
+  if (!fs.existsSync(configPath)) return {};
+  const raw = fs.readFileSync(configPath, 'utf-8');
+  try {
+    return JSON.parse(raw) as UserConfig;
+  } catch (err) {
+    throw new UserConfigParseError(
+      `~/.harness/config.json is not valid JSON: ${(err as Error).message}. Edit or delete the file to recover.`,
+    );
+  }
+}
+
+export function saveUserConfig(config: UserConfig, homeDir?: string): void {
+  const configPath = getUserConfigPath(homeDir);
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  const tmpPath = configPath + '.tmp';
+  fs.writeFileSync(tmpPath, JSON.stringify(config, null, 2));
+  const fd = fs.openSync(tmpPath, 'r+');
+  try { fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+  fs.renameSync(tmpPath, configPath);
+}
+
+export function parseConfigKey(key: string): { phase: string } {
+  const match = key.match(/^phase\.(\w+)\.preset$/);
+  if (!match) {
+    throw new UserConfigKeyError(
+      `Error: unknown config key '${key}'. Supported keys: phase.<1|2|3|4|5|7>.preset`,
+    );
+  }
+  const phase = match[1];
+  if (phase === '6') {
+    throw new UserConfigKeyError(
+      `Error: phase 6 is the verify script (no model); cannot configure. Supported phases: 1, 2, 3, 4, 5, 7.`,
+    );
+  }
+  if (!SUPPORTED_PHASES.has(phase)) {
+    throw new UserConfigKeyError(
+      `Error: unknown phase '${phase}'. Supported phases: 1, 2, 3, 4, 5, 7.`,
+    );
+  }
+  return { phase };
+}
+
+export function getOverride(config: UserConfig, key: string): string | undefined {
+  const { phase } = parseConfigKey(key);
+  return config.phase?.[phase]?.preset;
+}
+
+export function setOverride(config: UserConfig, key: string, value: string): UserConfig {
+  const { phase } = parseConfigKey(key);
+  return {
+    ...config,
+    phase: {
+      ...(config.phase ?? {}),
+      [phase]: { ...(config.phase?.[phase] ?? {}), preset: value },
+    },
+  };
+}
+
+export function clearOverride(config: UserConfig, key: string): UserConfig {
+  const { phase } = parseConfigKey(key);
+  if (!config.phase?.[phase]?.preset) return config;
+  const newPhase = { ...(config.phase ?? {}) };
+  const entry = { ...newPhase[phase] };
+  delete entry.preset;
+  if (Object.keys(entry).length === 0) {
+    delete newPhase[phase];
+  } else {
+    newPhase[phase] = entry;
+  }
+  return { ...config, phase: newPhase };
+}
+
+export function getEffectivePreset(
+  config: UserConfig,
+  phase: string,
+): { value: string; source: 'default' | 'override' } {
+  const override = config.phase?.[phase]?.preset;
+  if (override !== undefined) return { value: override, source: 'override' };
+  return { value: PHASE_DEFAULTS[Number(phase)], source: 'default' };
+}
+
+export function applyUserConfigOverrides(state: HarnessState, homeDir?: string): void {
+  const config = loadUserConfig(homeDir); // throws UserConfigParseError — caller handles
+  const presetIds = new Set(MODEL_PRESETS.map(p => p.id));
+  for (const phase of REQUIRED_PHASE_KEYS) {
+    const override = config.phase?.[phase]?.preset;
+    if (override === undefined) continue;
+    if (!presetIds.has(override)) {
+      process.stderr.write(
+        `Saved config phase.${phase}.preset='${override}' is no longer a known preset; ` +
+        `using built-in default '${PHASE_DEFAULTS[Number(phase)]}'.\n`,
+      );
+      continue;
+    }
+    state.phasePresets[phase] = override;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+pnpm vitest run tests/userConfig.test.ts tests/userConfigStartOverlay.test.ts
+```
+
+Expected: all tests pass, no failures.
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/userConfig.ts tests/userConfig.test.ts tests/userConfigStartOverlay.test.ts
+git commit -m "feat(config): add userConfig module with I/O, key parsing, and start-time overlay"
+```
+
+---
+
+### Task 2: `src/commands/config.ts` + `bin/harness.ts` + command tests
+
+**Files:**
+- Create: `src/commands/config.ts`
+- Modify: `bin/harness.ts`
+- Create: `tests/commands/config.test.ts`
+
+- [ ] **Step 1: Write failing command tests**
+
+Create `tests/commands/config.test.ts`:
+
+```typescript
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  configListCommand,
+  configGetCommand,
+  configSetCommand,
+  configResetCommand,
+} from '../../src/commands/config.js';
+import { PHASE_DEFAULTS } from '../../src/config.js';
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  vi.restoreAllMocks();
+});
+function makeTmp(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'config-cmd-test-'));
+  tmpDirs.push(d);
+  return d;
+}
+function writeConfig(home: string, data: object): void {
+  fs.mkdirSync(path.join(home, '.harness'), { recursive: true });
+  fs.writeFileSync(path.join(home, '.harness', 'config.json'), JSON.stringify(data));
+}
+function captureStdout(fn: () => void): string {
+  const chunks: string[] = [];
+  const spy = vi.spyOn(process.stdout, 'write').mockImplementation((s) => { chunks.push(String(s)); return true; });
+  try { fn(); } finally { spy.mockRestore(); }
+  return chunks.join('');
+}
+function captureStderr(fn: () => void): string {
+  const chunks: string[] = [];
+  const spy = vi.spyOn(process.stderr, 'write').mockImplementation((s) => { chunks.push(String(s)); return true; });
+  try { fn(); } finally { spy.mockRestore(); }
+  return chunks.join('');
+}
+
+describe('configListCommand', () => {
+  it('prints 6 data rows + header + separator when no overrides', () => {
+    const home = makeTmp();
+    const out = captureStdout(() => configListCommand({ homeDir: home }));
+    const lines = out.trim().split('\n');
+    expect(lines).toHaveLength(8); // header + separator + 6 rows
+    expect(out).toContain('phase.1.preset');
+    expect(out).toContain('phase.7.preset');
+    expect(out).toContain('default');
+  });
+  it('shows override source and value for overridden phase', () => {
+    const home = makeTmp();
+    writeConfig(home, { phase: { '1': { preset: 'opus-1m-max' } } });
+    const out = captureStdout(() => configListCommand({ homeDir: home }));
+    expect(out).toContain('opus-1m-max');
+    expect(out).toContain('override');
+  });
+});
+
+describe('configGetCommand', () => {
+  it('prints bare value when override present', () => {
+    const home = makeTmp();
+    writeConfig(home, { phase: { '1': { preset: 'opus-1m-max' } } });
+    const out = captureStdout(() => configGetCommand('phase.1.preset', { homeDir: home }));
+    expect(out.trim()).toBe('opus-1m-max');
+  });
+  it('prints default value with (default) annotation when unset', () => {
+    const home = makeTmp();
+    const out = captureStdout(() => configGetCommand('phase.1.preset', { homeDir: home }));
+    expect(out).toContain(PHASE_DEFAULTS[1]);
+    expect(out).toContain('(default)');
+  });
+  it('exits 1 with stderr mentioning phase 6 for phase.6.preset', () => {
+    const home = makeTmp();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit1'); });
+    const err = captureStderr(() => {
+      try { configGetCommand('phase.6.preset', { homeDir: home }); } catch { /* exit mock */ }
+    });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(err).toContain('phase 6');
+  });
+});
+
+describe('configSetCommand', () => {
+  it('writes config.json and prints "key = value" confirmation', () => {
+    const home = makeTmp();
+    const out = captureStdout(() => configSetCommand('phase.1.preset', 'opus-1m-max', { homeDir: home }));
+    expect(out.trim()).toBe('phase.1.preset = opus-1m-max');
+    const saved = JSON.parse(fs.readFileSync(path.join(home, '.harness', 'config.json'), 'utf-8'));
+    expect(saved.phase['1'].preset).toBe('opus-1m-max');
+  });
+  it('exits 1 for bogus preset id, does not create config.json', () => {
+    const home = makeTmp();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit1'); });
+    const err = captureStderr(() => {
+      try { configSetCommand('phase.1.preset', 'bogus-id', { homeDir: home }); } catch { /* exit mock */ }
+    });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(err).toContain('bogus-id');
+    expect(fs.existsSync(path.join(home, '.harness', 'config.json'))).toBe(false);
+  });
+  it('exits 1 for phase.6.preset, does not create config.json', () => {
+    const home = makeTmp();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit1'); });
+    captureStderr(() => {
+      try { configSetCommand('phase.6.preset', 'opus-1m-max', { homeDir: home }); } catch { /* exit mock */ }
+    });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(fs.existsSync(path.join(home, '.harness', 'config.json'))).toBe(false);
+  });
+});
+
+describe('configResetCommand', () => {
+  it('removes override and prints "reset <key>"', () => {
+    const home = makeTmp();
+    writeConfig(home, { phase: { '1': { preset: 'opus-1m-max' } } });
+    const out = captureStdout(() => configResetCommand('phase.1.preset', { homeDir: home }));
+    expect(out).toContain('reset phase.1.preset');
+    const saved = JSON.parse(fs.readFileSync(path.join(home, '.harness', 'config.json'), 'utf-8'));
+    expect(saved.phase?.['1']?.preset).toBeUndefined();
+  });
+  it('is idempotent — prints no-op message and exits 0 on second reset', () => {
+    const home = makeTmp();
+    writeConfig(home, { phase: { '1': { preset: 'opus-1m-max' } } });
+    configResetCommand('phase.1.preset', { homeDir: home });
+    const out2 = captureStdout(() => configResetCommand('phase.1.preset', { homeDir: home }));
+    expect(out2).toContain('no override to reset');
+  });
+});
+
+describe('malformed config.json — all four subcommands exit 1', () => {
+  function writeBadConfig(home: string): void {
+    fs.mkdirSync(path.join(home, '.harness'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.harness', 'config.json'), '{bad json}');
+  }
+  it.each([
+    ['list', (home: string) => configListCommand({ homeDir: home })],
+    ['get', (home: string) => configGetCommand('phase.1.preset', { homeDir: home })],
+    ['set', (home: string) => configSetCommand('phase.1.preset', 'opus-1m-max', { homeDir: home })],
+    ['reset', (home: string) => configResetCommand('phase.1.preset', { homeDir: home })],
+  ] as const)('config %s exits 1 with config.json in stderr', (_name, fn) => {
+    const home = makeTmp();
+    writeBadConfig(home);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit1'); });
+    const err = captureStderr(() => { try { fn(home); } catch { /* exit mock */ } });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(err).toContain('config.json');
+  });
+});
+
+describe('stale override annotation', () => {
+  it('config list shows (stale) for unknown preset id', () => {
+    const home = makeTmp();
+    fs.mkdirSync(path.join(home, '.harness'), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, '.harness', 'config.json'),
+      JSON.stringify({ phase: { '1': { preset: 'old-preset-removed' } } }),
+    );
+    const out = captureStdout(() => configListCommand({ homeDir: home }));
+    expect(out).toContain('stale');
+  });
+  it('config get shows (override, stale) for unknown preset id', () => {
+    const home = makeTmp();
+    fs.mkdirSync(path.join(home, '.harness'), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, '.harness', 'config.json'),
+      JSON.stringify({ phase: { '1': { preset: 'old-preset-removed' } } }),
+    );
+    const out = captureStdout(() => configGetCommand('phase.1.preset', { homeDir: home }));
+    expect(out).toContain('(override, stale)');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+pnpm vitest run tests/commands/config.test.ts
+```
+
+Expected: "Cannot find module '../../src/commands/config.js'"
+
+- [ ] **Step 3: Implement `src/commands/config.ts`**
+
+Create `src/commands/config.ts`:
+
+```typescript
+import {
+  loadUserConfig,
+  saveUserConfig,
+  parseConfigKey,
+  getEffectivePreset,
+  setOverride,
+  clearOverride,
+  UserConfigParseError,
+  UserConfigKeyError,
+  type UserConfig,
+} from '../userConfig.js';
+import { MODEL_PRESETS, REQUIRED_PHASE_KEYS } from '../config.js';
+
+export interface ConfigCommandOptions {
+  homeDir?: string;
+}
+
+const SUPPORTED_PRESET_IDS = new Set(MODEL_PRESETS.map(p => p.id));
+
+function loadOrExit(homeDir?: string): UserConfig {
+  try {
+    return loadUserConfig(homeDir);
+  } catch (err) {
+    if (err instanceof UserConfigParseError) {
+      process.stderr.write(err.message + '\n');
+      process.exit(1);
+    }
+    throw err;
+  }
+}
+
+function parseKeyOrExit(key: string): { phase: string } {
+  try {
+    return parseConfigKey(key);
+  } catch (err) {
+    if (err instanceof UserConfigKeyError) {
+      process.stderr.write(err.message + '\n');
+      process.exit(1);
+    }
+    throw err;
+  }
+}
+
+function padRight(s: string, len: number): string {
+  return s + ' '.repeat(Math.max(0, len - s.length));
+}
+
+export function configListCommand(opts: ConfigCommandOptions = {}): void {
+  const config = loadOrExit(opts.homeDir);
+  const rows: Array<{ key: string; value: string; source: string }> = [];
+  for (const phase of REQUIRED_PHASE_KEYS) {
+    const override = config.phase?.[phase]?.preset;
+    let value: string;
+    let source: string;
+    if (override !== undefined) {
+      const stale = !SUPPORTED_PRESET_IDS.has(override);
+      value = stale ? `${override} (stale)` : override;
+      source = stale ? 'override (stale)' : 'override';
+    } else {
+      value = getEffectivePreset(config, phase).value;
+      source = 'default';
+    }
+    rows.push({ key: `phase.${phase}.preset`, value, source });
+  }
+  const header = { key: 'key', value: 'value', source: 'source' };
+  const colKey = Math.max(header.key.length, ...rows.map(r => r.key.length));
+  const colVal = Math.max(header.value.length, ...rows.map(r => r.value.length));
+  const colSrc = Math.max(header.source.length, ...rows.map(r => r.source.length));
+  const line = (r: { key: string; value: string; source: string }) =>
+    `${padRight(r.key, colKey)}  ${padRight(r.value, colVal)}  ${r.source}\n`;
+  process.stdout.write(line(header));
+  process.stdout.write(`${'-'.repeat(colKey)}  ${'-'.repeat(colVal)}  ${'-'.repeat(colSrc)}\n`);
+  for (const row of rows) process.stdout.write(line(row));
+}
+
+export function configGetCommand(key: string, opts: ConfigCommandOptions = {}): void {
+  const { phase } = parseKeyOrExit(key);
+  const config = loadOrExit(opts.homeDir);
+  const override = config.phase?.[phase]?.preset;
+  if (override !== undefined) {
+    const stale = !SUPPORTED_PRESET_IDS.has(override);
+    process.stdout.write(stale ? `${override} (override, stale)\n` : `${override}\n`);
+  } else {
+    process.stdout.write(`${getEffectivePreset(config, phase).value} (default)\n`);
+  }
+}
+
+export function configSetCommand(key: string, value: string, opts: ConfigCommandOptions = {}): void {
+  parseKeyOrExit(key);
+  if (!SUPPORTED_PRESET_IDS.has(value)) {
+    process.stderr.write(
+      `Error: unknown preset id '${value}'. Run 'phase-harness config list' or see src/config.ts MODEL_PRESETS for valid ids.\n`,
+    );
+    process.exit(1);
+  }
+  const config = loadOrExit(opts.homeDir);
+  saveUserConfig(setOverride(config, key, value), opts.homeDir);
+  process.stdout.write(`${key} = ${value}\n`);
+}
+
+export function configResetCommand(key: string, opts: ConfigCommandOptions = {}): void {
+  const { phase } = parseKeyOrExit(key);
+  const config = loadOrExit(opts.homeDir);
+  if (!config.phase?.[phase]?.preset) {
+    process.stdout.write(`${key} already at default (no override to reset)\n`);
+    return;
+  }
+  saveUserConfig(clearOverride(config, key), opts.homeDir);
+  process.stdout.write(`reset ${key}\n`);
+}
+```
+
+- [ ] **Step 4: Register `config` command in `bin/harness.ts`**
+
+Add the import after the existing imports (before `const program = new Command();`):
+
+```typescript
+import {
+  configListCommand,
+  configGetCommand,
+  configSetCommand,
+  configResetCommand,
+} from '../src/commands/config.js';
+```
+
+Add the command block before `program.parseAsync(process.argv)`:
+
+```typescript
+const configCmd = program
+  .command('config')
+  .description('manage per-phase preset overrides in ~/.harness/config.json');
+
+configCmd
+  .command('list')
+  .description('list all phase preset keys with their current value and source')
+  .action(() => { configListCommand(); });
+
+configCmd
+  .command('get <key>')
+  .description('get the effective value for a config key (e.g. phase.1.preset)')
+  .action((key: string) => { configGetCommand(key); });
+
+configCmd
+  .command('set <key> <value>')
+  .description('set a config key to a preset id (e.g. phase.1.preset opus-1m-max)')
+  .action((key: string, value: string) => { configSetCommand(key, value); });
+
+configCmd
+  .command('reset <key>')
+  .description('remove the override for a config key, reverting to the built-in default')
+  .action((key: string) => { configResetCommand(key); });
+```
+
+- [ ] **Step 5: Run tests and typecheck**
+
+```bash
+pnpm vitest run tests/commands/config.test.ts tests/userConfig.test.ts tests/userConfigStartOverlay.test.ts
+pnpm tsc --noEmit
+```
+
+Expected: all pass, no type errors.
+
+- [ ] **Step 6: Smoke-test the registered command**
+
+```bash
+pnpm build
+node dist/bin/harness.js config list --help
+node dist/bin/harness.js config --help
+```
+
+Expected: `list`, `get`, `set`, `reset` subcommands appear in help output.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/commands/config.ts bin/harness.ts tests/commands/config.test.ts
+git commit -m "feat(config): add config subcommand (list/get/set/reset) and bin registration"
+```
+
+---
+
+### Task 3: `start.ts` overlay + doc updates
+
+**Files:**
+- Modify: `src/commands/start.ts`
+- Modify: `README.md`
+- Modify: `README.ko.md`
+- Modify: `docs/HOW-IT-WORKS.md`
+- Modify: `docs/HOW-IT-WORKS.ko.md`
+
+- [ ] **Step 1: Add `applyUserConfigOverrides` call to `start.ts`**
+
+At the top of `start.ts`, add the import alongside existing imports:
+
+```typescript
+import { applyUserConfigOverrides, UserConfigParseError } from '../userConfig.js';
+```
+
+In `startCommand`, after `state.dirtyBaseline = captureDirtyBaseline(trackedRepos[0].path);` (around line 256) and before `// 13. Save task.md`, insert:
+
+```typescript
+    // Apply user config overrides (from ~/.harness/config.json) before first writeState.
+    try {
+      applyUserConfigOverrides(state);
+    } catch (err) {
+      if (err instanceof UserConfigParseError) {
+        process.stderr.write(`Error: ${err.message}\n`);
+        process.exit(1);
+      }
+      throw err;
+    }
+```
+
+- [ ] **Step 2: Run existing start tests to confirm no regression**
+
+```bash
+pnpm vitest run tests/commands/start.test.ts tests/state.test.ts
+```
+
+Expected: all pass (NFR-3 — no `~/.harness/config.json` means no-op).
+
+- [ ] **Step 3: Add `config` section to `README.md`**
+
+Find the `### \`phase-harness resume [runId]\`` heading in README.md. Insert the following block immediately before it:
+
+```markdown
+### `phase-harness config`
+
+Manage per-phase preset overrides saved in `~/.harness/config.json`. Overrides apply to fresh `start`/`run` calls only; existing runs are unaffected.
+
+```bash
+phase-harness config list                           # show all phase keys with value and source
+phase-harness config get phase.1.preset             # effective value (override or default)
+phase-harness config set phase.1.preset opus-1m-max # persist override
+phase-harness config reset phase.1.preset           # remove override, revert to built-in default
+```
+
+Resolution precedence on `start`/`run`: (1) saved config override, (2) built-in `PHASE_DEFAULTS`.
+
+`resume` always uses the presets frozen in `state.json` at run-creation time — saved config is never re-applied on resume.
+
+```
+
+- [ ] **Step 4: Add `config` section to `README.ko.md`**
+
+Find `### \`phase-harness resume [runId]\`` in README.ko.md. Insert immediately before it:
+
+```markdown
+### `phase-harness config`
+
+`~/.harness/config.json`에 저장되는 페이즈별 프리셋 오버라이드를 관리합니다. 오버라이드는 새 `start`/`run` 실행 시에만 적용되며, 기존 실행에는 영향을 주지 않습니다.
+
+```bash
+phase-harness config list                           # 전체 페이즈 키와 현재 값·출처 표시
+phase-harness config get phase.1.preset             # 유효 값 확인 (오버라이드 또는 기본값)
+phase-harness config set phase.1.preset opus-1m-max # 오버라이드 저장
+phase-harness config reset phase.1.preset           # 오버라이드 제거, 내장 기본값으로 복원
+```
+
+`start`/`run` 시 해결 우선순위: (1) 저장된 config 오버라이드, (2) 내장 `PHASE_DEFAULTS`.
+
+`resume`은 항상 실행 생성 시 `state.json`에 고정된 프리셋을 사용합니다. 저장된 config는 resume 시 재적용되지 않습니다.
+
+```
+
+- [ ] **Step 5: Update `docs/HOW-IT-WORKS.md` "Built-in presets and defaults" section**
+
+After the last sentence in the "Built-in presets and defaults" section (`Existing saved runs are not auto-migrated...`), add:
+
+```markdown
+
+### User config overrides
+
+Users can persist per-phase preset overrides in `~/.harness/config.json` via `phase-harness config set`. On every fresh `phase-harness start` / `phase-harness run`, the harness reads this file and overlays any saved overrides onto the built-in `PHASE_DEFAULTS` before writing `state.json`. If a saved preset id is no longer in the catalog (stale), a stderr warning is emitted and the built-in default is used instead.
+
+`phase-harness resume` never reads `~/.harness/config.json`; the presets in `state.json` are authoritative for existing runs.
+
+If `~/.harness/config.json` contains invalid JSON, every `config` subcommand and any new `start`/`run` exits non-zero immediately.
+```
+
+- [ ] **Step 6: Update `docs/HOW-IT-WORKS.ko.md` "Built-in presets and defaults" section**
+
+Find the equivalent Korean section header in HOW-IT-WORKS.ko.md and append after the last sentence of that section:
+
+```markdown
+
+### 사용자 config 오버라이드
+
+`phase-harness config set`으로 `~/.harness/config.json`에 페이즈별 프리셋 오버라이드를 저장할 수 있습니다. 새 `phase-harness start` / `phase-harness run` 실행 시, 하네스가 이 파일을 읽어 내장 `PHASE_DEFAULTS` 위에 오버라이드를 덮어쓴 후 `state.json`을 기록합니다. 저장된 프리셋 id가 카탈로그에 더 이상 없으면(stale) stderr 경고를 출력하고 내장 기본값을 사용합니다.
+
+`phase-harness resume`은 `~/.harness/config.json`을 읽지 않습니다. 기존 실행의 프리셋은 `state.json`이 기준입니다.
+
+`~/.harness/config.json`이 유효하지 않은 JSON이면, 모든 `config` 서브커맨드와 새 `start`/`run`은 즉시 non-zero로 종료됩니다.
+```
+
+- [ ] **Step 7: Run full test suite and typecheck**
+
+```bash
+pnpm vitest run
+pnpm tsc --noEmit
+```
+
+Expected: all tests pass (including existing tests — NFR-3 regression check), no type errors.
+
+- [ ] **Step 8: Build and smoke-test**
+
+```bash
+pnpm build
+node dist/bin/harness.js config list
+```
+
+Expected: 6-row table covering phases 1, 2, 3, 4, 5, 7 with all rows showing `default` source.
+
+- [ ] **Step 9: Verify INV-8 doc grep**
+
+```bash
+grep -l "phase-harness config" README.md README.ko.md docs/HOW-IT-WORKS.md docs/HOW-IT-WORKS.ko.md
+```
+
+Expected: all four filenames printed.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/commands/start.ts README.md README.ko.md docs/HOW-IT-WORKS.md docs/HOW-IT-WORKS.ko.md
+git commit -m "feat(config): wire applyUserConfigOverrides into start.ts and update docs"
+```

--- a/docs/process/evals/2026-05-12-phase-harness-cli-config-b565-eval.md
+++ b/docs/process/evals/2026-05-12-phase-harness-cli-config-b565-eval.md
@@ -1,0 +1,270 @@
+# Auto Verification Report
+- Date: 2026-05-12
+- Related Spec: N/A
+- Related Plan: N/A
+
+## Results
+| Check | Status | Detail |
+|-------|--------|--------|
+| typecheck | pass |  |
+| test | pass |  |
+| build | pass |  |
+| smoke-config-list | pass |  |
+
+## Summary
+- Total: 4 checks
+- Pass: 4
+- Fail: 0
+
+## Raw Output
+
+### typecheck
+**Command:** `pnpm tsc --noEmit`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>
+
+### test
+**Command:** `pnpm vitest run`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+ RUN  v2.1.9 /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/config-cmd
+
+ ✓ tests/logger.test.ts (32 tests) 39ms
+ ✓ tests/state.test.ts (58 tests) 46ms
+ ✓ tests/context/skills-rendering.test.ts (45 tests) 53ms
+ ✓ tests/phases/gate.test.ts (38 tests) 134ms
+ ✓ tests/phases/retrospective.test.ts (16 tests) 47ms
+ ✓ tests/phases/runner-claude-resume.test.ts (13 tests) 35ms
+ ✓ tests/signal.test.ts (17 tests) 443ms
+ ✓ tests/phases/runner.test.ts (86 tests) 370ms
+ ✓ tests/phases/gate-resume.test.ts (12 tests) 130ms
+ ✓ tests/runners/claude-usage.test.ts (17 tests) 85ms
+ ✓ tests/commands/inner.test.ts (25 tests) 253ms
+ ✓ tests/integration/logging.test.ts (15 tests) 268ms
+ ✓ tests/phases/terminal-ui.test.ts (18 tests) 106ms
+ ✓ tests/lock.test.ts (20 tests) 162ms
+ ✓ tests/phases/stagnation.test.ts (32 tests) 8ms
+ ✓ tests/commands/footer-ticker.test.ts (10 tests) 25ms
+ ✓ tests/phases/verify.test.ts (15 tests) 18ms
+ ✓ tests/phases/drift.test.ts (36 tests) 10ms
+ ✓ tests/phases/runner-token-capture.test.ts (8 tests) 8ms
+ ✓ tests/metrics/footer-aggregator.test.ts (11 tests) 6ms
+ ✓ tests/integration/codex-session-resume.test.ts (6 tests) 88ms
+ ✓ tests/orphan-cleanup.test.ts (20 tests) 28ms
+ ✓ tests/phases/ambiguity.test.ts (19 tests) 5ms
+ ✓ tests/preflight.test.ts (27 tests | 1 skipped) 177ms
+ ✓ tests/runners/codex.test.ts (21 tests) 1592ms
+   ✓ spawnCodexInteractiveInPane — pane injection > sends a top-level `codex` TUI command (not `codex exec`) with prompt arg, sandbox, CODEX_HOME 310ms
+   ✓ spawnCodexInteractiveInPane — pane injection > uses --dangerously-bypass-approvals-and-sandbox for phase 5 309ms
+   ✓ spawnCodexInPane — fresh > sends fresh top-level `codex` TUI command with prompt as cat-substitution arg 303ms
+   ✓ spawnCodexInPane — fresh in non-git cwd > does NOT add --skip-git-repo-check even when cwd is non-git (trust-entry handles it) 303ms
+   ✓ spawnCodexInPane — resume > sends top-level `codex resume <sessionId>` TUI command with prompt arg 304ms
+ ✓ tests/context/assembler.test.ts (83 tests) 1542ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=1 trackedRepos[0].path===cwd → raw diff without ### repo: label 382ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N=2 → diff sections with ### repo: label for each repo 537ms
+   ✓ buildPhase7DiffAndMetadata — multi-repo (FR-5, ADR-N7, ADR-D1) > N>1 metadata uses "Harness implementation ranges (per tracked repo):" block 477ms
+ ✓ tests/integration/light-flow.test.ts (4 tests) 224ms
+ ✓ tests/resume-light.test.ts (10 tests) 63ms
+ ✓ tests/phases/verdict.test.ts (31 tests) 6ms
+ ✓ tests/commands/inner-footer.test.ts (2 tests) 11ms
+ ✓ tests/runners/codex-resume.test.ts (8 tests) 58ms
+ ✓ tests/tmux.test.ts (34 tests) 813ms
+   ✓ pollForPidFile > returns null on timeout when file never appears 404ms
+   ✓ pollForPidFile > returns null when file contains non-numeric content 404ms
+ ✓ tests/context/assembler-resume.test.ts (10 tests) 69ms
+ ✓ tests/runners/codex-isolation.test.ts (10 tests) 47ms
+reset phase.1.preset
+ ✓ tests/commands/config.test.ts (16 tests) 37ms
+ ✓ tests/integration/gate-stagnation.test.ts (2 tests) 15ms
+ ✓ tests/phases/interactive-watchdog.test.ts (6 tests) 7ms
+ ✓ tests/commands/resume-cmd.test.ts (13 tests) 2044ms
+ ✓ tests/phases/gate-feedback-archival.test.ts (2 tests) 67ms
+ ✓ tests/state-invalidation.test.ts (5 tests) 33ms
+ ✓ tests/runners/claude.test.ts (4 tests) 5ms
+ ✓ tests/phases/gate-resume-escalation.test.ts (2 tests) 35ms
+ ✓ tests/resume.test.ts (11 tests) 2501ms
+ ✓ tests/runners/codex-usage.test.ts (6 tests) 314ms
+   ✓ readCodexSessionUsage — pinned sessionId > returns null when file missing 305ms
+ ✓ tests/root.test.ts (10 tests) 187ms
+ ✓ tests/commands/status-list.test.ts (7 tests) 600ms
+ ✓ tests/context/reviewer-contract.test.ts (4 tests) 52ms
+ ✓ tests/git.test.ts (24 tests) 2324ms
+ ✓ tests/ink/components/CurrentPhase.test.tsx (10 tests) 37ms
+ ✓ tests/commands/jump.test.ts (6 tests) 740ms
+ ✓ tests/ui-footer.test.ts (9 tests) 3ms
+ ✓ tests/input.test.ts (12 tests) 5ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-RfmWy2/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-r7qcgZ/.claude/skills:
+  phase-harness-codex-gate-review
+ ✓ tests/multi-worktree.test.ts (11 tests) 2588ms
+   ✓ (a) depth=1 auto-detect — non-git outer cwd > detects exactly depth=1 git repos, skips non-git dirs 486ms
+   ✓ (b) --track / --exclude flag combinations > --track replaces auto-detect 481ms
+   ✓ (b) --track / --exclude flag combinations > --exclude removes from auto-detect 411ms
+   ✓ (c) assembler diff concat for N=2 repos > includes ### repo: label for each repo in N=2 case 406ms
+   ✓ (d) Phase 5 success: one-of-N advanced > returns true when only repo-a advanced in a 2-repo setup 566ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-JwcxsV/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-kwHAd1/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-vJvc2k/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/install-skills-test-vJvc2k/.claude/skills:
+  phase-harness-codex-gate-review
+ ✓ tests/install-skills.test.ts (7 tests) 17ms
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-Wedmip/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-Wedmip/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-Yjt3B5/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-Yjt3B5/.claude/skills:
+  phase-harness-codex-gate-review
+Installed 1 skill(s) to /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-uOoMxN/.claude/skills:
+  phase-harness-codex-gate-review
+Uninstalled 1 skill(s) from /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-uOoMxN/.claude/skills:
+  phase-harness-codex-gate-review
+No skills directory found at /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/uninstall-skills-test-eX4eeD/.claude/skills. Nothing to uninstall.
+ ✓ tests/uninstall-skills.test.ts (6 tests) 108ms
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
+⚠️  carryover feedback path not found on disk, skipping: /var/folders/vx/1ln4rqh969s1ynxythgw3y8m0000gn/T/sk-TeT6Xb/phase-5-carryover-missing.md
+⚠️  Complexity signal missing or invalid in spec; defaulting to Medium.
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: jsonl missing
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: no prior attempt id
+⚠️  claude session resume fallback: jsonl missing
+[ambiguity] ## Clarity Scores section missing or malformed — fail-open, verdict unchanged
+ℹ Received control signal (SIGUSR1). Applying pending action...
+✓ Applied: skip. Phase loop re-entering.
+ℹ Received control signal (SIGUSR1). Applying pending action...
+✓ Applied: jump → phase 3. Phase loop re-entering.
+ℹ Received control signal (SIGUSR1). Applying pending action...
+✓ Applied: skip. Phase loop re-entering.
+ℹ Received control signal (SIGUSR1). Applying pending action...
+[harness] cleanup: killing dedicated session test-sess
+[harness] cleanup: killing dedicated session test-sess
+fatal: not a git repository (or any of the parent directories): .git
+[harness] phase=5 status=failed
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+[harness] phase=5 status=failed
+
+Recent events:
+(events.jsonl not present — logging disabled)
+
+Working tree:
+(git not available)
+
+[R] Resume   [J] Jump to phase   [Q] Quit
+[harness] phase=5 status=completed
+
+Recent events:
+(events.jsonl not present — logging disabled)
+```
+
+</details>
+
+### build
+**Command:** `pnpm build`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+
+> phase-harness@1.1.0 build /Users/daniel/.grove/github.com/DongGukMon/harness-cli/worktrees/config-cmd
+> tsc -p tsconfig.build.json && node scripts/copy-assets.mjs
+
+[copy-assets] copied src/context/prompts -> dist/src/context/prompts
+[copy-assets] copied src/context/skills -> dist/src/context/skills
+[copy-assets] copied src/context/skills-standalone -> dist/src/context/skills-standalone
+[copy-assets] copied src/context/playbooks -> dist/src/context/playbooks
+[copy-assets] copied scripts/harness-verify.sh -> dist/scripts/harness-verify.sh
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>
+
+### smoke-config-list
+**Command:** `node dist/bin/harness.js config list`
+**Exit code:** 0
+
+<details>
+<summary>stdout (truncated to 100 lines)</summary>
+
+```
+key             value          source
+--------------  -------------  -------
+phase.1.preset  opus-1m-xhigh  default
+phase.2.preset  codex-high     default
+phase.3.preset  sonnet-high    default
+phase.4.preset  codex-high     default
+phase.5.preset  sonnet-high    default
+phase.7.preset  codex-high     default
+```
+
+</details>
+
+<details>
+<summary>stderr (truncated to 50 lines)</summary>
+
+```
+
+```
+
+</details>

--- a/docs/specs/2026-05-12-phase-harness-cli-config-b565-design.md
+++ b/docs/specs/2026-05-12-phase-harness-cli-config-b565-design.md
@@ -1,0 +1,269 @@
+# phase-harness `config` subcommand — design
+
+- Related plan: `docs/plans/2026-05-12-phase-harness-cli-config-b565.md` (to be written in Phase 3)
+- Related decision log: `.harness/2026-05-12-phase-harness-cli-config-b565/decisions.md`
+- Run id: `2026-05-12-phase-harness-cli-config-b565`
+
+## Context & Decisions
+
+### Why this exists
+`phase-harness` today picks a model for each phase from one of two sources:
+1. The user opens the model-config dialog every run and overrides (`promptModelConfig` in `src/ui.ts`).
+2. Otherwise the run inherits the built-in `PHASE_DEFAULTS` table in `src/config.ts`.
+
+There is no per-user persistent override. Users who consistently prefer e.g. `opus-1m-max` for Phase 1 have to re-pick it on every fresh run. This spec adds a `phase-harness config` subcommand that persists per-phase preset overrides in `~/.harness/config.json` and surfaces them as the dialog's default on new runs.
+
+### Scope
+- New CLI surface: `phase-harness config list|get|set|reset`.
+- New storage: `~/.harness/config.json`, written atomically.
+- Single supported key family in v1: `phase.<N>.preset` for `N ∈ {1, 2, 3, 4, 5, 7}`. Phase 6 is the verify script (no model) and is hard-rejected.
+- Saved overrides influence **fresh `start`/`run` only**. `resume` re-uses the existing `state.json` `phasePresets` untouched, because those values already reflect user choices made when that run was first launched.
+
+### Non-goals
+- No `config edit` / `$EDITOR` open. Out of v1.
+- No `config reset --all` / bulk operations. Out of v1.
+- No project-local config (`.harness/config.json`). Always user-global (`~/.harness/config.json`).
+- No new CLI flags for per-phase model selection at `start` time. Resolution precedence at start remains: (1) saved config, (2) built-in default. There is no (0) CLI flag in v1.
+- No migration of the existing in-flight runs (their `state.json` already has frozen `phasePresets`).
+- No changes to `migrateState()`'s legacy-preset fallback path. That migration is for **state.json** drift, not user config.
+
+### Key decisions (live-resolved during brainstorm)
+- **Resume scope**: saved config applies only at `start`. `resume` does **not** overlay saved config onto the existing `state.json`. Rationale: a `state.json` was already frozen at start with the user's intent; silently mutating it on resume is surprising.
+- **`config get` of an unset key**: prints the effective built-in default with a `(default)` annotation, e.g. `opus-1m-xhigh (default)`, exit 0. Rationale: makes "what model would this phase actually use?" answerable in one command; the annotation prevents shell scripts from confusing default and override.
+- **`config list` output**: 3-column table — `key`, `value`, `source` where `source ∈ {default, override}`. Rationale: surfaces every relevant key whether or not it has an override, which is what users want when sanity-checking before a run.
+- **Invalid JSON in `~/.harness/config.json`**: error and exit non-zero on **every** read path (`config list/get/set/reset` and `start`/`run`). Rationale: silent fail-open hides the user's intent and silently regresses to built-in defaults. A loud error tells the user exactly what to fix.
+- **Storage shape**: nested JSON (`{ "phase": { "1": { "preset": "..." } } }`) rather than flat dotted keys (`{ "phase.1.preset": "..." }`). Rationale: cleaner TypeScript types, room for future namespaces (e.g. `runner.*`, `gate.*`) without restructuring.
+- **No new dependency**: parsing/printing the table is hand-rolled with column padding; no `cli-table` package is added.
+
+## Complexity
+
+Small — three new files (~250 LoC total), one ~10-line touch in `start.ts`, one ~10-line registration block in `bin/harness.ts`, and doc syncs. No cross-module refactor.
+
+## Requirements
+
+### Functional
+
+**FR-1 — `config list`**: print a 3-column human-readable table to stdout listing every supported phase key (`phase.<N>.preset` for `N ∈ {1, 2, 3, 4, 5, 7}`). Columns: `key`, `value`, `source` (`default` or `override`). One row per supported phase. Exit 0.
+
+**FR-2 — `config get <key>`**: print the effective value for `<key>` to stdout. If `<key>` is set in `~/.harness/config.json`, print the override value with no annotation. If unset, print the built-in default followed by ` (default)`. Exit 0 on success.
+
+**FR-3 — `config set <key> <value>`**: validate `<key>` against the supported key set and `<value>` against the `MODEL_PRESETS` catalog from `src/config.ts`. On success, atomically update `~/.harness/config.json` and print a confirmation to stdout. Exit 0 on success.
+
+**FR-4 — `config reset <key>`**: remove the override for `<key>` from `~/.harness/config.json`. If `<key>` had no override (idempotent case), print a `(no override to reset)` notice and exit 0 — not an error. Atomic write. Exit 0 on success.
+
+**FR-5 — Saved config drives start defaults**: when `phase-harness start` / `phase-harness run` builds the initial `state.json`, any override in `~/.harness/config.json` replaces the corresponding built-in `PHASE_DEFAULTS` entry **before** `state.json` is written. The downstream model-config dialog (`promptModelConfig` in `inner.ts`) then sees the override as the "current" value with no code change required in the dialog itself.
+
+**FR-6 — `~/.harness/config.json` absence is fine**: when the file does not exist, every config subcommand and `start`/`run` behaves as if no overrides were set. No file is created lazily; `set` is the only command that creates it.
+
+**FR-7 — Resume is unaffected**: `phase-harness resume <runId>` does not consult `~/.harness/config.json`. The existing `state.json` `phasePresets` is the source of truth.
+
+### Non-functional
+
+**NFR-1 — No new runtime dependencies**: no new `package.json` entries. Stdlib `fs`, `path`, `os` and existing helpers only.
+
+**NFR-2 — Atomic writes**: `config set` / `config reset` write via a `config.json.tmp` + `fsync` + `rename` sequence (same pattern as `writeState` in `src/state.ts`).
+
+**NFR-3 — Backward compatibility**: in the absence of `~/.harness/config.json`, every observable behavior of `start`, `run`, `resume`, the model-config dialog, and `state.json` migration is byte-identical to today.
+
+**NFR-4 — Testability**: `userConfig.ts` accepts an optional `homeDir` override so tests can target a tmp directory without touching the real `~/.harness/`. Same pattern as `src/runners/claude-usage.ts` and `src/commands/install-skills.ts`.
+
+## Architecture
+
+### New modules
+
+`src/userConfig.ts` — pure I/O + validation:
+- `UserConfig` type: `{ phase?: Record<string, { preset?: string }> }`.
+- `getUserConfigPath(homeDir?)`: returns the resolved path.
+- `loadUserConfig(homeDir?)`: returns `UserConfig`. Returns `{}` when the file is missing. Throws a typed `UserConfigParseError` when the file exists but JSON parsing fails.
+- `saveUserConfig(config, homeDir?)`: atomic write via tmp+fsync+rename; creates `~/.harness/` if missing.
+- `parseConfigKey(key)`: returns `{ phase: string }` for a valid `phase.<N>.preset` (with `N ∈ {1,2,3,4,5,7}`) or throws a typed `UserConfigKeyError` with a message naming the invalid component. Specifically rejects `phase.6.preset` with a tailored error message.
+- `getOverride(config, key)` / `setOverride(config, key, value)` / `clearOverride(config, key)`: small pure helpers used by the command handlers and the start-time overlay.
+- `getEffectivePreset(config, phase)`: returns `{ value: string, source: 'default' | 'override' }` resolved against `PHASE_DEFAULTS` from `src/config.ts`.
+
+`src/commands/config.ts` — CLI handlers, one per subcommand:
+- `configListCommand(opts)`, `configGetCommand(key, opts)`, `configSetCommand(key, value, opts)`, `configResetCommand(key, opts)`.
+- Each handler calls into `userConfig.ts`, formats output, and returns/exits.
+- All four share a top-of-function `try { loadUserConfig() } catch (UserConfigParseError) → print error to stderr + exit 1` block — the loud-failure policy.
+
+`bin/harness.ts` — adds a `config` parent command with four sub-actions, wired through `commander`'s nested-command API.
+
+### Touch points in existing code
+
+`src/commands/start.ts` — after `createInitialState(...)` returns and before the first `writeState(...)`, call a new `applyUserConfigOverrides(state)` helper (lives in `userConfig.ts`):
+- Reads `loadUserConfig()`. If it throws `UserConfigParseError`, print the error to stderr and `process.exit(1)` before any directory side effects past the lock. Lock is released by the existing `finally` block.
+- For each `phase ∈ REQUIRED_PHASE_KEYS`, look up the override. If the override's preset id is still in `MODEL_PRESETS`, overwrite `state.phasePresets[phase]`. If the override's preset id is stale (preset has since been removed from the catalog), emit a stderr warning naming the phase + the stale id and keep the built-in default.
+
+`src/state.ts` — unchanged. `createInitialState` continues to seed from `PHASE_DEFAULTS`. The overlay is applied by `start.ts` afterward so `state.ts` stays pure and free of `os.homedir()` I/O.
+
+`src/commands/inner.ts` — unchanged. `promptModelConfig` already reads `state.phasePresets` as the dialog's "current" value, so overrides surface automatically.
+
+`src/commands/resume.ts` — unchanged. No overlay on resume per FR-7.
+
+### Storage shape
+
+`~/.harness/config.json`:
+
+```json
+{
+  "phase": {
+    "1": { "preset": "opus-1m-max" },
+    "2": { "preset": "codex-medium" }
+  }
+}
+```
+
+Empty file (no overrides) is represented by either the file's absence or `{ "phase": {} }` / `{}`. All three are equivalent.
+
+### Validation rules
+
+| Rule | Behavior |
+|---|---|
+| Unknown subcommand | commander handles (`Unknown command`, exit 1). |
+| `config get|set|reset` missing `<key>` | commander handles (`missing required argument`, exit 1). |
+| Unsupported key family (anything not matching `phase.<N>.preset`) | Print `Error: unknown config key '<raw>'. Supported keys: phase.<1|2|3|4|5|7>.preset` to stderr, exit 1. |
+| `phase.6.preset` | Print `Error: phase 6 is the verify script (no model); cannot configure. Supported phases: 1, 2, 3, 4, 5, 7.` to stderr, exit 1. |
+| Numeric phase outside `{1,2,3,4,5,7}` (`phase.0.preset`, `phase.8.preset`, ...) | Print `Error: unknown phase '<N>'. Supported phases: 1, 2, 3, 4, 5, 7.` to stderr, exit 1. |
+| `set` with an unknown preset id | Print `Error: unknown preset id '<value>'. Run 'phase-harness config list' or see src/config.ts MODEL_PRESETS for valid ids.` to stderr, exit 1. Do NOT modify config.json. |
+| `~/.harness/config.json` exists but is not valid JSON | Print `Error: ~/.harness/config.json is not valid JSON: <parse-error>. Edit or delete the file to recover.` to stderr, exit 1. |
+| Stale override (preset id in config.json was valid at write time but later removed from `MODEL_PRESETS`) | At start time: stderr warn (`Saved config phase.<N>.preset='<id>' is no longer a known preset; using built-in default '<default>'.`), keep built-in default. At `config list` time: print row with `value` column showing `<id> (stale)` and `source` column showing `override (stale)`. At `config get` time: print `<id> (override, stale)`. At `config set` time: not applicable (set always validates). At `config reset` time: removes the stale entry normally. |
+
+### `config list` output format
+
+```
+key                value                  source
+---                -----                  ------
+phase.1.preset     opus-1m-max            override
+phase.2.preset     codex-high             default
+phase.3.preset     sonnet-high            default
+phase.4.preset     codex-high             default
+phase.5.preset     sonnet-high            default
+phase.7.preset     codex-high             default
+```
+
+Columns are padded to the longest cell. A simple ASCII header underline separates the header row from data. Output goes to stdout.
+
+### `config get` output format
+
+Override present:
+```
+opus-1m-max
+```
+
+Unset:
+```
+opus-1m-xhigh (default)
+```
+
+Stale override:
+```
+opus-1m-max (override, stale)
+```
+
+### `config set` output format
+
+```
+phase.1.preset = opus-1m-max
+```
+
+### `config reset` output format
+
+Override removed:
+```
+reset phase.1.preset
+```
+
+No-op (idempotent):
+```
+phase.1.preset already at default (no override to reset)
+```
+
+## Error handling
+
+- Every command path that opens `~/.harness/config.json` re-throws `UserConfigParseError` after a single read. Handlers catch it once at the top and translate to stderr + `process.exit(1)`.
+- `saveUserConfig` is responsible for ensuring `~/.harness/` exists (`mkdirSync(..., { recursive: true })`) before writing.
+- Validation errors are printed once to stderr in a single line beginning with `Error:`, matching the style used elsewhere in the CLI.
+- `process.exit(1)` is reserved for user-fixable errors. Internal I/O failures (e.g. EACCES on `~/.harness/`) surface the system errno verbatim and also exit 1.
+
+## Testing
+
+### Unit tests
+
+`tests/userConfig.test.ts` (new):
+- `loadUserConfig` returns `{}` when file absent.
+- `loadUserConfig` parses valid JSON.
+- `loadUserConfig` throws `UserConfigParseError` on malformed JSON.
+- `saveUserConfig` writes atomically (tmp file present mid-write, real file appears after rename — verified by listing dir after write).
+- `saveUserConfig` creates `~/.harness/` when missing.
+- `parseConfigKey('phase.1.preset')` → `{ phase: '1' }`.
+- `parseConfigKey('phase.6.preset')` throws a `UserConfigKeyError` whose message names phase 6 + the supported set.
+- `parseConfigKey('phase.0.preset')`, `'phase.8.preset'`, `'phase.foo.preset'`, `'phase.1.model'`, `'random.thing'`, `''` → all throw with a recognizable message.
+- `getEffectivePreset(config, '1')` returns `{ value: PHASE_DEFAULTS[1], source: 'default' }` when no override, and `{ value: '<override>', source: 'override' }` when present.
+
+`tests/commands/config.test.ts` (new):
+- `config list`: with no override, every row shows `default`. With an override, that row shows `override` and the overridden value; others stay `default`.
+- `config get phase.1.preset`: prints override value bare when present, default + ` (default)` when absent.
+- `config get phase.6.preset`: stderr error + exit 1; does not read or print phase 6 default.
+- `config set phase.1.preset opus-1m-max`: writes config.json; subsequent `loadUserConfig` reflects the change; output matches the spec format.
+- `config set phase.1.preset bogus-id`: stderr error + exit 1; config.json is unchanged on disk.
+- `config set phase.6.preset opus-1m-max`: stderr error + exit 1; config.json unchanged.
+- `config reset phase.1.preset` after a set: override removed; second `reset` of the same key prints the idempotent no-op message and exits 0.
+- All four subcommands: when `~/.harness/config.json` is malformed JSON, stderr error + exit 1.
+- Stale override case: `config list` and `config get` annotate `(stale)` when the preset id is no longer in `MODEL_PRESETS`. (Simulate by hand-writing config.json with a fake id, then reading.)
+
+`tests/userConfigStartOverlay.test.ts` (new):
+- Given a config.json with `phase.1.preset = opus-1m-max`, calling `applyUserConfigOverrides(state)` mutates `state.phasePresets['1']` to `opus-1m-max` and leaves other phases at `PHASE_DEFAULTS`.
+- Given a stale-id override, `applyUserConfigOverrides(state)` emits the expected stderr warning and leaves the built-in default in place.
+- Given no config.json, `applyUserConfigOverrides(state)` is a no-op (state.phasePresets unchanged, no stderr output).
+- Given a malformed config.json, `applyUserConfigOverrides(state)` throws `UserConfigParseError`. (start.ts handles the throw.)
+
+### Regression checks
+
+- Existing tests under `tests/state.test.ts`, `tests/promptModelConfig*.test.ts`, `tests/commands/start*.test.ts` keep passing unchanged. New behavior must be invisible when `~/.harness/config.json` is absent (NFR-3).
+- `pnpm tsc --noEmit` must pass with the new types.
+- `pnpm build` must produce a usable `dist/bin/harness.js` that registers the `config` parent command (smoke-checked via `node dist/bin/harness.js config list --help`).
+
+## Success Criteria
+
+A reviewer can verify all of the following hold:
+
+1. `phase-harness config list` prints a 6-row table covering phases 1, 2, 3, 4, 5, 7 with a `source` column.
+2. `phase-harness config set phase.1.preset opus-1m-max` followed by `phase-harness config get phase.1.preset` prints `opus-1m-max` (no annotation).
+3. `phase-harness config set phase.6.preset X` exits non-zero, prints a stderr error naming phase 6, and does not create or modify `~/.harness/config.json`.
+4. `phase-harness config set phase.1.preset bogus` exits non-zero, prints a stderr error naming the bogus id, and does not modify `~/.harness/config.json`.
+5. With an override in `~/.harness/config.json`, a new `phase-harness start` (or `run`) writes a `state.json` whose `phasePresets` reflects the override for the overridden phase and the built-in default for every other phase.
+6. With no `~/.harness/config.json`, every `start`/`run`/`resume` code path observable to a user behaves identically to the pre-change build. The regression test suite passes unmodified beyond the new tests.
+7. `phase-harness resume <existing-runId>` is byte-identical to today regardless of whether `~/.harness/config.json` exists or not.
+8. A malformed `~/.harness/config.json` causes every config subcommand and any new `start`/`run` to exit non-zero with a stderr message naming the file path and the parse error.
+9. README.md, README.ko.md, docs/HOW-IT-WORKS.md, docs/HOW-IT-WORKS.ko.md each document the `config` subcommand and the new resolution precedence.
+10. `pnpm tsc --noEmit`, `pnpm vitest run`, and `pnpm build` succeed.
+
+## Invariants
+
+The Phase 2 reviewer / Phase 6 verifier can grep for these:
+
+- **INV-1**: `src/userConfig.ts` exists and exports `loadUserConfig`, `saveUserConfig`, `applyUserConfigOverrides`, `parseConfigKey`, `getEffectivePreset`. (`grep -nE "export function (loadUserConfig|saveUserConfig|applyUserConfigOverrides|parseConfigKey|getEffectivePreset)" src/userConfig.ts` returns 5 hits.)
+- **INV-2**: `src/commands/config.ts` exists and exports `configListCommand`, `configGetCommand`, `configSetCommand`, `configResetCommand`. (`grep -nE "export (async )?function config(List|Get|Set|Reset)Command" src/commands/config.ts` returns 4 hits.)
+- **INV-3**: `bin/harness.ts` registers a `config` parent command. (`grep -n "\.command('config" bin/harness.ts` returns at least 1 hit.)
+- **INV-4**: `package.json` has **no new dependency entries** vs. the pre-change baseline (`git diff main -- package.json` shows no `+` lines under `"dependencies"` or `"devDependencies"`). This enforces NFR-1.
+- **INV-5**: `src/state.ts` `createInitialState` is unchanged in signature (`grep -n "export function createInitialState" src/state.ts` returns one hit with the same parameter list as before — the overlay lives in `start.ts`, not `state.ts`).
+- **INV-6**: `src/commands/resume.ts` contains zero references to `userConfig` or `loadUserConfig`. (`grep -n "userConfig\|loadUserConfig" src/commands/resume.ts` returns zero hits.) Enforces FR-7.
+- **INV-7**: `src/commands/start.ts` calls `applyUserConfigOverrides` exactly once, before the first `writeState`. (`grep -n "applyUserConfigOverrides" src/commands/start.ts` returns at least one hit ordered before the first `writeState(`.)
+- **INV-8**: All four doc files (`README.md`, `README.ko.md`, `docs/HOW-IT-WORKS.md`, `docs/HOW-IT-WORKS.ko.md`) mention `phase-harness config`. (`grep -l "phase-harness config" README.md README.ko.md docs/HOW-IT-WORKS.md docs/HOW-IT-WORKS.ko.md` returns all four paths.)
+
+## File Impact Summary
+
+| Path | Change |
+|---|---|
+| `src/userConfig.ts` | NEW — atomic I/O, key parsing, validation, start-time overlay helper |
+| `src/commands/config.ts` | NEW — four subcommand handlers |
+| `bin/harness.ts` | EDIT — register `config` parent command with four sub-actions |
+| `src/commands/start.ts` | EDIT — call `applyUserConfigOverrides` after `createInitialState`, before first `writeState`; handle `UserConfigParseError` |
+| `tests/userConfig.test.ts` | NEW |
+| `tests/commands/config.test.ts` | NEW |
+| `tests/userConfigStartOverlay.test.ts` | NEW |
+| `README.md` | EDIT — `Config` section |
+| `README.ko.md` | EDIT — `Config` section |
+| `docs/HOW-IT-WORKS.md` | EDIT — "Default model resolution" section |
+| `docs/HOW-IT-WORKS.ko.md` | EDIT — "Default model resolution" section |
+
+No edits to `src/state.ts`, `src/commands/inner.ts`, `src/commands/resume.ts`, `src/ui.ts`, `src/config.ts`.

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,110 @@
+import {
+  loadUserConfig,
+  saveUserConfig,
+  parseConfigKey,
+  getEffectivePreset,
+  setOverride,
+  clearOverride,
+  UserConfigParseError,
+  UserConfigKeyError,
+  type UserConfig,
+} from '../userConfig.js';
+import { MODEL_PRESETS, REQUIRED_PHASE_KEYS } from '../config.js';
+
+export interface ConfigCommandOptions {
+  homeDir?: string;
+}
+
+const SUPPORTED_PRESET_IDS = new Set(MODEL_PRESETS.map(p => p.id));
+
+function loadOrExit(homeDir?: string): UserConfig {
+  try {
+    return loadUserConfig(homeDir);
+  } catch (err) {
+    if (err instanceof UserConfigParseError) {
+      process.stderr.write(err.message + '\n');
+      process.exit(1);
+    }
+    throw err;
+  }
+}
+
+function parseKeyOrExit(key: string): { phase: string } {
+  try {
+    return parseConfigKey(key);
+  } catch (err) {
+    if (err instanceof UserConfigKeyError) {
+      process.stderr.write(err.message + '\n');
+      process.exit(1);
+    }
+    throw err;
+  }
+}
+
+function padRight(s: string, len: number): string {
+  return s + ' '.repeat(Math.max(0, len - s.length));
+}
+
+export function configListCommand(opts: ConfigCommandOptions = {}): void {
+  const config = loadOrExit(opts.homeDir);
+  const rows: Array<{ key: string; value: string; source: string }> = [];
+  for (const phase of REQUIRED_PHASE_KEYS) {
+    const override = config.phase?.[phase]?.preset;
+    let value: string;
+    let source: string;
+    if (override !== undefined) {
+      const stale = !SUPPORTED_PRESET_IDS.has(override);
+      value = stale ? `${override} (stale)` : override;
+      source = stale ? 'override (stale)' : 'override';
+    } else {
+      value = getEffectivePreset(config, phase).value;
+      source = 'default';
+    }
+    rows.push({ key: `phase.${phase}.preset`, value, source });
+  }
+  const header = { key: 'key', value: 'value', source: 'source' };
+  const colKey = Math.max(header.key.length, ...rows.map(r => r.key.length));
+  const colVal = Math.max(header.value.length, ...rows.map(r => r.value.length));
+  const colSrc = Math.max(header.source.length, ...rows.map(r => r.source.length));
+  const line = (r: { key: string; value: string; source: string }) =>
+    `${padRight(r.key, colKey)}  ${padRight(r.value, colVal)}  ${r.source}\n`;
+  process.stdout.write(line(header));
+  process.stdout.write(`${'-'.repeat(colKey)}  ${'-'.repeat(colVal)}  ${'-'.repeat(colSrc)}\n`);
+  for (const row of rows) process.stdout.write(line(row));
+}
+
+export function configGetCommand(key: string, opts: ConfigCommandOptions = {}): void {
+  const { phase } = parseKeyOrExit(key);
+  const config = loadOrExit(opts.homeDir);
+  const override = config.phase?.[phase]?.preset;
+  if (override !== undefined) {
+    const stale = !SUPPORTED_PRESET_IDS.has(override);
+    process.stdout.write(stale ? `${override} (override, stale)\n` : `${override}\n`);
+  } else {
+    process.stdout.write(`${getEffectivePreset(config, phase).value} (default)\n`);
+  }
+}
+
+export function configSetCommand(key: string, value: string, opts: ConfigCommandOptions = {}): void {
+  parseKeyOrExit(key);
+  if (!SUPPORTED_PRESET_IDS.has(value)) {
+    process.stderr.write(
+      `Error: unknown preset id '${value}'. Run 'phase-harness config list' or see src/config.ts MODEL_PRESETS for valid ids.\n`,
+    );
+    process.exit(1);
+  }
+  const config = loadOrExit(opts.homeDir);
+  saveUserConfig(setOverride(config, key, value), opts.homeDir);
+  process.stdout.write(`${key} = ${value}\n`);
+}
+
+export function configResetCommand(key: string, opts: ConfigCommandOptions = {}): void {
+  const { phase } = parseKeyOrExit(key);
+  const config = loadOrExit(opts.homeDir);
+  if (!config.phase?.[phase]?.preset) {
+    process.stdout.write(`${key} already at default (no override to reset)\n`);
+    return;
+  }
+  saveUserConfig(clearOverride(config, key), opts.homeDir);
+  process.stdout.write(`reset ${key}\n`);
+}

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -9,6 +9,7 @@ import { findHarnessRoot, setCurrentRun } from '../root.js';
 import { cleanupOrphans } from '../orphan-cleanup.js';
 import { createInitialState, writeState } from '../state.js';
 import { captureDirtyBaseline } from '../artifact.js';
+import { applyUserConfigOverrides, UserConfigParseError } from '../userConfig.js';
 import { isInsideTmux, getCurrentSessionName, getActiveWindowId, createSession, createWindow, sendKeys, killSession, selectWindow, getDefaultPaneId } from '../tmux.js';
 import { openTerminalWindow } from '../terminal.js';
 import { HANDOFF_TIMEOUT_MS } from '../config.js';
@@ -254,6 +255,16 @@ export async function startCommand(task: string | undefined, options: StartOptio
     // in the depth-1 multi-repo mode the outer cwd may not be a git repo itself.
     // captureDirtyBaseline() returns [] when called on a non-git path.
     state.dirtyBaseline = captureDirtyBaseline(trackedRepos[0].path);
+
+    try {
+      applyUserConfigOverrides(state);
+    } catch (err) {
+      if (err instanceof UserConfigParseError) {
+        process.stderr.write(`Error: ${err.message}\n`);
+        process.exit(1);
+      }
+      throw err;
+    }
 
     if (options.codexNoIsolate) {
       // BUG-C risk surface: user explicitly bypassed isolation.

--- a/src/userConfig.ts
+++ b/src/userConfig.ts
@@ -1,0 +1,129 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { MODEL_PRESETS, PHASE_DEFAULTS, REQUIRED_PHASE_KEYS } from './config.js';
+import type { HarnessState } from './types.js';
+
+export interface UserConfig {
+  phase?: Record<string, { preset?: string }>;
+}
+
+export class UserConfigParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UserConfigParseError';
+  }
+}
+
+export class UserConfigKeyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UserConfigKeyError';
+  }
+}
+
+const SUPPORTED_PHASES = new Set(['1', '2', '3', '4', '5', '7']);
+
+export function getUserConfigPath(homeDir?: string): string {
+  return path.join(homeDir ?? os.homedir(), '.harness', 'config.json');
+}
+
+export function loadUserConfig(homeDir?: string): UserConfig {
+  const configPath = getUserConfigPath(homeDir);
+  if (!fs.existsSync(configPath)) return {};
+  const raw = fs.readFileSync(configPath, 'utf-8');
+  try {
+    return JSON.parse(raw) as UserConfig;
+  } catch (err) {
+    throw new UserConfigParseError(
+      `~/.harness/config.json is not valid JSON: ${(err as Error).message}. Edit or delete the file to recover.`,
+    );
+  }
+}
+
+export function saveUserConfig(config: UserConfig, homeDir?: string): void {
+  const configPath = getUserConfigPath(homeDir);
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  const tmpPath = configPath + '.tmp';
+  fs.writeFileSync(tmpPath, JSON.stringify(config, null, 2));
+  const fd = fs.openSync(tmpPath, 'r+');
+  try { fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+  fs.renameSync(tmpPath, configPath);
+}
+
+export function parseConfigKey(key: string): { phase: string } {
+  const match = key.match(/^phase\.(\w+)\.preset$/);
+  if (!match) {
+    throw new UserConfigKeyError(
+      `Error: unknown config key '${key}'. Supported keys: phase.<1|2|3|4|5|7>.preset`,
+    );
+  }
+  const phase = match[1];
+  if (phase === '6') {
+    throw new UserConfigKeyError(
+      `Error: phase 6 is the verify script (no model); cannot configure. Supported phases: 1, 2, 3, 4, 5, 7.`,
+    );
+  }
+  if (!SUPPORTED_PHASES.has(phase)) {
+    throw new UserConfigKeyError(
+      `Error: unknown phase '${phase}'. Supported phases: 1, 2, 3, 4, 5, 7.`,
+    );
+  }
+  return { phase };
+}
+
+export function getOverride(config: UserConfig, key: string): string | undefined {
+  const { phase } = parseConfigKey(key);
+  return config.phase?.[phase]?.preset;
+}
+
+export function setOverride(config: UserConfig, key: string, value: string): UserConfig {
+  const { phase } = parseConfigKey(key);
+  return {
+    ...config,
+    phase: {
+      ...(config.phase ?? {}),
+      [phase]: { ...(config.phase?.[phase] ?? {}), preset: value },
+    },
+  };
+}
+
+export function clearOverride(config: UserConfig, key: string): UserConfig {
+  const { phase } = parseConfigKey(key);
+  if (!config.phase?.[phase]?.preset) return config;
+  const newPhase = { ...(config.phase ?? {}) };
+  const entry = { ...newPhase[phase] };
+  delete entry.preset;
+  if (Object.keys(entry).length === 0) {
+    delete newPhase[phase];
+  } else {
+    newPhase[phase] = entry;
+  }
+  return { ...config, phase: newPhase };
+}
+
+export function getEffectivePreset(
+  config: UserConfig,
+  phase: string,
+): { value: string; source: 'default' | 'override' } {
+  const override = config.phase?.[phase]?.preset;
+  if (override !== undefined) return { value: override, source: 'override' };
+  return { value: PHASE_DEFAULTS[Number(phase)], source: 'default' };
+}
+
+export function applyUserConfigOverrides(state: HarnessState, homeDir?: string): void {
+  const config = loadUserConfig(homeDir); // throws UserConfigParseError — caller handles
+  const presetIds = new Set(MODEL_PRESETS.map(p => p.id));
+  for (const phase of REQUIRED_PHASE_KEYS) {
+    const override = config.phase?.[phase]?.preset;
+    if (override === undefined) continue;
+    if (!presetIds.has(override)) {
+      process.stderr.write(
+        `Saved config phase.${phase}.preset='${override}' is no longer a known preset; ` +
+        `using built-in default '${PHASE_DEFAULTS[Number(phase)]}'.\n`,
+      );
+      continue;
+    }
+    state.phasePresets[phase] = override;
+  }
+}

--- a/tests/commands/config.test.ts
+++ b/tests/commands/config.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  configListCommand,
+  configGetCommand,
+  configSetCommand,
+  configResetCommand,
+} from '../../src/commands/config.js';
+import { PHASE_DEFAULTS } from '../../src/config.js';
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  vi.restoreAllMocks();
+});
+function makeTmp(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'config-cmd-test-'));
+  tmpDirs.push(d);
+  return d;
+}
+function writeConfig(home: string, data: object): void {
+  fs.mkdirSync(path.join(home, '.harness'), { recursive: true });
+  fs.writeFileSync(path.join(home, '.harness', 'config.json'), JSON.stringify(data));
+}
+function captureStdout(fn: () => void): string {
+  const chunks: string[] = [];
+  const spy = vi.spyOn(process.stdout, 'write').mockImplementation((s) => { chunks.push(String(s)); return true; });
+  try { fn(); } finally { spy.mockRestore(); }
+  return chunks.join('');
+}
+function captureStderr(fn: () => void): string {
+  const chunks: string[] = [];
+  const spy = vi.spyOn(process.stderr, 'write').mockImplementation((s) => { chunks.push(String(s)); return true; });
+  try { fn(); } finally { spy.mockRestore(); }
+  return chunks.join('');
+}
+
+describe('configListCommand', () => {
+  it('prints 6 data rows + header + separator when no overrides', () => {
+    const home = makeTmp();
+    const out = captureStdout(() => configListCommand({ homeDir: home }));
+    const lines = out.trim().split('\n');
+    expect(lines).toHaveLength(8); // header + separator + 6 rows
+    expect(out).toContain('phase.1.preset');
+    expect(out).toContain('phase.7.preset');
+    expect(out).toContain('default');
+  });
+  it('shows override source and value for overridden phase', () => {
+    const home = makeTmp();
+    writeConfig(home, { phase: { '1': { preset: 'opus-1m-max' } } });
+    const out = captureStdout(() => configListCommand({ homeDir: home }));
+    expect(out).toContain('opus-1m-max');
+    expect(out).toContain('override');
+  });
+});
+
+describe('configGetCommand', () => {
+  it('prints bare value when override present', () => {
+    const home = makeTmp();
+    writeConfig(home, { phase: { '1': { preset: 'opus-1m-max' } } });
+    const out = captureStdout(() => configGetCommand('phase.1.preset', { homeDir: home }));
+    expect(out.trim()).toBe('opus-1m-max');
+  });
+  it('prints default value with (default) annotation when unset', () => {
+    const home = makeTmp();
+    const out = captureStdout(() => configGetCommand('phase.1.preset', { homeDir: home }));
+    expect(out).toContain(PHASE_DEFAULTS[1]);
+    expect(out).toContain('(default)');
+  });
+  it('exits 1 with stderr mentioning phase 6 for phase.6.preset', () => {
+    const home = makeTmp();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit1'); });
+    const err = captureStderr(() => {
+      try { configGetCommand('phase.6.preset', { homeDir: home }); } catch { /* exit mock */ }
+    });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(err).toContain('phase 6');
+  });
+});
+
+describe('configSetCommand', () => {
+  it('writes config.json and prints "key = value" confirmation', () => {
+    const home = makeTmp();
+    const out = captureStdout(() => configSetCommand('phase.1.preset', 'opus-1m-max', { homeDir: home }));
+    expect(out.trim()).toBe('phase.1.preset = opus-1m-max');
+    const saved = JSON.parse(fs.readFileSync(path.join(home, '.harness', 'config.json'), 'utf-8'));
+    expect(saved.phase['1'].preset).toBe('opus-1m-max');
+  });
+  it('exits 1 for bogus preset id, does not create config.json', () => {
+    const home = makeTmp();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit1'); });
+    const err = captureStderr(() => {
+      try { configSetCommand('phase.1.preset', 'bogus-id', { homeDir: home }); } catch { /* exit mock */ }
+    });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(err).toContain('bogus-id');
+    expect(fs.existsSync(path.join(home, '.harness', 'config.json'))).toBe(false);
+  });
+  it('exits 1 for phase.6.preset, does not create config.json', () => {
+    const home = makeTmp();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit1'); });
+    captureStderr(() => {
+      try { configSetCommand('phase.6.preset', 'opus-1m-max', { homeDir: home }); } catch { /* exit mock */ }
+    });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(fs.existsSync(path.join(home, '.harness', 'config.json'))).toBe(false);
+  });
+});
+
+describe('configResetCommand', () => {
+  it('removes override and prints "reset <key>"', () => {
+    const home = makeTmp();
+    writeConfig(home, { phase: { '1': { preset: 'opus-1m-max' } } });
+    const out = captureStdout(() => configResetCommand('phase.1.preset', { homeDir: home }));
+    expect(out).toContain('reset phase.1.preset');
+    const saved = JSON.parse(fs.readFileSync(path.join(home, '.harness', 'config.json'), 'utf-8'));
+    expect(saved.phase?.['1']?.preset).toBeUndefined();
+  });
+  it('is idempotent — prints no-op message and exits 0 on second reset', () => {
+    const home = makeTmp();
+    writeConfig(home, { phase: { '1': { preset: 'opus-1m-max' } } });
+    configResetCommand('phase.1.preset', { homeDir: home });
+    const out2 = captureStdout(() => configResetCommand('phase.1.preset', { homeDir: home }));
+    expect(out2).toContain('no override to reset');
+  });
+});
+
+describe('malformed config.json — all four subcommands exit 1', () => {
+  function writeBadConfig(home: string): void {
+    fs.mkdirSync(path.join(home, '.harness'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.harness', 'config.json'), '{bad json}');
+  }
+  it.each([
+    ['list', (home: string) => configListCommand({ homeDir: home })],
+    ['get', (home: string) => configGetCommand('phase.1.preset', { homeDir: home })],
+    ['set', (home: string) => configSetCommand('phase.1.preset', 'opus-1m-max', { homeDir: home })],
+    ['reset', (home: string) => configResetCommand('phase.1.preset', { homeDir: home })],
+  ] as const)('config %s exits 1 with config.json in stderr', (_name, fn) => {
+    const home = makeTmp();
+    writeBadConfig(home);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit1'); });
+    const err = captureStderr(() => { try { fn(home); } catch { /* exit mock */ } });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(err).toContain('config.json');
+  });
+});
+
+describe('stale override annotation', () => {
+  it('config list shows (stale) for unknown preset id', () => {
+    const home = makeTmp();
+    fs.mkdirSync(path.join(home, '.harness'), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, '.harness', 'config.json'),
+      JSON.stringify({ phase: { '1': { preset: 'old-preset-removed' } } }),
+    );
+    const out = captureStdout(() => configListCommand({ homeDir: home }));
+    expect(out).toContain('stale');
+  });
+  it('config get shows (override, stale) for unknown preset id', () => {
+    const home = makeTmp();
+    fs.mkdirSync(path.join(home, '.harness'), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, '.harness', 'config.json'),
+      JSON.stringify({ phase: { '1': { preset: 'old-preset-removed' } } }),
+    );
+    const out = captureStdout(() => configGetCommand('phase.1.preset', { homeDir: home }));
+    expect(out).toContain('(override, stale)');
+  });
+});

--- a/tests/userConfig.test.ts
+++ b/tests/userConfig.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  loadUserConfig,
+  saveUserConfig,
+  parseConfigKey,
+  getEffectivePreset,
+  UserConfigParseError,
+  UserConfigKeyError,
+} from '../src/userConfig.js';
+import { PHASE_DEFAULTS } from '../src/config.js';
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  vi.restoreAllMocks();
+});
+function makeTmp(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'userconfig-test-'));
+  tmpDirs.push(d);
+  return d;
+}
+
+describe('loadUserConfig', () => {
+  it('returns {} when file absent', () => {
+    expect(loadUserConfig(makeTmp())).toEqual({});
+  });
+  it('parses valid JSON', () => {
+    const home = makeTmp();
+    fs.mkdirSync(path.join(home, '.harness'));
+    fs.writeFileSync(
+      path.join(home, '.harness', 'config.json'),
+      JSON.stringify({ phase: { '1': { preset: 'opus-1m-max' } } }),
+    );
+    expect(loadUserConfig(home)).toEqual({ phase: { '1': { preset: 'opus-1m-max' } } });
+  });
+  it('throws UserConfigParseError on malformed JSON', () => {
+    const home = makeTmp();
+    fs.mkdirSync(path.join(home, '.harness'));
+    fs.writeFileSync(path.join(home, '.harness', 'config.json'), '{bad json}');
+    expect(() => loadUserConfig(home)).toThrowError(UserConfigParseError);
+  });
+});
+
+describe('saveUserConfig', () => {
+  it('writes atomically — no tmp file left behind', () => {
+    const home = makeTmp();
+    saveUserConfig({ phase: { '1': { preset: 'sonnet-high' } } }, home);
+    const configPath = path.join(home, '.harness', 'config.json');
+    expect(fs.existsSync(configPath)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(configPath, 'utf-8'))).toEqual({
+      phase: { '1': { preset: 'sonnet-high' } },
+    });
+    expect(fs.existsSync(configPath + '.tmp')).toBe(false);
+  });
+  it('creates ~/.harness/ when missing', () => {
+    const home = makeTmp();
+    saveUserConfig({}, home);
+    expect(fs.existsSync(path.join(home, '.harness'))).toBe(true);
+  });
+});
+
+describe('parseConfigKey', () => {
+  it("parses 'phase.1.preset' → { phase: '1' }", () => {
+    expect(parseConfigKey('phase.1.preset')).toEqual({ phase: '1' });
+  });
+  it("throws UserConfigKeyError for 'phase.6.preset' and names phase 6", () => {
+    expect(() => parseConfigKey('phase.6.preset')).toThrowError(UserConfigKeyError);
+    try { parseConfigKey('phase.6.preset'); } catch (e) {
+      expect((e as Error).message).toContain('phase 6');
+    }
+  });
+  it.each(['phase.0.preset', 'phase.8.preset', 'phase.foo.preset', 'phase.1.model', 'random.thing', ''])(
+    'throws UserConfigKeyError for invalid key %s',
+    (key) => expect(() => parseConfigKey(key)).toThrowError(UserConfigKeyError),
+  );
+});
+
+describe('getEffectivePreset', () => {
+  it('returns built-in default when no override', () => {
+    expect(getEffectivePreset({}, '1')).toEqual({ value: PHASE_DEFAULTS[1], source: 'default' });
+  });
+  it('returns override when present', () => {
+    expect(getEffectivePreset({ phase: { '1': { preset: 'opus-1m-max' } } }, '1')).toEqual({
+      value: 'opus-1m-max',
+      source: 'override',
+    });
+  });
+});

--- a/tests/userConfigStartOverlay.test.ts
+++ b/tests/userConfigStartOverlay.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { applyUserConfigOverrides, UserConfigParseError } from '../src/userConfig.js';
+import { PHASE_DEFAULTS, REQUIRED_PHASE_KEYS } from '../src/config.js';
+import type { HarnessState } from '../src/types.js';
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  vi.restoreAllMocks();
+});
+function makeTmp(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'overlay-test-'));
+  tmpDirs.push(d);
+  return d;
+}
+function makeState(): HarnessState {
+  const phasePresets: Record<string, string> = {};
+  for (const p of REQUIRED_PHASE_KEYS) phasePresets[p] = PHASE_DEFAULTS[Number(p)];
+  return { phasePresets } as unknown as HarnessState;
+}
+
+describe('applyUserConfigOverrides', () => {
+  it('no-op when config.json absent', () => {
+    const state = makeState();
+    const before = { ...state.phasePresets };
+    applyUserConfigOverrides(state, makeTmp());
+    expect(state.phasePresets).toEqual(before);
+  });
+  it('applies override for phase 1, leaves other phases at built-in default', () => {
+    const home = makeTmp();
+    fs.mkdirSync(path.join(home, '.harness'));
+    fs.writeFileSync(
+      path.join(home, '.harness', 'config.json'),
+      JSON.stringify({ phase: { '1': { preset: 'opus-1m-max' } } }),
+    );
+    const state = makeState();
+    applyUserConfigOverrides(state, home);
+    expect(state.phasePresets['1']).toBe('opus-1m-max');
+    expect(state.phasePresets['2']).toBe(PHASE_DEFAULTS[2]);
+  });
+  it('warns to stderr and keeps built-in default for stale override', () => {
+    const home = makeTmp();
+    fs.mkdirSync(path.join(home, '.harness'));
+    fs.writeFileSync(
+      path.join(home, '.harness', 'config.json'),
+      JSON.stringify({ phase: { '1': { preset: 'stale-gone-preset' } } }),
+    );
+    const state = makeState();
+    const stderrSpy = vi.spyOn(process.stderr, 'write');
+    applyUserConfigOverrides(state, home);
+    expect(state.phasePresets['1']).toBe(PHASE_DEFAULTS[1]);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('stale-gone-preset'));
+  });
+  it('throws UserConfigParseError on malformed config.json', () => {
+    const home = makeTmp();
+    fs.mkdirSync(path.join(home, '.harness'));
+    fs.writeFileSync(path.join(home, '.harness', 'config.json'), '{bad}');
+    expect(() => applyUserConfigOverrides(makeState(), home)).toThrowError(UserConfigParseError);
+  });
+});


### PR DESCRIPTION
## Summary

New \`phase-harness config\` subcommand lets users persist per-phase model preset overrides without losing the per-run model configuration dialog. The dialog still runs every \`start\`, but now seeds its defaults from \`~/.harness/config.json\` instead of always falling back to the built-in \`DEFAULT_PRESETS\`.

- New \`src/userConfig.ts\` — \`~/.harness/config.json\` read/write, key parsing (\`phase.<N>.preset\`), validation against \`PRESETS\` ids, fail-loud on malformed JSON, \`applyUserConfigOverrides(state)\` overlay applied at run-creation time only.
- New \`src/commands/config.ts\` — \`list\` / \`get\` / \`set\` / \`reset\` handlers. \`list\` table marks every row as \`override\` or \`default\` so the user can see what's tweaked. \`get\` on an unset key prints the effective default with a \`(default)\` annotation.
- \`bin/harness.ts\` registers the four \`config\` subcommands (~30 LoC).
- \`src/commands/start.ts\` calls \`applyUserConfigOverrides\` once before launching the model configuration dialog (~11 LoC). The dialog itself is unchanged — same \"Change?\" prompt — only its initial defaults move.
- Tests: 173 LoC config subcommand tests + 93 LoC userConfig I/O tests + 65 LoC start-overlay regression test.
- README + HOW-IT-WORKS (en/ko) sync.

## Decisions

| Q | Answer | Rationale |
|---|---|---|
| Resume scope | Saved config applies on start only | Matches \`--light\` / \`--no-drift\` / \`--auto\` \"frozen at run creation\" pattern. Resume reads \`state.json.phasePresets\` already chosen at start time. |
| Get on unset key | Print effective default + \`(default)\` annotation, exit 0 | UX-friendly — single output line shows both the resolved value AND whether it's overridden. |
| List annotation | Explicit \`override\` / \`default\` column | Scannable table; user immediately sees what they've tweaked. |
| Bad JSON | Error and exit 1 from both \`start\` and \`config *\` | Fail-loud. Silent fallback to built-in defaults hides config bugs and creates surprise. |

## Dogfood notes

This PR was produced by phase-harness itself (run \`2026-05-12-phase-harness-cli-config-b565\`) as the first end-to-end validation of three recent fixes:

- **#104** (drift cap 30K→100K): \`phase_drift\` event emitted with \`action=pass\`, \`driftSource=codex-only\`, \`score=0.078\`. **First time in any phase-harness self-dogfood that drift produced an actual numeric score** instead of \`action=error driftSource=error\` on the spec+plan cap. Old cap would have errored on this run's combined ~60K spec+plan.
- **#103** (retro SIGINT flush ordering): \`session_end\` event present in \`events.jsonl\`, \`retrospective.md\` auto-emitted at 1.6 KB without manual subcommand invocation.
- **#105** (tmux cleanup): TBD on this PR's merge — will verify the \`harness-ctrl\` window disappears after \`Ctrl+C\` once the user exits the idle wait.

Bonus signal on gate quality: every gate (P2, P4, P7) approved on the first attempt (\`gateRetries = {2: 0, 4: 0, 7: 0}\`). P2 ambiguity score was 0.0175 — far below the 0.2 threshold — vs 0.0895 in PR #102's dogfood. Tighter spec via the new four-question batched brainstorming UI.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm vitest run\` — full suite passing (4/4 eval checks)
- [x] \`pnpm build\` clean
- [x] Smoke: \`phase-harness config list\` runs and prints the table
- [ ] Manual: \`phase-harness config set phase.5.preset codex-high\` then \`phase-harness start\` — confirm dialog shows codex-high as P5 default
- [ ] Manual: \`phase-harness config get phase.3.preset\` on a fresh machine — confirm prints \`sonnet-high (default)\`