### PR TITLE
fix(phase): time out waitForPhaseCompletion when sentinel never arrives (#107)

### DIFF
--- a/src/phases/gate.ts
+++ b/src/phases/gate.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 import type { HarnessState, GatePhaseResult, GateResult, GateSessionInfo, ClaudeTokens } from '../types.js';
 import { assembleGatePrompt, assembleGateResumePrompt } from '../context/assembler.js';
-import { getPresetById, SIGTERM_WAIT_MS } from '../config.js';
+import { getPresetById, SIGTERM_WAIT_MS, GATE_TIMEOUT_MS } from '../config.js';
 import type { ModelPreset } from '../config.js';
 import { runClaudeGate } from '../runners/claude.js';
 import { spawnCodexInPane } from '../runners/codex.js';
@@ -360,10 +360,15 @@ export async function runGatePhaseInteractive(
     sessionId: resumeSessionId ?? undefined,
   });
 
-  // Step 8: Wait for sentinel using existing waitForPhaseCompletion
+  // Step 8: Wait for sentinel using existing waitForPhaseCompletion.
+  // Pass GATE_TIMEOUT_MS so a Codex CLI that emits its verdict to stdout but
+  // refuses to exit (drops into TUI REPL prompt without writing the sentinel
+  // via tool use) fails the gate after the budget instead of wedging the
+  // main loop forever — issue #107.
   const attemptId = state.phaseAttemptId[String(phase)] ?? '';
   const sentinelResult = await waitForPhaseCompletion(
     sentinelPath, attemptId, spawnResult.pid, phase, state, cwd, runDir,
+    GATE_TIMEOUT_MS,
   );
 
   // Interrupt TUI and wait for process group to flush JSONL before reading usage

--- a/src/phases/interactive.ts
+++ b/src/phases/interactive.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { randomUUID } from 'crypto';
 import chokidar from 'chokidar';
 import type { HarnessState, InteractivePhase, Artifacts } from '../types.js';
-import { getPhaseArtifactFiles, getPresetById } from '../config.js';
+import { getPhaseArtifactFiles, getPresetById, INTERACTIVE_TIMEOUT_MS } from '../config.js';
 import { writeState, syncLegacyMirror } from '../state.js';
 import { getHead, detectUncommittedChanges, type UncommittedRepo } from '../git.js';
 import { isPidAlive } from '../process.js';
@@ -279,7 +279,8 @@ export async function runInteractivePhase(
     const sentinelPath = path.join(runDir, `phase-${phase}.done`);
     const resolvedAttemptId = updatedState.phaseAttemptId[String(phase)] ?? attemptId;
     const result = await waitForPhaseCompletion(
-      sentinelPath, resolvedAttemptId, claudePid, phase, updatedState, cwd, runDir
+      sentinelPath, resolvedAttemptId, claudePid, phase, updatedState, cwd, runDir,
+      INTERACTIVE_TIMEOUT_MS,
     );
     return { ...result, attemptId };
   } else {
@@ -324,6 +325,7 @@ export async function runInteractivePhase(
 
     const result: InteractiveResult = await waitForPhaseCompletion(
       sentinelPath, attemptId, codexPid, phase, updatedState, cwd, runDir,
+      INTERACTIVE_TIMEOUT_MS,
     );
 
     // Issue #84 — when Phase 5 fails under a Codex preset and Codex itself
@@ -368,7 +370,15 @@ export async function waitForPhaseCompletion(
   phase: number,
   state: HarnessState,
   cwd: string,
-  runDir: string
+  runDir: string,
+  // Absolute wall-clock timeout. Issue #107: when Codex CLI / Claude TUI keeps
+  // its PID alive past the verdict (e.g. drops into an interactive REPL prompt
+  // after emitting the response) but never writes the sentinel via tool use,
+  // the harness used to wait forever. Callers MUST pass a phase-appropriate
+  // timeout (GATE_TIMEOUT_MS for gates, INTERACTIVE_TIMEOUT_MS for P1/P3/P5).
+  // The parameter stays optional so existing test helpers compile, but
+  // production callers always set it.
+  timeoutMs?: number,
 ): Promise<InteractiveResult> {
   return new Promise<InteractiveResult>((resolve) => {
     let settled = false;
@@ -377,6 +387,7 @@ export async function waitForPhaseCompletion(
     let pidPollInterval: ReturnType<typeof setInterval> | null = null;
     let interruptPollInterval: ReturnType<typeof setInterval> | null = null;
     let nullPidTimeout: ReturnType<typeof setTimeout> | null = null;
+    let absTimeout: ReturnType<typeof setTimeout> | null = null;
 
     function settle(status: 'completed' | 'failed'): void {
       if (settled) return;
@@ -401,8 +412,25 @@ export async function waitForPhaseCompletion(
         clearTimeout(nullPidTimeout);
         nullPidTimeout = null;
       }
+      if (absTimeout !== null) {
+        clearTimeout(absTimeout);
+        absTimeout = null;
+      }
       // Workspace pane persists — no kill/select needed
       resolve({ status });
+    }
+
+    // Absolute timeout (issue #107). Fires even when claudePid is alive but
+    // the runner refuses to exit (TUI mode after verdict; sentinel never
+    // written). One stderr line so the operator knows why the phase failed.
+    if (timeoutMs !== undefined && timeoutMs > 0) {
+      absTimeout = setTimeout(() => {
+        if (settled) return;
+        process.stderr.write(
+          `[harness] phase ${phase} timed out after ${Math.round(timeoutMs / 1000)}s waiting for sentinel\n`,
+        );
+        settle('failed');
+      }, timeoutMs);
     }
 
     // Sentinel detection → evaluate artifacts

--- a/tests/phases/interactive.test.ts
+++ b/tests/phases/interactive.test.ts
@@ -7,6 +7,7 @@ import {
   preparePhase,
   checkSentinelFreshness,
   validatePhaseArtifacts,
+  waitForPhaseCompletion,
 } from '../../src/phases/interactive.js';
 import { createInitialState, readState } from '../../src/state.js';
 import type { HarnessState } from '../../src/types.js';
@@ -1100,5 +1101,49 @@ describe('validatePhaseArtifacts — Phase 5 multi-repo (FR-6, ADR-D4)', () => {
     const runDir = makeTmpDir('rundir2-');
     const result = validatePhaseArtifacts(5, state, outer, runDir);
     expect(result).toBe(false);
+  });
+});
+
+// ─── waitForPhaseCompletion absolute timeout (issue #107) ───────────────────
+
+describe('waitForPhaseCompletion — absolute timeout (issue #107)', () => {
+  it('settles "failed" when timeoutMs elapses even though pid is still alive and no sentinel is written', async () => {
+    const runDir = makeTmpDir();
+    const sentinelPath = path.join(runDir, 'phase-4.done');
+    const state = makeState();
+    // Mocked isPidAlive returns false at module-mock level — flip it to true
+    // for this test so the PID-death backstop never fires.
+    const processMock = await import('../../src/process.js');
+    vi.mocked(processMock.isPidAlive).mockReturnValue(true);
+
+    // Pretend codex CLI is alive (pid=42) but never writes the sentinel.
+    // Without the timeout fix this Promise would hang forever; with it the
+    // 250 ms budget fires and resolves to 'failed'.
+    const t0 = Date.now();
+    const result = await waitForPhaseCompletion(
+      sentinelPath, 'fake-attempt-id', 42, 4, state, runDir, runDir, 250,
+    );
+    const elapsedMs = Date.now() - t0;
+
+    expect(result.status).toBe('failed');
+    expect(elapsedMs).toBeGreaterThanOrEqual(200);
+    expect(elapsedMs).toBeLessThan(1500); // generous upper bound for CI jitter
+
+    vi.mocked(processMock.isPidAlive).mockReturnValue(false);
+  });
+
+  it('does not start an absolute timer when timeoutMs is omitted (backwards compat)', async () => {
+    // With timeoutMs omitted and isPidAlive returning false (default mock),
+    // the PID-death backstop should fire and settle 'failed' quickly via the
+    // 1 s poll. This confirms we did NOT regress the existing behavior for
+    // callers that haven't been updated yet.
+    const runDir = makeTmpDir();
+    const sentinelPath = path.join(runDir, 'phase-4.done');
+    const state = makeState();
+
+    const result = await waitForPhaseCompletion(
+      sentinelPath, 'fake-attempt-id', 7777, 4, state, runDir, runDir,
+    );
+    expect(result.status).toBe('failed');
   });
 });


### PR DESCRIPTION
## Summary

Fixes #107 — Codex CLI emitted a REJECT verdict to the workspace pane but \`gate-4-raw.txt\` stayed at 0 bytes and the main loop wedged at \"Starting phase…\" for 14 minutes. Same root cause behind any future runner that gets stuck in a TUI REPL after producing its response.

### Root cause

\`waitForPhaseCompletion\` only had an absolute timeout when \`claudePid === null\` (10 min). When the PID was known — every production path — settle() could only fire via:

1. Sentinel file appearing (\`chokidar\` watcher + 500ms poll)
2. PID dying (1s poll)
3. SIGUSR1 interrupt flag

Codex CLI in gate mode (PR #74's intentional TUI invocation, not \`codex exec\`) doesn't exit after writing its response — it drops into the interactive REPL prompt waiting for the next user line. If the model also forgets to invoke the apply_patch tool that writes the sentinel, the PID stays alive forever and the harness has no way to break out.

### Fix

\`waitForPhaseCompletion\` accepts an optional \`timeoutMs\` parameter and arms a \`setTimeout\` that fires regardless of PID state. On expiry it writes a single \`[harness] phase N timed out after Xs waiting for sentinel\` line to stderr and settles \`'failed'\`. The existing gate-error / interactive-failure handler then picks up cleanly and renders the \`[R]/[S]/[Q]\` ActionMenu (PR #101's Ink restoration), so the user sees what happened and can decide.

Production callers wire the phase-appropriate constant:

- \`gate.ts\` → \`GATE_TIMEOUT_MS\` (6 min) for P2/P4/P7.
- \`interactive.ts\` → \`INTERACTIVE_TIMEOUT_MS\` (30 min) for P1/P3/P5 (both Claude and Codex preset paths).

The parameter is optional — test helpers and any not-yet-updated callers keep their existing no-timeout behavior. Cleanup in \`settle()\` clears the new timer alongside the existing watchers/intervals.

### What about the missing raw.txt?

A separate concern. The 0-byte \`gate-4-raw.txt\` and the empty \"## Output\" in \`gate-4-error.md\` reflect that the codex TUI never wrote the sentinel via tool use, so the harness never reaches the verdict-file read path. Once the timeout fires, the existing error-sidecar machinery records \"Gate N failed (timed out or interrupted)\" — which is exactly what #107's evidence showed *after* a supervisor SIGTERM forced PID death. With this PR the harness reaches that state on its own after 6 minutes, instead of waiting forever.

### Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm vitest run\` — 1253 passed / 1 skipped (2 new regression tests in \`tests/phases/interactive.test.ts\` cover timeout-fires-while-pid-alive and absent-timeout backward compat)
- [x] \`pnpm build\` clean
- [ ] Manual: run a phase-harness gate with a deliberately stubborn Codex prompt that emits the verdict but skips the apply_patch sentinel write — confirm the harness times out after ~6 minutes and surfaces \`[R]/[S]/[Q]\` instead of hanging.

Closes #107.