### PR TITLE
fix(gate): skip stale sidecar replay when retryIndex moved on (#94 Bug 1)

### DIFF
--- a/src/phases/gate.ts
+++ b/src/phases/gate.ts
@@ -150,6 +150,7 @@ async function _persistSidecars(
   promptBytes: number,
   durationMs: number,
   preset: ModelPreset,
+  retryIndex: number,
   codexSessionIdOverride?: string,
 ): Promise<void> {
   const rawPath = path.join(runDir, `gate-${phase}-raw.txt`);
@@ -165,6 +166,7 @@ async function _persistSidecars(
     runner,
     promptBytes,
     durationMs,
+    retryIndex,
     ...(result.tokensTotal !== undefined ? { tokensTotal: result.tokensTotal } : {}),
     ...(effectiveSessionId !== undefined ? { codexSessionId: effectiveSessionId } : {}),
     ...(runner === 'codex' ? { sourcePreset: { model: preset.model, effort: preset.effort } } : {}),
@@ -203,12 +205,38 @@ export async function runGatePhaseInteractive(
   allowSidecarReplay?: { value: boolean },
 ): Promise<GatePhaseResult & { codexTokens?: ClaudeTokens | null }> {
   const phaseKey = String(phase) as GatePhaseKey;
+  // Current retry index — handleGatePhase captured the same value at gate
+  // entry. Used both for sidecar staleness check (#94 Bug 1) and persisted
+  // into the new sidecar so a future replay can apply the same check.
+  const currentRetryIndex = state.gateRetries[phaseKey] ?? 0;
 
   // Step 1: One-shot sidecar replay
   if (allowSidecarReplay?.value) {
     allowSidecarReplay.value = false;
     const replay = checkGateSidecars(runDir, phase);
     if (replay !== null) {
+      // #94 Bug 1 staleness check: a sidecar from retry-N is invalid on
+      // resume when state.gateRetries[N] has already advanced. Without this,
+      // the old verdict gets re-emitted under the new retryIndex (consuming
+      // a retry slot with no actual gate run) — see
+      // https://github.com/DongGukMon/harness-cli/issues/94 Bug 1.
+      //
+      // Legacy sidecars (pre-PR) lack retryIndex. To preserve replay on the
+      // common "resume on first attempt" path (= currentRetryIndex 0) while
+      // still catching the bug for any prior-retry resume, treat absence as
+      // valid only when current=0. Any prior retries (current > 0) force a
+      // fresh gate run because we can't prove the sidecar matches.
+      const sidecarRetryIndex = (replay as GatePhaseResult & { retryIndex?: number }).retryIndex;
+      const replayMatchesCurrent =
+        sidecarRetryIndex === undefined
+          ? currentRetryIndex === 0
+          : sidecarRetryIndex === currentRetryIndex;
+      if (!replayMatchesCurrent) {
+        process.stderr.write(
+          `[harness] gate ${phase} sidecar replay skipped: sidecar retryIndex=${sidecarRetryIndex ?? '<absent>'} ≠ current retryIndex=${currentRetryIndex} (running fresh gate)\n`,
+        );
+        // Fall through to fresh gate run below.
+      } else {
       const currentPreset = getPresetById(state.phasePresets[phaseKey]);
       const replayCompatible =
         currentPreset !== undefined &&
@@ -246,6 +274,7 @@ export async function runGatePhaseInteractive(
           }
         }
         return { ...replay, recoveredFromSidecar: true };
+      }
       }
     }
   }
@@ -334,7 +363,7 @@ export async function runGatePhaseInteractive(
       result = applyAmbiguityGate(result, result.rawOutput ?? '', threshold);
     }
     if (state.currentPhase !== phase) return result;
-    await _persistSidecars(result, runDir, phase, runner, promptBytes, durationMs, preset);
+    await _persistSidecars(result, runDir, phase, runner, promptBytes, durationMs, preset, currentRetryIndex);
     return result;
   }
 
@@ -449,7 +478,7 @@ export async function runGatePhaseInteractive(
   // Step 12: Persist session + sidecars
   if (state.currentPhase === phase) {
     _persistCodexSession(state, phase, gateResult, resumeSessionId, discoveredSessionId, preset, runDir);
-    await _persistSidecars(gateResult, runDir, phase, 'codex', promptBytes, durationMs, preset, discoveredSessionId);
+    await _persistSidecars(gateResult, runDir, phase, 'codex', promptBytes, durationMs, preset, currentRetryIndex, discoveredSessionId);
   }
 
   return { ...gateResult, codexTokens };

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,6 +145,11 @@ export interface GateResult {
   ambiguityThreshold?: number;
   ambiguityVetoed?: boolean;
   clarityParseError?: boolean;
+  // Retry index captured at the time the gate ran — used by sidecar replay
+  // staleness check (#94 Bug 1). Without this, a resume after retry-N+1
+  // re-emits the old retry-N verdict labeled as retry-N+1, consuming a slot
+  // without an actual fresh attempt.
+  retryIndex?: number;
 }
 
 export interface VerifyResult {

--- a/tests/phases/gate.test.ts
+++ b/tests/phases/gate.test.ts
@@ -452,6 +452,88 @@ describe('checkGateSidecars — legacy vs extended sidecar', () => {
 // ─── runGatePhase — one-shot sidecar replay ───────────────────────────────────
 
 describe('runGatePhase — one-shot sidecar replay', () => {
+  it('skips sidecar replay when sidecar retryIndex differs from current state.gateRetries (issue #94 Bug 1)', async () => {
+    const runDir = makeTmpDir();
+    // Sidecar represents retry 0 (the first attempt). gate-N-result.json
+    // carries retryIndex=0 explicitly.
+    fs.writeFileSync(
+      path.join(runDir, 'gate-7-result.json'),
+      JSON.stringify({
+        exitCode: 0,
+        timestamp: Date.now(),
+        runner: 'codex',
+        promptBytes: 1000,
+        durationMs: 375626,
+        sourcePreset: { model: 'gpt-5.5', effort: 'high' },
+        retryIndex: 0, // retry-0 run produced this sidecar
+      }),
+    );
+    fs.writeFileSync(path.join(runDir, 'gate-7-raw.txt'), '## Verdict\nREJECT\n');
+
+    // After retry-0 REJECT, handleGateReject advanced gateRetries.7 to 1.
+    // On resume, currentRetryIndex computed from state is 1 — does NOT match
+    // the sidecar's retryIndex=0 → replay MUST be skipped to avoid double-
+    // counting the same verdict against retry-1's slot. Without the fix
+    // this would return `recoveredFromSidecar: true` with retry-0's verdict.
+    const state = {
+      phasePresets: { '7': 'codex-high' },
+      gateRetries: { '2': 0, '4': 0, '7': 1 },
+      phaseCodexSessions: { '2': null, '4': null, '7': null },
+      phaseAttemptId: { '7': 'fresh-attempt-id' },
+      currentPhase: 7,
+    } as any;
+
+    const { spawnCodexInPane } = await import('../../src/runners/codex.js');
+    vi.mocked(spawnCodexInPane).mockResolvedValueOnce({ pid: null });
+    const { assembleGatePrompt } = await import('../../src/context/assembler.js');
+    vi.mocked(assembleGatePrompt).mockReturnValue('mock prompt');
+
+    const flag = { value: true };
+    const result = await runGatePhase(7, state, '/fake-harness', runDir, '/cwd', flag);
+
+    // Stale sidecar must NOT be replayed.
+    expect((result as any).recoveredFromSidecar).not.toBe(true);
+    expect(flag.value).toBe(false); // flag still consumed (one-shot)
+    // Fresh gate run was attempted — spawnCodexInPane should have been called.
+    expect(vi.mocked(spawnCodexInPane)).toHaveBeenCalled();
+  });
+
+  it('skips replay when sidecar lacks retryIndex AND current retry > 0 (legacy sidecar safety)', async () => {
+    const runDir = makeTmpDir();
+    // Pre-PR sidecar without retryIndex field.
+    fs.writeFileSync(
+      path.join(runDir, 'gate-7-result.json'),
+      JSON.stringify({
+        exitCode: 0,
+        timestamp: Date.now(),
+        runner: 'codex',
+        promptBytes: 1000,
+        durationMs: 375626,
+        sourcePreset: { model: 'gpt-5.5', effort: 'high' },
+      }),
+    );
+    fs.writeFileSync(path.join(runDir, 'gate-7-raw.txt'), '## Verdict\nREJECT\n');
+
+    const state = {
+      phasePresets: { '7': 'codex-high' },
+      gateRetries: { '2': 0, '4': 0, '7': 1 }, // already past retry-0
+      phaseCodexSessions: { '2': null, '4': null, '7': null },
+      phaseAttemptId: { '7': 'fresh-attempt-id' },
+      currentPhase: 7,
+    } as any;
+
+    const { spawnCodexInPane } = await import('../../src/runners/codex.js');
+    vi.mocked(spawnCodexInPane).mockResolvedValueOnce({ pid: null });
+    const { assembleGatePrompt } = await import('../../src/context/assembler.js');
+    vi.mocked(assembleGatePrompt).mockReturnValue('mock prompt');
+
+    const flag = { value: true };
+    const result = await runGatePhase(7, state, '/fake-harness', runDir, '/cwd', flag);
+
+    // Conservative: can't prove the sidecar matches retry-1, so don't replay.
+    expect((result as any).recoveredFromSidecar).not.toBe(true);
+  });
+
   it('first call with allowSidecarReplay.value=true replays sidecar and consumes flag', async () => {
     const { assembleGatePrompt } = await import('../../src/context/assembler.js');
     // assembleGatePrompt mock not needed for replay path (sidecar exists before assembler is called)


### PR DESCRIPTION
## Summary

Fixes the last open thread on #94 (\"Bug 1 — Sidecar replay on resume miscounts as next retryIndex\"). When a paused run resumed after a gate REJECT had already advanced \`state.gateRetries[N]\` to N+1, \`runGatePhaseInteractive\`'s one-shot sidecar replay re-emitted retry-N's verdict labeled as retry-(N+1) with the prior duration carried over and \`recoveredFromSidecar: true\`. The retry slot was consumed with no actual gate attempt — directly contributing to the unrecoverable cap-hit cascade described in #94.

## Fix

Add \`retryIndex\` to the gate sidecar and gate replay on it.

- \`GateResult.retryIndex?\` (\`src/types.ts\`) — new optional field on the persisted sidecar shape.
- \`_persistSidecars\` (\`src/phases/gate.ts\`) accepts the current \`retryIndex\` and writes it. Both call sites (Claude path, Codex pane path) thread it from the same \`state.gateRetries[phase]\` value \`handleGatePhase\` captured at gate entry, so the sidecar always reflects which attempt produced it.
- \`runGatePhaseInteractive\` computes \`currentRetryIndex = state.gateRetries[phase] ?? 0\` and gates the existing replay on:
  - sidecar has \`retryIndex\` → require exact equality with current.
  - sidecar lacks \`retryIndex\` (legacy / pre-PR file) → allow replay only when \`currentRetryIndex === 0\`. Any prior retries → can't prove the sidecar matches → run fresh.

On mismatch, one stderr line is logged (\`[harness] gate N sidecar replay skipped: …\`) and the function falls through to the existing fresh-gate spawn path. The replay flag is still consumed (it's one-shot), preserving the existing single-attempt invariant.

## Why this is safe

- **New runs** always write \`retryIndex\` and benefit from the strict check.
- **Legacy paused runs** retain replay for the common \"resume on first attempt\" case (retry-0 sidecar + current retry-0 state). They lose replay only when current retry > 0 — exactly the bug case.
- **Stagnation, force-pass, ambiguity, drift** paths are unaffected — they all run downstream of \`gate_verdict\` emission, which now correctly reflects whether a fresh gate ran.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm vitest run\` — 1255 passed / 1 skipped
- [x] \`pnpm build\` clean
- [x] New regression tests in \`tests/phases/gate.test.ts\`:
  - sidecar with \`retryIndex: 0\` + state.gateRetries.7 = 1 → replay skipped, spawnCodexInPane invoked.
  - legacy sidecar (no \`retryIndex\`) + state.gateRetries.7 = 1 → replay skipped (conservative).
- [ ] Manual: pause a run mid-P7 after retry-1 REJECT, resume — confirm \`gate_verdict retryIndex=2 recoveredFromSidecar=false\` instead of \`true\`.

Closes #94 Bug 1.